### PR TITLE
change URLs to new repository location

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -2,7 +2,7 @@
 A clear and concise description of the changes done by your pull request.
 
 **Pull Request Checklist**
-- [] I have read and accepted the [code of conduct](https://github.com/memorysafety/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
+- [] I have read and accepted the [code of conduct](https://github.com/trifectatechfoundation/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
 - [] I have tested, formatted and ran clippy over my changes.
 - [] I have commented and documented my changes.
-- [] This pull request will fix issue https://github.com/memorysafety/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.
+- [] This pull request will fix issue https://github.com/trifectatechfoundation/sudo-rs/issues/<#issue> where a proper discussion about a solution has taken place.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -397,11 +397,7 @@ jobs:
           shared-key: "stable"
 
       - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          name: clippy-result
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --no-deps -- --deny warnings
+        run: cargo clippy --no-deps --all-targets --all-features -- --deny warnings
 
   docs:
     needs: clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,9 +111,9 @@
 - Use canonicalized paths for the executed binaries
 - Simplified CLI help to only display supported actions
 
-[0.2.2]: https://github.com/memorysafety/sudo-rs/compare/v0.2.1...v0.2.2
-[0.2.1]: https://github.com/memorysafety/sudo-rs/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/memorysafety/sudo-rs/compare/v0.2.0-dev.20230711...v0.2.0
-[0.2.0-dev.20230711]: https://github.com/memorysafety/sudo-rs/compare/v0.2.0-dev.20230703...v0.2.0-dev.20230711
-[0.2.0-dev.20230703]: https://github.com/memorysafety/sudo-rs/compare/v0.2.0-dev.20230627...v0.2.0-dev.20230703
-[0.2.0-dev.20230627]: https://github.com/memorysafety/sudo-rs/compare/v0.1.0-dev.20230620...v0.2.0-dev.20230627
+[0.2.2]: https://github.com/trifectatechfoundation/sudo-rs/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/trifectatechfoundation/sudo-rs/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/trifectatechfoundation/sudo-rs/compare/v0.2.0-dev.20230711...v0.2.0
+[0.2.0-dev.20230711]: https://github.com/trifectatechfoundation/sudo-rs/compare/v0.2.0-dev.20230703...v0.2.0-dev.20230711
+[0.2.0-dev.20230703]: https://github.com/trifectatechfoundation/sudo-rs/compare/v0.2.0-dev.20230627...v0.2.0-dev.20230703
+[0.2.0-dev.20230627]: https://github.com/trifectatechfoundation/sudo-rs/compare/v0.1.0-dev.20230620...v0.2.0-dev.20230627

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ If you find a security problem that can be used to used to compromise a system,
 do follow our [security policy] and report a vulnerability instead of using the
 issue tracker.
 
-[security policy]: https://github.com/memorysafety/sudo-rs/security/policy
+[security policy]: https://github.com/trifectatechfoundation/sudo-rs/security/policy
 
 ## Working on a bigger issue
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ description = "A memory safe implementation of sudo and su."
 version = "0.2.2"
 license = "Apache-2.0 OR MIT"
 edition = "2021"
-repository = "https://github.com/memorysafety/sudo-rs"
-homepage = "https://github.com/memorysafety/sudo-rs"
+repository = "https://github.com/trifectatechfoundation/sudo-rs"
+homepage = "https://github.com/trifectatechfoundation/sudo-rs"
 publish = true
 categories = ["command-line-interface"]
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A safety oriented and memory safe implementation of sudo and su written in Rust.
 Sudo-rs is being developed further; features you might expect from original sudo
 may still be unimplemented or not planned. If there is an important one you need,
 please request it using the issue tracker. If you encounter any usability bugs,
-also please report them on the [issue tracker](https://github.com/memorysafety/sudo-rs/issues).
-Suspected vulnerabilities can be reported on our [security page](https://github.com/memorysafety/sudo-rs/security).
+also please report them on the [issue tracker](https://github.com/trifectatechfoundation/sudo-rs/issues).
+Suspected vulnerabilities can be reported on our [security page](https://github.com/trifectatechfoundation/sudo-rs/security).
 
 An [audit of sudo-rs version 0.2.0](docs/audit/audit-report-sudo-rs.pdf) has been performed in August 2023.
 The findings from that audit are addressed in the current version.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security policy
 **Do not report security vulnerabilities through public GitHub issues.**
 
-Instead, you can report them using [our security page](https://github.com/memorysafety/sudo-rs/security). Alternatively, you can also send them
+Instead, you can report them using [our security page](https://github.com/trifectatechfoundation/sudo-rs/security). Alternatively, you can also send them
 by email to security+sudo@tweedegolf.com. You can encrypt your email using GnuPG if you want. Use the GPG key with fingerprint
 [C2E4 CAC4 B122 25DE 1C3B  B1C9 289D 0820 03D0 1E95](https://keys.openpgp.org/search?q=C2E4CAC4B12225DE1C3BB1C9289D082003D01E95).
 
@@ -24,4 +24,4 @@ We prefer to receive reports in English. If necessary, we also understand Spanis
 Like original sudo, we adhere to the principle of [Coordinated Vulnerability Disclosure](https://vuls.cert.org/confluence/display/CVD/Executive+Summary).
 
 # Security Advisories
-Security advisories will be published [on GitHub](https://github.com/memorysafety/sudo-rs/security/advisories) and possibly through other channels.
+Security advisories will be published [on GitHub](https://github.com/trifectatechfoundation/sudo-rs/security/advisories) and possibly through other channels.

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -456,7 +456,7 @@ fn match_group_alias(group: &impl UnixGroup) -> impl Fn(&UserSpecifier) -> bool 
     move |spec| match spec {
         UserSpecifier::User(ident) => match_group(group)(ident),
         /* the parser does not allow this, but can happen due to Runas_Alias,
-         * see https://github.com/memorysafety/sudo-rs/issues/13 */
+         * see https://github.com/trifectatechfoundation/sudo-rs/issues/13 */
         _ => {
             auth_warn!("warning: ignoring %group syntax in runas_alias for checking sudo -g");
             false

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -645,7 +645,7 @@ pub fn escape_os_str_lossy(s: &std::ffi::OsStr) -> String {
 pub fn make_zeroed_sigaction() -> libc::sigaction {
     // SAFETY: since sigaction is a C struct, all-zeroes is a valid representation
     // We cannot use a "literal struct" initialization method since the exact representation
-    // of libc::sigaction is not fixed, see e.g. https://github.com/memorysafety/sudo-rs/issues/829
+    // of libc::sigaction is not fixed, see e.g. https://github.com/trifectatechfoundation/sudo-rs/issues/829
     unsafe { std::mem::zeroed() }
 }
 

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_user.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_user.rs
@@ -108,7 +108,7 @@ fn user_can_become_another_user() -> Result<()> {
     Ok(())
 }
 
-// regression test for memorysafety/sudo-rs#81
+// regression test for trifectatechfoundation/sudo-rs#81
 #[test]
 fn invoking_user_groups_are_lost_when_becoming_another_user() -> Result<()> {
     let invoking_user = USERNAME;


### PR DESCRIPTION
The repository changed, so we changed all occurrences of 'memorysafety/sudo-rs' to 'trifectatechfoundation/sudo-rs'.