### PR TITLE
Refactor `SysLog`

### DIFF
--- a/src/log/syslog.rs
+++ b/src/log/syslog.rs
@@ -198,4 +198,11 @@ mod tests {
 
         logger.log(&record);
     }
+
+    #[test]
+    fn will_not_break_utf8() {
+        let mut writer = SysLogWriter::new(libc::LOG_DEBUG, FACILITY);
+
+        let _ = write!(writer, "{}¢", "x".repeat(959));
+    }
 }

--- a/src/log/syslog.rs
+++ b/src/log/syslog.rs
@@ -87,23 +87,19 @@ fn suggested_break(message: &str, max_size: usize) -> usize {
 
 impl Write for SysLogWriter {
     fn write_str(&mut self, mut message: &str) -> fmt::Result {
-        loop {
-            if message.len() > self.available() {
-                let truncate_boundary = suggested_break(message, self.available());
+        while message.len() > self.available() {
+            let truncate_boundary = suggested_break(message, self.available());
 
-                let left = &message[..truncate_boundary];
-                let right = &message[truncate_boundary..];
+            let left = &message[..truncate_boundary];
+            let right = &message[truncate_boundary..];
 
-                self.append(left.as_bytes());
-                self.line_break();
+            self.append(left.as_bytes());
+            self.line_break();
 
-                message = right;
-            } else {
-                self.append(message.as_bytes());
-
-                break;
-            }
+            message = right;
         }
+
+        self.append(message.as_bytes());
 
         Ok(())
     }

--- a/src/log/syslog.rs
+++ b/src/log/syslog.rs
@@ -66,12 +66,20 @@ mod internal {
 
 use internal::SysLogWriter;
 
-fn suggested_break(message: &str, max_size: usize) -> usize {
-    // floor_char_boundary is currently unstable
-    let mut truncate_boundary = max_size;
-    while !message.is_char_boundary(truncate_boundary) {
-        truncate_boundary -= 1;
+/// `floor_char_boundary` is currently unstable in Rust
+fn floor_char_boundary(data: &str, mut index: usize) -> usize {
+    if index >= data.len() {
+        return data.len();
     }
+    while !data.is_char_boundary(index) {
+        index -= 1;
+    }
+
+    index
+}
+
+fn suggested_break(message: &str, max_size: usize) -> usize {
+    let mut truncate_boundary = floor_char_boundary(message, max_size);
 
     // don't overzealously truncate log messages
     truncate_boundary = message[..truncate_boundary]

--- a/src/log/syslog.rs
+++ b/src/log/syslog.rs
@@ -92,7 +92,7 @@ fn suggested_break(message: &str, max_size: usize) -> usize {
         .unwrap_or(truncate_boundary);
 
     if truncate_boundary == 0 {
-        max_size
+        floor_char_boundary(message, max_size)
     } else {
         truncate_boundary
     }

--- a/src/log/syslog.rs
+++ b/src/log/syslog.rs
@@ -45,7 +45,7 @@ mod internal {
             self.append(DOTDOTDOT_START);
         }
 
-        pub fn commit_to_syslog(&mut self) {
+        fn commit_to_syslog(&mut self) {
             self.append(&[0]);
             let message = CStr::from_bytes_with_nul(&self.buffer[..self.cursor]).unwrap();
             syslog(self.priority, self.facility, message);
@@ -54,6 +54,12 @@ mod internal {
 
         pub fn available(&self) -> usize {
             MAX_MSG_LEN - self.cursor
+        }
+    }
+
+    impl Drop for SysLogWriter {
+        fn drop(&mut self) {
+            self.commit_to_syslog();
         }
     }
 }
@@ -116,7 +122,6 @@ impl Log for Syslog {
 
         let mut writer = SysLogWriter::new(priority, FACILITY);
         let _ = write!(writer, "{}", record.args());
-        writer.commit_to_syslog();
     }
 
     fn flush(&self) {

--- a/src/log/syslog.rs
+++ b/src/log/syslog.rs
@@ -84,17 +84,16 @@ fn floor_char_boundary(data: &str, mut index: usize) -> usize {
 /// This function WILL return a non-zero result if `max_size` is large enough to fit
 /// at least the first character of `message`.
 fn suggested_break(message: &str, max_size: usize) -> usize {
-    let mut truncate_boundary = floor_char_boundary(message, max_size);
-
-    // don't overzealously truncate log messages
-    truncate_boundary = message[..truncate_boundary]
-        .rfind(|c: char| c.is_ascii_whitespace())
-        .unwrap_or(truncate_boundary);
-
-    if truncate_boundary == 0 {
-        floor_char_boundary(message, max_size)
+    // method A: try to split the message in two non-empty parts on an ASCII white space character
+    // method B: split on the utf8 character boundary that consumes the most data
+    if let Some(pos) = message.as_bytes()[1..max_size]
+        .iter()
+        .rposition(|c| c.is_ascii_whitespace())
+    {
+        // since pos+1 contains ASCII whitespace, it acts as a valid utf8 boundary as well
+        pos + 1
     } else {
-        truncate_boundary
+        floor_char_boundary(message, max_size)
     }
 }
 


### PR DESCRIPTION
Issues #809, #824 and #856 have all hit the same spot.  Which is the same spot that gave rise to the infamous `vudo` in original sudo ([CVE 2001-0279](https://nvd.nist.gov/vuln/detail/CVE-2001-0279)). Luckily in safe Rust, the problems are contained to `panic` and hangs, but still: if you have metal pole in your garden where lightning has struck three times, it's probably wise to reconsider the pole.

This PR disects and rewrites the old syslog code in a commit-by-commit basis. Enjoy.