### PR TITLE
Safety comments: PR1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ name = "visudo"
 path = "bin/visudo.rs"
 
 [dependencies]
-libc = "0.2.127"
+libc = "0.2.149"
 glob = "0.3.0"
 log = { version = "0.4.11", features = ["std"] }
 

--- a/src/exec/event.rs
+++ b/src/exec/event.rs
@@ -178,6 +178,9 @@ impl<T: Process> EventRegistry<T> {
             return Ok(ids);
         }
 
+        // SAFETY: `poll` expects a pointer to an array of file descriptors (first argument),
+        // the length of which is indicated by the second argument; the third argument being -1
+        // denotes an infinite timeout.
         // FIXME: we should set either a timeout or use ppoll when available.
         cerr(unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as _, -1) })?;
 

--- a/src/pam/converse.rs
+++ b/src/pam/converse.rs
@@ -203,8 +203,13 @@ pub(super) unsafe extern "C" fn converse<C: Converser>(
             messages: Vec::with_capacity(num_msg as usize),
         };
         for i in 0..num_msg as isize {
+            // SAFETY: the PAM contract ensures that `num_msg` does not exceed the amount
+            // of messages presented to this function in `msg`, and that it is not being
+            // written to at the same time as we are reading it. Note that the reference
+            // we create does not escape this loopy body.
             let message: &pam_message = unsafe { &**msg.offset(i) };
 
+            // SAFETY: PAM ensures that the messages passed are properly null-terminated
             let msg = unsafe { string_from_ptr(message.msg) };
             let style = if let Some(style) = PamMessageStyle::from_int(message.msg_style) {
                 style
@@ -221,6 +226,7 @@ pub(super) unsafe extern "C" fn converse<C: Converser>(
         }
 
         // send the conversation of to the Rust part
+        // SAFETY: appdata_ptr contains the `*mut ConverserData` that is untouched by PAM
         let app_data = unsafe { &mut *(appdata_ptr as *mut ConverserData<C>) };
         if app_data
             .converser
@@ -232,6 +238,8 @@ pub(super) unsafe extern "C" fn converse<C: Converser>(
 
         // Conversation should now contain response messages
         // allocate enough memory for the responses, set it to zero
+        // SAFETY: this will either allocate the required amount of (initialized) bytes,
+        // or return a null pointer.
         let temp_resp = unsafe {
             libc::calloc(
                 num_msg as libc::size_t,
@@ -244,6 +252,9 @@ pub(super) unsafe extern "C" fn converse<C: Converser>(
 
         // Store the responses
         for (i, msg) in conversation.messages.into_iter().enumerate() {
+            // SAFETY: `i` will not exceed `num_msg` by the way `conversation_messages`
+            // is constructed, so `temp_resp` will have allocated-and-initialized data at
+            // the required offset that only we have a writable pointer to.
             let response: &mut pam_response = unsafe { &mut *(temp_resp.add(i)) };
 
             if let Some(secbuf) = msg.response {
@@ -252,6 +263,7 @@ pub(super) unsafe extern "C" fn converse<C: Converser>(
         }
 
         // Set the responses
+        // SAFETY: PAM contract says that we are passed a valid, non-null, writeable pointer here.
         unsafe { *response = temp_resp };
 
         PamErrorType::Success
@@ -262,6 +274,7 @@ pub(super) unsafe extern "C" fn converse<C: Converser>(
         Ok(r) => r,
         Err(_) => {
             // notify caller that a panic has occured
+            // SAFETY: appdata_ptr contains the `*mut ConverserData` that is untouched by PAM
             let app_data = unsafe { &mut *(appdata_ptr as *mut ConverserData<C>) };
             app_data.panicked = true;
 

--- a/src/pam/error.rs
+++ b/src/pam/error.rs
@@ -154,13 +154,14 @@ impl PamErrorType {
     }
 
     fn get_err_msg(&self) -> String {
-        // pam_strerror technically takes a pam handle as the first argument,
+        // SAFETY: pam_strerror technically takes a pam handle as the first argument,
         // but we do not know of any implementation that actually uses the pamh
         // argument. See also the netbsd man page for `pam_strerror`.
         let data = unsafe { pam_strerror(std::ptr::null_mut(), self.as_int()) };
         if data.is_null() {
             String::from("Error unresolved by PAM")
         } else {
+            // SAFETY: pam_strerror returns a pointer to a null-terminated string
             unsafe { string_from_ptr(data) }
         }
     }

--- a/src/pam/mod.rs
+++ b/src/pam/mod.rs
@@ -331,6 +331,8 @@ impl<C: Converser> PamContext<C> {
             }
 
             // SAFETY: curr_str was obtained via libc::malloc() so we are responsible for freeing it.
+            // At this point, curr_str is also the only remaining pointer/reference to that allocated data
+            // (the data was copied above), so it can be deallocated without risk of use-after-free errors.
             unsafe { libc::free(curr_str.as_ptr().cast()) };
             // SAFETY: curr_env was not NULL, so it was not the last element in the list and so PAM
             // ensures that the next offset also is a valid pointer, and points to valid data.

--- a/src/pam/mod.rs
+++ b/src/pam/mod.rs
@@ -57,6 +57,8 @@ impl<C: Converser> PamContextBuilder<C> {
             }));
 
             let mut pamh = std::ptr::null_mut();
+            // SAFETY: we are passing the required fields to `pam_start`; in particular, the value
+            // of `pamh` set above is not used, but will be overwritten by `pam_start`.
             let res = unsafe {
                 pam_start(
                     c_service_name.as_ptr(),
@@ -161,6 +163,7 @@ impl<C: Converser> PamContext<C> {
         flags |= self.silent_flag();
         flags |= self.disallow_null_auth_token_flag();
 
+        // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`)
         pam_err(unsafe { pam_authenticate(self.pamh, flags) })?;
 
         if self.has_panicked() {
@@ -175,6 +178,7 @@ impl<C: Converser> PamContext<C> {
         flags |= self.silent_flag();
         flags |= self.disallow_null_auth_token_flag();
 
+        // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`)
         pam_err(unsafe { pam_acct_mgmt(self.pamh, flags) })
     }
 
@@ -195,6 +199,8 @@ impl<C: Converser> PamContext<C> {
     /// Set the user that will be authenticated.
     pub fn set_user(&mut self, user: &str) -> PamResult<()> {
         let c_user = CString::new(user)?;
+        // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`); furthermore,
+        // `c_user.as_ptr()` will point to a correct null-terminated string.
         pam_err(unsafe {
             pam_set_item(self.pamh, PAM_USER, c_user.as_ptr() as *const libc::c_void)
         })
@@ -203,14 +209,17 @@ impl<C: Converser> PamContext<C> {
     /// Get the user that is currently active in the PAM handle
     pub fn get_user(&mut self) -> PamResult<String> {
         let mut data = std::ptr::null();
+        // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`)
         pam_err(unsafe { pam_get_item(self.pamh, PAM_USER, &mut data) })?;
 
-        // safety check to make sure that we do not ready a null ptr into a cstr
+        // safety check to make sure that we were not passed a null pointer by PAM,
+        // or that in fact PAM did not write to `data` at all.
         if data.is_null() {
             return Err(PamError::InvalidState);
         }
 
-        // unsafe conversion to cstr
+        // SAFETY: the contract for `pam_get_item` ensures that if `data` was touched by
+        // `pam_get_item`, it will point to a valid null-terminated string.
         let cstr = unsafe { CStr::from_ptr(data as *const c_char) };
 
         Ok(cstr.to_str()?.to_owned())
@@ -219,12 +228,16 @@ impl<C: Converser> PamContext<C> {
     /// Set the TTY path for the current TTY that this PAM session started from.
     pub fn set_tty<P: AsRef<OsStr>>(&mut self, tty_path: P) -> PamResult<()> {
         let data = CString::new(tty_path.as_ref().as_bytes())?;
+        // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`); furthermore,
+        // `data.as_ptr()` will point to a correct null-terminated string.
         pam_err(unsafe { pam_set_item(self.pamh, PAM_TTY, data.as_ptr() as *const libc::c_void) })
     }
 
     // Set the user that requested the actions in this PAM instance.
     pub fn set_requesting_user(&mut self, user: &str) -> PamResult<()> {
         let data = CString::new(user.as_bytes())?;
+        // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`); furthermore,
+        // `data.as_ptr()` will point to a correct null-terminated string.
         pam_err(unsafe { pam_set_item(self.pamh, PAM_RUSER, data.as_ptr() as *const libc::c_void) })
     }
 
@@ -238,6 +251,7 @@ impl<C: Converser> PamContext<C> {
         let mut flags = action;
         flags |= self.silent_flag();
 
+        // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`).
         pam_err(unsafe { pam_setcred(self.pamh, flags) })
     }
 
@@ -252,12 +266,14 @@ impl<C: Converser> PamContext<C> {
         if expired_only {
             flags |= PAM_CHANGE_EXPIRED_AUTHTOK;
         }
+        // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`).
         pam_err(unsafe { pam_chauthtok(self.pamh, flags) })
     }
 
     /// Start a user session for the authenticated user.
     pub fn open_session(&mut self) -> PamResult<()> {
         if !self.session_started {
+            // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`).
             pam_err(unsafe { pam_open_session(self.pamh, self.silent_flag()) })?;
             self.session_started = true;
             Ok(())
@@ -269,6 +285,7 @@ impl<C: Converser> PamContext<C> {
     /// End the user session.
     pub fn close_session(&mut self) -> PamResult<()> {
         if self.session_started {
+            // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`).
             pam_err(unsafe { pam_close_session(self.pamh, self.silent_flag()) })?;
             self.session_started = false;
             Ok(())
@@ -280,13 +297,25 @@ impl<C: Converser> PamContext<C> {
     /// Get a full listing of the current PAM environment
     pub fn env(&mut self) -> PamResult<HashMap<OsString, OsString>> {
         let mut res = HashMap::new();
+        // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`).
+        // The man page for pam_getenvlist states that:
+        //    The format of the memory is a malloc()'d array of char pointers, the last element
+        //    of which is set to NULL. Each of the non-NULL entries in this array point to a
+        //    NUL terminated and malloc()'d char string of the form: "name=value".
+        //
+        //    The pam_getenvlist function returns NULL on failure.
         let envs = unsafe { pam_getenvlist(self.pamh) };
         if envs.is_null() {
             return Err(PamError::EnvListFailure);
         }
         let mut curr_env = envs;
+        // SAFETY: the loop invariant is as follows:
+        // - `curr_env` itself is always a valid pointer to an array of valid (possibly NULL) pointers
+        // - if `curr_env` points to a pointer that is not-null, that data is a c-string allocated by malloc()
+        // - `curr_env` points to NULL if and only if it is the final element in the array
         while let Some(curr_str) = NonNull::new(unsafe { curr_env.read() }) {
             let data = {
+                // SAFETY: `curr_str` points to a valid null-terminated string per the above
                 let cstr = unsafe { CStr::from_ptr(curr_str.as_ptr()) };
                 let bytes = cstr.to_bytes();
                 if let Some(pos) = bytes.iter().position(|b| *b == b'=') {
@@ -301,12 +330,14 @@ impl<C: Converser> PamContext<C> {
                 res.insert(k, v);
             }
 
-            // free the current string and move to the next one
+            // SAFETY: curr_str was obtained via libc::malloc() so we are responsible for freeing it.
             unsafe { libc::free(curr_str.as_ptr().cast()) };
+            // SAFETY: curr_env was not NULL, so it was not the last element in the list and so PAM
+            // ensures that the next offset also is a valid pointer, and points to valid data.
             curr_env = unsafe { curr_env.offset(1) };
         }
 
-        // free the entire array
+        // SAFETY: `envs` itself was obtained by malloc(), so we are reponsible for freeing it.
         unsafe { libc::free(envs.cast()) };
 
         Ok(res)
@@ -314,6 +345,7 @@ impl<C: Converser> PamContext<C> {
 
     /// Check if anything panicked since the last call.
     pub fn has_panicked(&self) -> bool {
+        // SAFETY: self.data_ptr was created by Box::into_raw
         unsafe { (*self.data_ptr).panicked }
     }
 }
@@ -336,6 +368,7 @@ impl PamContext<CLIConverser> {
 impl<C: Converser> Drop for PamContext<C> {
     fn drop(&mut self) {
         // data_ptr's pointee is de-allocated in this scope
+        // SAFETY: self.data_ptr was created by Box::into_raw
         let _data = unsafe { Box::from_raw(self.data_ptr) };
         let _ = self.close_session();
 
@@ -343,6 +376,7 @@ impl<C: Converser> Drop for PamContext<C> {
         // it is unclear what it really does and does not do, other than the vague
         // documentation description to 'not take the call to seriously'
         // Also see https://github.com/systemd/systemd/issues/22318
+        // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`)
         unsafe {
             pam_end(
                 self.pamh,

--- a/src/system/file/chown.rs
+++ b/src/system/file/chown.rs
@@ -13,6 +13,8 @@ impl Chown for File {
     fn chown(&self, owner: UserId, group: GroupId) -> io::Result<()> {
         let fd = self.as_raw_fd();
 
+        // SAFETY: `fchown` is passed a proper file descriptor; and even if the user/group id
+        // is invalid, it will not cause UB.
         cerr(unsafe { libc::fchown(fd, owner, group) }).map(|_| ())
     }
 }

--- a/src/system/file/lock.rs
+++ b/src/system/file/lock.rs
@@ -52,6 +52,8 @@ fn flock(fd: RawFd, action: LockOp, nonblocking: bool) -> Result<()> {
         operation |= libc::LOCK_NB;
     }
 
+    // SAFETY: even if `fd` would not be a valid file descriptor, that would merely
+    // result in an error condition, not UB
     cerr(unsafe { libc::flock(fd, operation) })?;
     Ok(())
 }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -109,7 +109,7 @@ impl FileCloser {
 fn close_range(min_fd: c_uint, max_fd: c_uint) -> io::Result<()> {
     if min_fd <= max_fd {
         // SAFETY: this function is safe to call with these arguments
-        cerr(unsafe { libc::syscall(libc::SYS_close_range, min_fd, max_fd, 0 as c_uint) })?;
+        cerr(unsafe { libc::close_range(min_fd, max_fd, 0) })?;
     }
 
     Ok(())

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -108,7 +108,10 @@ impl FileCloser {
 
 fn close_range(min_fd: c_uint, max_fd: c_uint) -> io::Result<()> {
     if min_fd <= max_fd {
-        // SAFETY: this function is safe to call with these arguments
+        // SAFETY: this function is safe to call:
+        // - any errors while closing a specific fd will be effectively ignored
+        // - if the provided range or flags are invalid, that will be reported
+        //   as an error but will not cause undefined behaviour
         cerr(unsafe { libc::close_range(min_fd, max_fd, 0) })?;
     }
 
@@ -584,7 +587,8 @@ impl Process {
 
     /// Get the session id for the current process
     pub fn session_id() -> ProcessId {
-        // SAFETY: "If pid is 0, getsid() returns the session ID of the calling process."
+        // SAFETY: this function is explicitly safe to call with argument 0,
+        // and more generally getsid will never cause memory safety issues.
         unsafe { libc::getsid(0) }
     }
 

--- a/src/system/signal/stream.rs
+++ b/src/system/signal/stream.rs
@@ -18,12 +18,17 @@ use super::{
 
 static STREAM: OnceLock<SignalStream> = OnceLock::new();
 
+/// # Safety
+///
+/// The `info` parameters has to point to a valid instance of SignalInfo
 pub(super) unsafe fn send_siginfo(
     _signal: SignalNumber,
     info: *const SignalInfo,
     _context: *const libc::c_void,
 ) {
     if let Some(tx) = STREAM.get().map(|stream| stream.tx.as_raw_fd()) {
+        // SAFETY: called ensures that info is a valid pointer; any instance of SignalInfo will
+        // consists of SignalInfo::SIZE bytes
         unsafe { libc::send(tx, info.cast(), SignalInfo::SIZE, libc::MSG_DONTWAIT) };
     }
 }

--- a/src/system/time.rs
+++ b/src/system/time.rs
@@ -20,6 +20,7 @@ impl SystemTime {
 
     pub fn now() -> std::io::Result<SystemTime> {
         let mut spec = MaybeUninit::<libc::timespec>::uninit();
+        // SAFETY: valid pointer is passed to clock_gettime
         crate::cutils::cerr(unsafe {
             libc::clock_gettime(libc::CLOCK_BOOTTIME, spec.as_mut_ptr())
         })?;

--- a/src/system/wait.rs
+++ b/src/system/wait.rs
@@ -27,6 +27,7 @@ impl Wait for ProcessId {
     fn wait(self, options: WaitOptions) -> Result<(ProcessId, WaitStatus), WaitError> {
         let mut status: c_int = 0;
 
+        // SAFETY: a valid pointer is passed to `waitpid`
         let pid = cerr(unsafe { libc::waitpid(self, &mut status, options.flags) })
             .map_err(WaitError::Io)?;
 


### PR DESCRIPTION
It's tedious to do, but let's have proper `# Safety` and `// SAFETY` comments all across the board.

This PR addresses some low-hanging fruit:
- simple routines from `system`
- `pam` and `cutils`.
- file locking
- this PR also replaces our raw `sys call` with `libc::close_range`, since that is available now.

This is related to #861 but does not close that issue. I've broken it up in multiple PR's for easier reviewing.