### PR TITLE
Add more Rustified version of kernel_check

### DIFF
--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -57,7 +57,7 @@ impl fmt::Display for Error {
             Error::SelfCheck => {
                 f.write_str("sudo must be owned by uid 0 and have the setuid bit set")
             }
-            Error::KernelCheck => f.write_str("sudo needs a Kernel >= 5.9"),
+            Error::KernelCheck => f.write_str("sudo-rs needs a Linux kernel newer than v5.9"),
             Error::CommandNotFound(p) => write!(f, "'{}': command not found", p.display()),
             Error::InvalidCommand(p) => write!(f, "'{}': invalid command", p.display()),
             Error::UserNotFound(u) => write!(f, "user '{u}' not found"),

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -111,7 +111,7 @@ fn sudo_process() -> Result<(), Error> {
     dev_info!("development logs are enabled");
 
     self_check()?;
-    kernel_check(5, 9)?;
+    kernel_check()?;
 
     let pipeline = Pipeline {
         policy: SudoersPolicy::default(),


### PR DESCRIPTION
The PR in #854 didn't strike me as particular elegant; and if we move to different OS's we might probably need different kernel checks as well. So this cleans up that routine.