### PR TITLE
Safety comments: PR2

### DIFF
--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -14,7 +14,7 @@ use crate::{
     },
 };
 use crate::{
-    exec::{handle_sigchld, opt_fmt, signal_fmt},
+    exec::{handle_sigchld, signal_fmt},
     log::{dev_error, dev_info, dev_warn},
     system::{
         fork, getpgid, getpgrp,
@@ -238,12 +238,7 @@ impl ExecClosure {
             }
         };
 
-        dev_info!(
-            "received{} {} from {}",
-            opt_fmt(info.is_user_signaled(), " user signaled"),
-            info.signal(),
-            info.pid()
-        );
+        dev_info!("received{}", info);
 
         let Some(command_pid) = self.command_pid else {
             dev_info!("command was terminated, ignoring signal");
@@ -256,9 +251,11 @@ impl ExecClosure {
                 // FIXME: we should handle SIGWINCH here if we want to support I/O plugins that
                 // react on window change events.
 
-                // Skip the signal if it was sent by the user and it is self-terminating.
-                if info.is_user_signaled() && self.is_self_terminating(info.pid()) {
-                    return;
+                if let Some(pid) = info.signaler_pid() {
+                    if self.is_self_terminating(pid) {
+                        // Skip the signal if it was sent by the user and it is self-terminating.
+                        return;
+                    }
                 }
 
                 if signal == SIGALRM {

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -381,12 +381,7 @@ impl<'a> MonitorClosure<'a> {
             }
         };
 
-        dev_info!(
-            "monitor received{} {} from {}",
-            opt_fmt(info.is_user_signaled(), " user signaled"),
-            info.signal(),
-            info.pid()
-        );
+        dev_info!("monitor received{}", info);
 
         // Don't do anything if the command has terminated already
         let Some(command_pid) = self.command_pid else {
@@ -396,10 +391,16 @@ impl<'a> MonitorClosure<'a> {
 
         match info.signal() {
             SIGCHLD => handle_sigchld(self, registry, "command", command_pid),
-            // Skip the signal if it was sent by the user and it is self-terminating.
-            _ if info.is_user_signaled()
-                && is_self_terminating(info.pid(), command_pid, self.command_pgrp) => {}
-            signal => self.send_signal(signal, command_pid, false),
+            signal => {
+                if let Some(pid) = info.signaler_pid() {
+                    if is_self_terminating(pid, command_pid, self.command_pgrp) {
+                        // Skip the signal if it was sent by the user and it is self-terminating.
+                        return;
+                    }
+                }
+
+                self.send_signal(signal, command_pid, false)
+            }
         }
     }
 }

--- a/src/system/signal/info.rs
+++ b/src/system/signal/info.rs
@@ -21,6 +21,11 @@ impl SignalInfo {
     /// Gets the PID that sent the signal.
     pub(crate) fn pid(&self) -> ProcessId {
         // FIXME: some signals don't set si_pid.
+        //
+        // SAFETY: this just fetches the `si_pid` field; since this is an integer,
+        // even if the information is nonsense it will not cause UB. Note that
+        // that a `ProcessId` does not have as type invariant that it always holds a valid
+        // process id, only that it is the appropriate type for storing such ids.
         unsafe { self.info.si_pid() }
     }
 

--- a/src/system/signal/info.rs
+++ b/src/system/signal/info.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::system::interface::ProcessId;
 
 use super::SignalNumber;
@@ -13,24 +15,42 @@ impl SignalInfo {
 
     /// Returns whether the signal was sent by the user or not.
     pub(crate) fn is_user_signaled(&self) -> bool {
-        // FIXME: we should check if si_code is equal to SI_USER but for some reason the latter it
-        // is not available in libc.
+        // This matches the definition of the SI_FROMUSER macro.
         self.info.si_code <= 0
     }
 
     /// Gets the PID that sent the signal.
-    pub(crate) fn pid(&self) -> ProcessId {
-        // FIXME: some signals don't set si_pid.
-        //
-        // SAFETY: this just fetches the `si_pid` field; since this is an integer,
-        // even if the information is nonsense it will not cause UB. Note that
-        // that a `ProcessId` does not have as type invariant that it always holds a valid
-        // process id, only that it is the appropriate type for storing such ids.
-        unsafe { self.info.si_pid() }
+    pub(crate) fn signaler_pid(&self) -> Option<ProcessId> {
+        if self.is_user_signaled() {
+            // SAFETY: si_pid is always initialized if the signal is user signaled.
+            unsafe { Some(self.info.si_pid()) }
+        } else {
+            None
+        }
     }
 
     /// Gets the signal number.
     pub(crate) fn signal(&self) -> SignalNumber {
         self.info.si_signo
+    }
+}
+
+impl fmt::Display for SignalInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} {} from ",
+            if self.is_user_signaled() {
+                " user signaled"
+            } else {
+                ""
+            },
+            self.signal(),
+        )?;
+        if let Some(pid) = self.signaler_pid() {
+            write!(f, "{pid}")
+        } else {
+            write!(f, "<none>")
+        }
     }
 }

--- a/src/system/signal/info.rs
+++ b/src/system/signal/info.rs
@@ -14,7 +14,7 @@ impl SignalInfo {
     pub(super) const SIZE: usize = std::mem::size_of::<Self>();
 
     /// Returns whether the signal was sent by the user or not.
-    pub(crate) fn is_user_signaled(&self) -> bool {
+    fn is_user_signaled(&self) -> bool {
         // This matches the definition of the SI_FROMUSER macro.
         self.info.si_code <= 0
     }

--- a/src/system/signal/set.rs
+++ b/src/system/signal/set.rs
@@ -41,8 +41,11 @@ impl SignalAction {
     pub(super) fn register(&self, signal: SignalNumber) -> io::Result<Self> {
         let mut original_action = MaybeUninit::<Self>::zeroed();
 
+        // SAFETY: `sigaction` expects a valid pointer, which we provide; the typecast is valid
+        // since SignalAction is a repr(transparent) newtype struct.
         cerr(unsafe { libc::sigaction(signal, &self.raw, original_action.as_mut_ptr().cast()) })?;
 
+        // SAFETY: `sigaction` will have properly initialized `original_action`.
         Ok(unsafe { original_action.assume_init() })
     }
 }
@@ -58,8 +61,10 @@ impl SignalSet {
     pub(crate) fn empty() -> io::Result<Self> {
         let mut set = MaybeUninit::<Self>::zeroed();
 
+        // SAFETY: same as above
         cerr(unsafe { libc::sigemptyset(set.as_mut_ptr().cast()) })?;
 
+        // SAFETY: `sigemptyset` will have initialized `set`
         Ok(unsafe { set.assume_init() })
     }
 
@@ -67,16 +72,20 @@ impl SignalSet {
     pub(crate) fn full() -> io::Result<Self> {
         let mut set = MaybeUninit::<Self>::zeroed();
 
+        // SAFETY: same as above
         cerr(unsafe { libc::sigfillset(set.as_mut_ptr().cast()) })?;
 
+        // SAFETY: `sigfillset` will have initialized `set`
         Ok(unsafe { set.assume_init() })
     }
 
     fn sigprocmask(&self, how: libc::c_int) -> io::Result<Self> {
         let mut original_set = MaybeUninit::<Self>::zeroed();
 
+        // SAFETY: same as above
         cerr(unsafe { libc::sigprocmask(how, &self.raw, original_set.as_mut_ptr().cast()) })?;
 
+        // SAFETY: `sigprocmask` will have initialized `set`
         Ok(unsafe { original_set.assume_init() })
     }
 

--- a/src/system/signal/stream.rs
+++ b/src/system/signal/stream.rs
@@ -67,6 +67,9 @@ impl SignalStream {
     pub(crate) fn recv(&self) -> io::Result<SignalInfo> {
         let mut info = MaybeUninit::<SignalInfo>::uninit();
         let fd = self.rx.as_raw_fd();
+        // SAFETY: type invariant for `SignalStream` ensures that `fd` is a valid file descriptor;
+        // furthermore, `info` is a valid pointer to `siginfo_t` (by virtue of `SignalInfo` being a
+        // transparent newtype for it), which has room for `SignalInfo::SIZE` bytes.
         let bytes = cerr(unsafe { libc::recv(fd, info.as_mut_ptr().cast(), SignalInfo::SIZE, 0) })?;
 
         if bytes as usize != SignalInfo::SIZE {
@@ -97,6 +100,8 @@ pub(crate) fn register_handlers<const N: usize>(
             })?;
     }
 
+    // SAFETY: if the above for-loop has terminated, every handler will have
+    // been written to via "MaybeUnit::new", and so is initialized.
     Ok(handlers.map(|(_, handler)| unsafe { handler.assume_init() }))
 }
 

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -65,11 +65,11 @@ impl Pty {
         Ok(Self {
             path,
             leader: PtyLeader {
-                // SAFETY: `leader` has been set by `openpty`
+                // SAFETY: `openpty` has set `leader` to an open fd suitable for assuming ownership by `OwnedFd`.
                 file: unsafe { OwnedFd::from_raw_fd(leader) }.into(),
             },
             follower: PtyFollower {
-                // SAFETY: `follower` has been set by `openpty`
+                // SAFETY: `openpty` has set `follower` to an open fd suitable for assuming ownership by `OwnedFd`.
                 file: unsafe { OwnedFd::from_raw_fd(follower) }.into(),
             },
         })
@@ -166,7 +166,7 @@ impl<F: AsRawFd> Terminal for F {
         // SAFETY: tcgetpgrp cannot cause UB
         cerr(unsafe { libc::tcgetpgrp(self.as_raw_fd()) })
     }
-    /// Set the foreground process group ID associated with this terminalto `pgrp`.
+    /// Set the foreground process group ID associated with this terminal to `pgrp`.
     fn tcsetpgrp(&self, pgrp: ProcessId) -> io::Result<()> {
         // SAFETY: tcsetpgrp cannot cause UB
         cerr(unsafe { libc::tcsetpgrp(self.as_raw_fd(), pgrp) }).map(|_| ())
@@ -189,7 +189,7 @@ impl<F: AsRawFd> Terminal for F {
         }
 
         // SAFETY: `buf` is a valid and initialized pointer, and its  correct length is passed
-        cerr(unsafe { libc::ttyname_r(self.as_raw_fd(), buf.as_mut_ptr() as _, buf.len()) })?;
+        cerr(unsafe { libc::ttyname_r(self.as_raw_fd(), buf.as_mut_ptr(), buf.len()) })?;
         // SAFETY: `buf` will have been initialized by the `ttyname_r` call, if it succeeded
         Ok(unsafe { os_string_from_ptr(buf.as_ptr()) })
     }

--- a/src/system/term/user_term.rs
+++ b/src/system/term/user_term.rs
@@ -56,7 +56,7 @@ const LOCAL_FLAGS: tcflag_t = ISIG
 
 static GOT_SIGTTOU: AtomicBool = AtomicBool::new(false);
 
-/// This is like `tcsetattr` but it only suceeds if we are in the foreground process group.
+/// This is like `tcsetattr` but it only succeeds if we are in the foreground process group.
 /// # Safety
 ///
 /// The arguments to this function have to be valid arguments to `tcsetattr`.
@@ -246,7 +246,7 @@ impl UserTerm {
         };
 
         // Set terminal to raw mode.
-        // SAFETY: `term` is a valid, initialized pointer to struct of type `termios`, which
+        // SAFETY: `term` is a valid, initialized struct of type `termios`, which
         // was previously obtained through `tcgetattr`.
         unsafe { cfmakeraw(&mut term) };
         // Enable terminal signals.

--- a/src/system/term/user_term.rs
+++ b/src/system/term/user_term.rs
@@ -136,8 +136,7 @@ fn catching_sigttou(mut function: impl FnMut() -> io::Result<()>) -> io::Result<
 /// Type to manipulate the settings of the user's terminal.
 pub struct UserTerm {
     tty: File,
-    original_termios: MaybeUninit<termios>,
-    changed: bool,
+    original_termios: Option<termios>,
 }
 
 impl UserTerm {
@@ -145,8 +144,7 @@ impl UserTerm {
     pub fn open() -> io::Result<Self> {
         Ok(Self {
             tty: OpenOptions::new().read(true).write(true).open("/dev/tty")?,
-            original_termios: MaybeUninit::uninit(),
-            changed: false,
+            original_termios: None,
         })
     }
 
@@ -235,13 +233,18 @@ impl UserTerm {
         let fd = self.tty.as_raw_fd();
 
         // Retrieve the original terminal (if we haven't done so already)
-        if !self.changed {
-            // SAFETY: `termios` is a valid pointer to pass to tcgetattr
-            cerr(unsafe { tcgetattr(fd, self.original_termios.as_mut_ptr()) })?;
-        }
-        // Retrieve the original terminal.
-        // SAFETY: tcgetattr will have initialized `termios`
-        let mut term = unsafe { self.original_termios.assume_init() };
+        let mut term = if let Some(termios) = self.original_termios {
+            termios
+        } else {
+            // SAFETY: `termios` is a valid pointer to pass to tcgetattr; if that calls succeeds,
+            // it will have initialized the `termios` strucutre
+            *self.original_termios.insert(unsafe {
+                let mut termios = MaybeUninit::uninit();
+                cerr(tcgetattr(fd, termios.as_mut_ptr()))?;
+                termios.assume_init()
+            })
+        };
+
         // Set terminal to raw mode.
         // SAFETY: `term` is a valid, initialized pointer to ` struct of type `termios`, which
         // was previously obtained through `tcgetattr`.
@@ -253,7 +256,6 @@ impl UserTerm {
 
         // SAFETY: `fd` is a valid file descriptor for the tty; for `term`: same as above.
         unsafe { tcsetattr_nobg(fd, TCSADRAIN, &term) }?;
-        self.changed = true;
 
         Ok(())
     }
@@ -263,13 +265,12 @@ impl UserTerm {
     /// This change is done after waiting for all the queued output to be written. To discard the
     /// queued input `flush` must be set to `true`.
     pub fn restore(&mut self, flush: bool) -> io::Result<()> {
-        if self.changed {
+        if let Some(termios) = self.original_termios.take() {
             let fd = self.tty.as_raw_fd();
             let flags = if flush { TCSAFLUSH } else { TCSADRAIN };
             // SAFETY: `fd` is a valid file descriptor for the tty; and `termios` is a valid pointer
             // that was obtained through `tcgetattr`.
-            unsafe { tcsetattr_nobg(fd, flags, self.original_termios.as_ptr()) }?;
-            self.changed = false;
+            unsafe { tcsetattr_nobg(fd, flags, &termios) }?;
         }
 
         Ok(())

--- a/src/system/term/user_term.rs
+++ b/src/system/term/user_term.rs
@@ -237,7 +237,7 @@ impl UserTerm {
             termios
         } else {
             // SAFETY: `termios` is a valid pointer to pass to tcgetattr; if that calls succeeds,
-            // it will have initialized the `termios` strucutre
+            // it will have initialized the `termios` structure
             *self.original_termios.insert(unsafe {
                 let mut termios = MaybeUninit::uninit();
                 cerr(tcgetattr(fd, termios.as_mut_ptr()))?;
@@ -246,7 +246,7 @@ impl UserTerm {
         };
 
         // Set terminal to raw mode.
-        // SAFETY: `term` is a valid, initialized pointer to ` struct of type `termios`, which
+        // SAFETY: `term` is a valid, initialized pointer to struct of type `termios`, which
         // was previously obtained through `tcgetattr`.
         unsafe { cfmakeraw(&mut term) };
         // Enable terminal signals.

--- a/src/system/term/user_term.rs
+++ b/src/system/term/user_term.rs
@@ -56,10 +56,6 @@ const LOCAL_FLAGS: tcflag_t = ISIG
 
 static GOT_SIGTTOU: AtomicBool = AtomicBool::new(false);
 
-extern "C" fn on_sigttou(_signal: c_int, _info: *mut siginfo_t, _: *mut c_void) {
-    GOT_SIGTTOU.store(true, Ordering::SeqCst);
-}
-
 /// This is like `tcsetattr` but it only suceeds if we are in the foreground process group.
 /// # Safety
 ///
@@ -67,6 +63,17 @@ extern "C" fn on_sigttou(_signal: c_int, _info: *mut siginfo_t, _: *mut c_void) 
 unsafe fn tcsetattr_nobg(fd: c_int, flags: c_int, tp: *const termios) -> io::Result<()> {
     // This function is based around the fact that we receive `SIGTTOU` if we call `tcsetattr` and
     // we are not in the foreground process group.
+
+    // SAFETY: is the responsibility of the caller of `tcsetattr_nobg`
+    let setattr = || cerr(unsafe { tcsetattr(fd, flags, tp) }).map(|_| ());
+
+    catching_sigttou(setattr)
+}
+
+fn catching_sigttou(mut function: impl FnMut() -> io::Result<()>) -> io::Result<()> {
+    extern "C" fn on_sigttou(_signal: c_int, _info: *mut siginfo_t, _: *mut c_void) {
+        GOT_SIGTTOU.store(true, Ordering::SeqCst);
+    }
 
     let action = {
         let mut raw: libc::sigaction = make_zeroed_sigaction();
@@ -105,8 +112,7 @@ unsafe fn tcsetattr_nobg(fd: c_int, flags: c_int, tp: *const termios) -> io::Res
 
     // Call `tcsetattr` until it suceeds and ignore interruptions if we did not receive `SIGTTOU`.
     let result = loop {
-        // SAFETY: is the responsibility of the caller of `tcsetattr_nobg`
-        match cerr(unsafe { tcsetattr(fd, flags, tp) }) {
+        match function() {
             Ok(_) => break Ok(()),
             Err(err) => {
                 let got_sigttou = GOT_SIGTTOU.load(Ordering::SeqCst);
@@ -251,53 +257,7 @@ impl UserTerm {
         // This function is based around the fact that we receive `SIGTTOU` if we call `tcsetpgrp` and
         // we are not in the foreground process group.
 
-        let action = {
-            let mut raw: libc::sigaction = make_zeroed_sigaction();
-            // Call `on_sigttou` if `SIGTTOU` arrives.
-            raw.sa_sigaction = on_sigttou as sighandler_t;
-            // Exclude any other signals from the set
-            raw.sa_mask = {
-                let mut sa_mask = MaybeUninit::<sigset_t>::uninit();
-                // SAFETY: see tcsetattr_nobg
-                unsafe {
-                    sigemptyset(sa_mask.as_mut_ptr());
-                    sa_mask.assume_init()
-                }
-            };
-            raw.sa_flags = 0;
-            raw
-        };
-
-        // Reset `GOT_SIGTTOU`.
-        GOT_SIGTTOU.store(false, Ordering::SeqCst);
-
-        // Set `action` as the action for `SIGTTOU` and store the original action in `original_action`
-        // to restore it later.
-        // SAFETY: see tcsetattr_nobg
-        let original_action = unsafe {
-            let mut original_action = MaybeUninit::<sigaction>::uninit();
-            sigaction(SIGTTOU, &action, original_action.as_mut_ptr());
-            original_action.assume_init()
-        };
-
-        // Call `tcsetattr` until it suceeds and ignore interruptions if we did not receive `SIGTTOU`.
-        let result = loop {
-            match self.tty.tcsetpgrp(pgrp) {
-                Ok(()) => break Ok(()),
-                Err(err) => {
-                    let got_sigttou = GOT_SIGTTOU.load(Ordering::SeqCst);
-                    if got_sigttou || err.kind() != io::ErrorKind::Interrupted {
-                        break Err(err);
-                    }
-                }
-            }
-        };
-
-        // Restore the original action.
-        // SAFETY: see tcsetattr_nobg
-        unsafe { sigaction(SIGTTOU, &original_action, std::ptr::null_mut()) };
-
-        result
+        catching_sigttou(|| self.tty.tcsetpgrp(pgrp))
     }
 }
 


### PR DESCRIPTION
This is related to PR #860. Together with that PR it will close #861.

This PR also refactors some code in the signal handling, since there was code duplication going.

There are 3 missing `unsafe` statements after this:

- 1 in `exec` (related to `pre_exec`)
- 2 in `system` (related to `fork` and `pre_exec`)

Anything relating to `fork` and `pre_exec` probably needs special attention so I did not annotate those yet; for those please refer to issue #863

There are also two unsafe statements in the `visudo` module, but that is handled by issue #859.