### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       SUDO_TEST_VERBOSE_DOCKER_BUILD: 1
       CI: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: set up docker buildx
         run: docker buildx create --name builder --use
@@ -53,7 +53,7 @@ jobs:
       SUDO_TEST_VERBOSE_DOCKER_BUILD: 1
       CI: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: set up docker buildx
         run: docker buildx create --name builder --use
@@ -93,7 +93,7 @@ jobs:
       SUDO_TEST_VERBOSE_DOCKER_BUILD: 1
       CI: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: set up docker buildx
         run: docker buildx create --name builder --use
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install llvm-tools component
         run: rustup component add llvm-tools
@@ -198,7 +198,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set rust nightly version
         run: echo "NIGHTLY_VERSION=$(curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/rustc)" >> $GITHUB_ENV
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install rust 1.70
         run: rustup override set 1.70
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set rust nightly version
         run: echo "NIGHTLY_VERSION=$(curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> $GITHUB_ENV
@@ -289,7 +289,7 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -305,7 +305,7 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -321,7 +321,7 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -335,7 +335,7 @@ jobs:
     needs: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install cargo-audit
         uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -307,12 +307,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libpam0g-dev
-          version: "1.0"
-
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -328,12 +322,6 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libpam0g-dev
-          version: "1.0"
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,13 +58,6 @@ jobs:
       - name: set up docker buildx
         run: docker buildx create --name builder --use
 
-      - name: cache docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: docker-buildx-og-${{ github.sha }}
-          restore-keys: docker-buildx-og-
-
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install rust
-        run: |
-          rustup override set stable
-          rustup update stable
-
       - name: set up docker buildx
         run: docker buildx create --name builder --use
 
@@ -59,11 +54,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install rust
-        run: |
-          rustup override set stable
-          rustup update stable
 
       - name: set up docker buildx
         run: docker buildx create --name builder --use
@@ -104,11 +94,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install rust
-        run: |
-          rustup override set stable
-          rustup update stable
 
       - name: set up docker buildx
         run: docker buildx create --name builder --use
@@ -153,11 +138,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install rust
-        run: |
-          rustup override set stable
-          rustup update stable
-
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -184,11 +164,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install rust
-        run: |
-          rustup override set stable
-          rustup update stable
-          rustup component add llvm-tools
+      - name: Install llvm-tools component
+        run: rustup component add llvm-tools
 
       - name: Add cargo-llvm-cov
         uses: taiki-e/install-action@v2
@@ -226,7 +203,7 @@ jobs:
       - name: Set rust nightly version
         run: echo "NIGHTLY_VERSION=$(curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/rustc)" >> $GITHUB_ENV
 
-      - name: Install rust
+      - name: Install nightly rust
         run: |
           rustup set profile minimal
           rustup override set nightly-${{ env.NIGHTLY_VERSION }}
@@ -257,9 +234,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install rust
-        run: |
-          rustup override set 1.70
+      - name: Install rust 1.70
+        run: rustup override set 1.70
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -288,7 +264,7 @@ jobs:
       - name: Set rust nightly version
         run: echo "NIGHTLY_VERSION=$(curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> $GITHUB_ENV
 
-      - name: Install rust
+      - name: Install nightly rust and miri
         run: |
           rustup set profile minimal
           rustup override set nightly-${{ env.NIGHTLY_VERSION }}
@@ -315,13 +291,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install rust
-        run: |
-          rustup set profile minimal
-          rustup override set stable
-          rustup update stable
-          rustup component add rustfmt
-
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -337,13 +306,6 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install rust
-        run: |
-          rustup set profile minimal
-          rustup override set stable
-          rustup update stable
-          rustup component add clippy
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -367,12 +329,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install rust
-        run: |
-          rustup set profile minimal
-          rustup override set stable
-          rustup update stable
-
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
@@ -392,12 +348,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install rust
-        run: |
-          rustup set profile minimal
-          rustup override set stable
-          rustup update stable
 
       - name: Install cargo-audit
         uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+          rustup override set stable
+          rustup update stable
 
       - name: set up docker buildx
         run: docker buildx create --name builder --use
@@ -62,10 +61,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+          rustup override set stable
+          rustup update stable
 
       - name: set up docker buildx
         run: docker buildx create --name builder --use
@@ -108,10 +106,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+          rustup override set stable
+          rustup update stable
 
       - name: set up docker buildx
         run: docker buildx create --name builder --use
@@ -157,10 +154,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+          rustup override set stable
+          rustup update stable
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -189,11 +185,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: llvm-tools
+        run: |
+          rustup override set stable
+          rustup update stable
+          rustup component add llvm-tools
 
       - name: Add cargo-llvm-cov
         uses: taiki-e/install-action@v2
@@ -212,16 +207,10 @@ jobs:
           shared-key: "stable"
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --all-targets --all-features --release
+        run: cargo build --workspace --all-targets --all-features --release
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: llvm-cov
-          args: --workspace --all-features --all-targets --release --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --all-features --all-targets --release --lcov --output-path lcov.info
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
@@ -238,11 +227,9 @@ jobs:
         run: echo "NIGHTLY_VERSION=$(curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/rustc)" >> $GITHUB_ENV
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-${{ env.NIGHTLY_VERSION }}
-          override: true
+        run: |
+          rustup set profile minimal
+          rustup override set nightly-${{ env.NIGHTLY_VERSION }}
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -256,22 +243,13 @@ jobs:
           shared-key: "nightly"
 
       - name: Update to minimal direct dependencies
-        uses: actions-rs/cargo@v1
-        with:
-          command: update
-          args: -Zdirect-minimal-versions
+        run: cargo update -Zdirect-minimal-versions
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --all-targets --all-features --release
+        run: cargo build --workspace --all-targets --all-features --release
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features --all-targets --release
+        run: cargo test --workspace --all-features --all-targets --release
 
   build-and-test-msrv:
     runs-on: ubuntu-latest
@@ -280,10 +258,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: "1.70"
-          override: true
+        run: |
+          rustup override set 1.70
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -297,16 +273,10 @@ jobs:
           shared-key: "msrv"
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --all-targets --all-features --release
+        run: cargo build --workspace --all-targets --all-features --release
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-features --all-targets --release
+        run: cargo test --workspace --all-features --all-targets --release
 
   miri:
     needs: build-and-test
@@ -319,12 +289,10 @@ jobs:
         run: echo "NIGHTLY_VERSION=$(curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> $GITHUB_ENV
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-${{ env.NIGHTLY_VERSION }}
-          override: true
-          components: miri
+        run: |
+          rustup set profile minimal
+          rustup override set nightly-${{ env.NIGHTLY_VERSION }}
+          rustup component add miri
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -338,10 +306,7 @@ jobs:
           shared-key: miri
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: miri
-          args: test --workspace --all-features miri
+        run: cargo miri test --workspace --all-features miri
 
   format:
     runs-on: ubuntu-latest
@@ -351,12 +316,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
+        run: |
+          rustup set profile minimal
+          rustup override set stable
+          rustup update stable
+          rustup component add rustfmt
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -364,10 +328,7 @@ jobs:
           shared-key: "stable"
 
       - name: Run rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   clippy:
     needs: format
@@ -378,12 +339,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: clippy
+        run: |
+          rustup set profile minimal
+          rustup override set stable
+          rustup update stable
+          rustup component add clippy
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -408,11 +368,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        run: |
+          rustup set profile minimal
+          rustup override set stable
+          rustup update stable
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -426,10 +385,7 @@ jobs:
           shared-key: "stable"
 
       - name: Build docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps --document-private-items --all-features
+        run: cargo doc --no-deps --document-private-items --all-features
 
   audit:
     needs: clippy
@@ -438,11 +394,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        run: |
+          rustup set profile minimal
+          rustup override set stable
+          rustup update stable
 
       - name: Install cargo-audit
         uses: taiki-e/install-action@v2
@@ -455,6 +410,4 @@ jobs:
           shared-key: "audit"
 
       - name: Run audit
-        uses: actions-rs/cargo@v1
-        with:
-          command: audit
+        run: cargo audit


### PR DESCRIPTION
This removes all usages of the deprecated actions-rs/toolchain action in favor of either depending on the default rust installation (should be latest stable) or explicit rustup commands. It also removes all usages of the deprecated actions-rs/cargo action in favor of direct cargo invocations. I've upgraded the checkout action to v4 to fix warning spam by github actions. And finally CI should be about 1-2 minutes faster by removing the docker cache. Persisting it seems to take significantly more time than it actually saves, making it a net loss.

Best reviewed commit-by-commit.

Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/852