### PR TITLE
Couple more CI improvements

### DIFF
--- a/.github/problem-matchers/rust.json
+++ b/.github/problem-matchers/rust.json
@@ -1,0 +1,21 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "rust",
+            "pattern": [
+                {
+                    "regexp": "^(warning|warn|error)(\\[(.*)\\])?: (.*)$",
+                    "severity": 1,
+                    "message": 4,
+                    "code": 3
+                },
+                {
+                    "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
+                    "file": 2,
+                    "line": 3,
+                    "column": 4
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,9 @@ jobs:
           workspaces: |
             test-framework
 
+      - name: Register rust problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/rust.json"
+
       - name: Run all E2E tests
         working-directory: test-framework
         run: cargo test -p e2e-tests
@@ -62,6 +65,9 @@ jobs:
           shared-key: "compliance-tests"
           workspaces: |
             test-framework
+
+      - name: Register rust problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/rust.json"
 
       - name: Test sudo-test itself
         working-directory: test-framework
@@ -98,6 +104,9 @@ jobs:
           workspaces: |
             test-framework
 
+      - name: Register rust problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/rust.json"
+
       - name: Run gated compliance tests against sudo-rs
         working-directory: test-framework
         env:
@@ -130,6 +139,9 @@ jobs:
           shared-key: "compliance-tests"
           workspaces: |
             test-framework
+
+      - name: Register rust problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/rust.json"
 
       - name: clippy sudo-test
         working-directory: test-framework
@@ -168,6 +180,9 @@ jobs:
         with:
           shared-key: "stable"
 
+      - name: Register rust problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/rust.json"
+
       - name: Build
         run: cargo build --workspace --all-targets --all-features --release
 
@@ -200,6 +215,9 @@ jobs:
         with:
           shared-key: "nightly"
 
+      - name: Register rust problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/rust.json"
+
       - name: Update to minimal direct dependencies
         run: cargo update -Zdirect-minimal-versions
 
@@ -227,6 +245,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "msrv"
+
+      - name: Register rust problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/rust.json"
 
       - name: Build
         run: cargo build --workspace --all-targets --all-features --release
@@ -257,6 +278,9 @@ jobs:
         with:
           shared-key: miri
 
+      - name: Register rust problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/rust.json"
+
       - name: Run tests
         run: cargo miri test --workspace --all-features miri
 
@@ -283,6 +307,9 @@ jobs:
         with:
           shared-key: "stable"
 
+      - name: Register rust problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/rust.json"
+
       - name: Run clippy
         run: cargo clippy --no-deps --all-targets --all-features -- --deny warnings
 
@@ -298,6 +325,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "stable"
+
+      - name: Register rust problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/rust.json"
 
       - name: Build docs
         run: cargo doc --no-deps --document-private-items --all-features

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   merge_group:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -282,11 +282,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "stable"
-
       - name: Run rustfmt
         run: cargo fmt --all -- --check
 
@@ -332,11 +327,6 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-audit
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "audit"
 
       - name: Run audit
         run: cargo audit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,13 +191,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set rust nightly version
-        run: echo "NIGHTLY_VERSION=$(curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/rustc)" >> $GITHUB_ENV
-
       - name: Install nightly rust
         run: |
           rustup set profile minimal
-          rustup override set nightly-${{ env.NIGHTLY_VERSION }}
+          rustup override set nightly
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -252,13 +249,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set rust nightly version
-        run: echo "NIGHTLY_VERSION=$(curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> $GITHUB_ENV
-
       - name: Install nightly rust and miri
         run: |
           rustup set profile minimal
-          rustup override set nightly-${{ env.NIGHTLY_VERSION }}
+          rustup override set nightly
           rustup component add miri
 
       - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,10 +159,9 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libpam0g-dev
-          version: "1.0"
+        run: |
+          sudo apt update
+          sudo apt install libpam0g-dev
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -192,10 +191,9 @@ jobs:
           rustup override set nightly
 
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libpam0g-dev
-          version: "1.0"
+        run: |
+          sudo apt update
+          sudo apt install libpam0g-dev
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -221,10 +219,9 @@ jobs:
         run: rustup override set 1.70
 
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libpam0g-dev
-          version: "1.0"
+        run: |
+          sudo apt update
+          sudo apt install libpam0g-dev
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -251,10 +248,9 @@ jobs:
           rustup component add miri
 
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libpam0g-dev
-          version: "1.0"
+        run: |
+          sudo apt update
+          sudo apt install libpam0g-dev
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,11 +71,6 @@ jobs:
         working-directory: test-framework
         run: cargo test -p sudo-compliance-tests -- --include-ignored
 
-      - name: prevent the cache from growing too large
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
   compliance-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
* Give CI feedback for PR's against all branches, not just the main branch.
* Let rustup pick the right nightly version instead of manually determining it.
* Add back the problem matcher that https://github.com/trifectatechfoundation/sudo-rs/pull/870 removed.
* Remove some unnecessary or counterproductive caching.

Continuation of https://github.com/trifectatechfoundation/sudo-rs/pull/870.