### PR TITLE
Mark fork as unsafe again

### DIFF
--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -50,7 +50,8 @@ pub(super) fn exec_no_pty(sudo_pid: ProcessId, mut command: Command) -> io::Resu
     // fails.
     file_closer.except(&errpipe_tx);
 
-    let ForkResult::Parent(command_pid) = fork().map_err(|err| {
+    // SAFETY: There should be no other threads at this point.
+    let ForkResult::Parent(command_pid) = unsafe { fork() }.map_err(|err| {
         dev_warn!("unable to fork command process: {err}");
         err
     })?

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -87,7 +87,8 @@ pub(super) fn exec_monitor(
 
     // FIXME (ogsudo): Some extra config happens here if selinux is available.
 
-    let ForkResult::Parent(command_pid) = fork().map_err(|err| {
+    // SAFETY: There should be no other threads at this point.
+    let ForkResult::Parent(command_pid) = unsafe { fork() }.map_err(|err| {
         dev_warn!("unable to fork command process: {err}");
         err
     })?

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -162,7 +162,8 @@ pub(in crate::exec) fn exec_pty(
         }
     };
 
-    let ForkResult::Parent(monitor_pid) = fork().map_err(|err| {
+    // SAFETY: There should be no other threads at this point.
+    let ForkResult::Parent(monitor_pid) = (unsafe { fork() }).map_err(|err| {
         dev_error!("cannot fork monitor process: {err}");
         err
     })?

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -236,7 +236,9 @@ mod tests {
         // Create a socket so the child can send us a byte if successful.
         let (mut rx, mut tx) = UnixStream::pair().unwrap();
 
-        let ForkResult::Parent(_) = fork().unwrap() else {
+        // FIXME fork will deadlock when this test panics if it forked while
+        // another test was panicking.
+        let ForkResult::Parent(_) = (unsafe { fork().unwrap() }) else {
             // Open a new pseudoterminal.
             let leader = Pty::open().unwrap().leader;
             // The pty leader should not have a foreground process group yet.


### PR DESCRIPTION
Calling any functions that are not async signal safe after the fork will deadlock or worse if the original process was multithreaded.