### PR TITLE
Make sure panic after fork reliably causes the test to fail

### DIFF
--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -906,11 +906,11 @@ mod tests {
         // another test was panicking.
         let ForkResult::Parent(child_pid) = (unsafe { fork_for_test() }) else {
             let should_close =
-                std::fs::File::open(std::env::temp_dir().join("should_close.txt")).unwrap();
+                std::fs::File::create(std::env::temp_dir().join("should_close.txt")).unwrap();
             assert!(!is_closed(&should_close));
 
             let should_not_close =
-                std::fs::File::open(std::env::temp_dir().join("should_not_close.txt")).unwrap();
+                std::fs::File::create(std::env::temp_dir().join("should_not_close.txt")).unwrap();
             assert!(!is_closed(&should_not_close));
 
             let mut closer = super::FileCloser::new();

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -129,16 +129,37 @@ pub(crate) enum ForkResult {
 ///
 /// # Safety
 ///
-/// In a multithreaded program, only async-signal-safe functions are guaranteed to work in the
-/// child process until a call to `execve` or a similar function is done.
+/// Must not be called in multithreaded programs.
 pub(crate) unsafe fn fork() -> io::Result<ForkResult> {
-    // FIXME use std::panic::always_abort() once it is stable if the current
-    // process is multi-threaded.
+    // FIXME add debug assertion that we are not currently using multiple threads.
     let pid = cerr(unsafe { libc::fork() })?;
     if pid == 0 {
         Ok(ForkResult::Child)
     } else {
         Ok(ForkResult::Parent(pid))
+    }
+}
+
+/// Create a new process with extra precautions for usage in tests.
+///
+/// # Safety
+///
+/// In a multithreaded program, only async-signal-safe functions are guaranteed to work in the
+/// child process until a call to `execve` or a similar function is done.
+#[cfg(test)]
+unsafe fn fork_for_test() -> ForkResult {
+    let pid = cerr(unsafe { libc::fork() }).unwrap();
+    if pid == 0 {
+        // Make sure that panics in the child always abort the process if it doesn't deadlock.
+        // FIXME use std::panic::always_abort() once it is stable
+        std::panic::set_hook(Box::new(|info| {
+            use std::io::Write;
+            let _ = writeln!(std::io::stderr(), "{info}");
+            std::process::exit(101);
+        }));
+        ForkResult::Child
+    } else {
+        ForkResult::Parent(pid)
     }
 }
 
@@ -704,7 +725,7 @@ mod tests {
     use libc::SIGKILL;
 
     use super::{
-        fork, getpgrp, setpgid,
+        fork_for_test, getpgrp, setpgid,
         wait::{Wait, WaitOptions},
         ForkResult, Group, User, WithProcess, ROOT_GROUP_NAME,
     };
@@ -814,7 +835,7 @@ mod tests {
 
         // FIXME fork will deadlock when this test panics if it forked while
         // another test was panicking.
-        match unsafe { super::fork().unwrap() } {
+        match unsafe { super::fork_for_test() } {
             ForkResult::Child => {
                 // wait for the parent.
                 std::thread::sleep(std::time::Duration::from_secs(1))
@@ -845,7 +866,7 @@ mod tests {
 
         // FIXME fork will deadlock when this test panics if it forked while
         // another test was panicking.
-        let ForkResult::Parent(pid1) = (unsafe { fork().unwrap() }) else {
+        let ForkResult::Parent(pid1) = (unsafe { fork_for_test() }) else {
             std::thread::sleep(std::time::Duration::from_secs(1));
             tx.write_all(&[42]).unwrap();
             exit(0);
@@ -853,7 +874,7 @@ mod tests {
 
         // FIXME fork will deadlock when this test panics if it forked while
         // another test was panicking.
-        let ForkResult::Parent(pid2) = (unsafe { fork().unwrap() }) else {
+        let ForkResult::Parent(pid2) = (unsafe { fork_for_test() }) else {
             std::thread::sleep(std::time::Duration::from_secs(1));
             tx.write_all(&[42]).unwrap();
             exit(0);
@@ -883,7 +904,7 @@ mod tests {
     fn close_the_universe() {
         // FIXME fork will deadlock when this test panics if it forked while
         // another test was panicking.
-        let ForkResult::Parent(child_pid) = (unsafe { fork().unwrap() }) else {
+        let ForkResult::Parent(child_pid) = (unsafe { fork_for_test() }) else {
             let should_close =
                 std::fs::File::open(std::env::temp_dir().join("should_close.txt")).unwrap();
             assert!(!is_closed(&should_close));
@@ -916,7 +937,7 @@ mod tests {
     fn except_stdio_is_fine() {
         // FIXME fork will deadlock when this test panics if it forked while
         // another test was panicking.
-        let ForkResult::Parent(child_pid) = (unsafe { fork().unwrap() }) else {
+        let ForkResult::Parent(child_pid) = (unsafe { fork_for_test() }) else {
             let mut closer = super::FileCloser::new();
 
             closer.except(&io::stdin());

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -148,8 +148,8 @@ pub(crate) unsafe fn fork() -> io::Result<ForkResult> {
 /// child process until a call to `execve` or a similar function is done.
 #[cfg(test)]
 unsafe fn fork_for_test() -> ForkResult {
-    let pid = cerr(unsafe { libc::fork() }).unwrap();
-    if pid == 0 {
+    let result = fork().unwrap();
+    if let ForkResult::Child = result {
         // Make sure that panics in the child always abort the process if it doesn't deadlock.
         // FIXME use std::panic::always_abort() once it is stable
         std::panic::set_hook(Box::new(|info| {
@@ -157,10 +157,8 @@ unsafe fn fork_for_test() -> ForkResult {
             let _ = writeln!(std::io::stderr(), "{info}");
             std::process::exit(101);
         }));
-        ForkResult::Child
-    } else {
-        ForkResult::Parent(pid)
     }
+    result
 }
 
 pub fn setsid() -> io::Result<ProcessId> {

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -218,7 +218,7 @@ mod tests {
         process::exit,
     };
 
-    use crate::system::{fork, getpgid, setsid, term::*, ForkResult};
+    use crate::system::{fork_for_test, getpgid, setsid, term::*, ForkResult};
 
     #[test]
     fn open_pty() {
@@ -238,7 +238,7 @@ mod tests {
 
         // FIXME fork will deadlock when this test panics if it forked while
         // another test was panicking.
-        let ForkResult::Parent(_) = (unsafe { fork().unwrap() }) else {
+        let ForkResult::Parent(_) = (unsafe { fork_for_test() }) else {
             // Open a new pseudoterminal.
             let leader = Pty::open().unwrap().leader;
             // The pty leader should not have a foreground process group yet.


### PR DESCRIPTION
I found this while investigating why the `close_the_universe` test was spuriously deadlocking on my system.