### PR TITLE
Handle a couple of portability issues affecting all non-Linux systems

### DIFF
--- a/src/system/signal/set.rs
+++ b/src/system/signal/set.rs
@@ -34,7 +34,6 @@ impl SignalAction {
         raw.sa_sigaction = sa_sigaction;
         raw.sa_mask = sa_mask.raw;
         raw.sa_flags = sa_flags;
-        raw.sa_restorer = None;
 
         Ok(Self { raw })
     }

--- a/src/system/term/user_term.rs
+++ b/src/system/term/user_term.rs
@@ -78,7 +78,6 @@ fn tcsetattr_nobg(fd: c_int, flags: c_int, tp: *const termios) -> io::Result<()>
             unsafe { sa_mask.assume_init() }
         };
         raw.sa_flags = 0;
-        raw.sa_restorer = None;
         raw
     };
     // Reset `GOT_SIGTTOU`.
@@ -241,7 +240,6 @@ impl UserTerm {
                 unsafe { sa_mask.assume_init() }
             };
             raw.sa_flags = 0;
-            raw.sa_restorer = None;
             raw
         };
         // Reset `GOT_SIGTTOU`.

--- a/src/system/wait.rs
+++ b/src/system/wait.rs
@@ -1,13 +1,18 @@
 use std::io;
 
+#[cfg(target_os = "linux")]
+use libc::__WALL;
 use libc::{
     c_int, WEXITSTATUS, WIFCONTINUED, WIFEXITED, WIFSIGNALED, WIFSTOPPED, WNOHANG, WSTOPSIG,
-    WTERMSIG, WUNTRACED, __WALL,
+    WTERMSIG, WUNTRACED,
 };
 
 use crate::cutils::cerr;
 use crate::system::signal::signal_name;
 use crate::{system::interface::ProcessId, system::signal::SignalNumber};
+
+#[cfg(not(target_os = "linux"))]
+const __WALL: c_int = 0;
 
 mod sealed {
     pub(crate) trait Sealed {}


### PR DESCRIPTION
`sa_restorer` is a Linux extension of sigaction which is only meant for libc. `__WALL` is a waitpid flag which only applies to Linux.

Part of https://github.com/trifectatechfoundation/sudo-rs/issues/869