### PR TITLE
Second batch of FreeBSD changes for the compliance test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ via the usual commands `sudo` and `su` instead, prepend `/usr/lib/cargo/bin` to 
 
 ### Fedora
 
-If you are running Fedora 38 or later, you can use: 
+If you are running Fedora 38 or later, you can use:
 ```sh
 sudo dnf install sudo-rs
 ```
@@ -86,6 +86,11 @@ cargo build --release
 This produces a binary `target/release/sudo`. However, this binary must have
 the setuid flag set and must be owned by the root user in order to provide any
 useful functionality. Consult your operating system manual for details.
+On operating systems other than Linux we also require an environment variable
+`SUDO_RS_IS_UNSTABLE` to be set, and it must have the value
+`I accept that my system may break unexpectedly`. This because we are in an
+early stage of supporting non-Linux OSes. If you are unsure about how to set
+this up, then the current version of sudo is not intended for you.
 
 Sudo-rs needs the sudoers configuration file. The sudoers configuration file
 will be loaded from `/etc/sudoers-rs` if that file exists, otherwise the

--- a/test-framework/e2e-tests/src/pty.rs
+++ b/test-framework/e2e-tests/src/pty.rs
@@ -37,13 +37,13 @@ fn do_test(binary: Binary, not_use_pty: bool, user_tty: bool, expected: ExecMode
     let mut cmd = match binary {
         Binary::Su => {
             let mut cmd = Command::new("su");
-            cmd.args(["-c", "sh -c 'touch /tmp/barrier; sleep 3'"]);
+            cmd.args(["-c", "sh -c 'touch /tmp/barrier; sleep 3; true'"]);
             cmd
         }
 
         Binary::Sudo => {
             let mut cmd = Command::new("sudo");
-            cmd.args(["sh", "-c", "touch /tmp/barrier; sleep 3"]);
+            cmd.args(["sh", "-c", "touch /tmp/barrier; sleep 3; true"]);
             cmd
         }
     };

--- a/test-framework/e2e-tests/src/su/flag_pty.rs
+++ b/test-framework/e2e-tests/src/su/flag_pty.rs
@@ -17,7 +17,7 @@ fn fixture() -> Result<Processes> {
 
     let child = Command::new("su")
         .args(["--pty", "-c"])
-        .arg("sh -c 'touch /tmp/barrier; sleep 3'")
+        .arg("sh -c 'touch /tmp/barrier; sleep 3; true'")
         .tty(true)
         .spawn(&env)?;
 

--- a/test-framework/sudo-compliance-tests/src/lib.rs
+++ b/test-framework/sudo-compliance-tests/src/lib.rs
@@ -35,6 +35,9 @@ const PAMD_SUDO_PAM_PERMIT: &str = "auth sufficient pam_permit.so";
 
 const OG_SUDO_STANDARD_LECTURE: &str= "\nWe trust you have received the usual lecture from the local System\nAdministrator. It usually boils down to these three things:\n\n    #1) Respect the privacy of others.\n    #2) Think before you type.\n    #3) With great power comes great responsibility.";
 
+const SUDO_RS_IS_UNSTABLE: &str =
+    "SUDO_RS_IS_UNSTABLE=I accept that my system may break unexpectedly";
+
 const SUDO_ENV_DEFAULT_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
 const SUDO_ENV_DEFAULT_TERM: &str = "unknown";
 

--- a/test-framework/sudo-compliance-tests/src/su.rs
+++ b/test-framework/sudo-compliance-tests/src/su.rs
@@ -49,7 +49,7 @@ fn target_user_must_exist_in_passwd_db() -> Result<()> {
     let env = Env("").build()?;
 
     let output = Command::new("su")
-        .args(["-c", "true", USERNAME])
+        .args([USERNAME, "-c", "true"])
         .output(&env)?;
 
     assert!(!output.status().success());
@@ -77,7 +77,7 @@ fn required_password_is_target_users_pass() -> Result<()> {
         .build()?;
 
     let actual = Command::new("su")
-        .args(["-c", "whoami", target_user_name])
+        .args([target_user_name, "-c", "whoami"])
         .stdin(target_user_password)
         .as_user(invoking_user)
         .output(&env)?
@@ -97,7 +97,7 @@ fn required_password_is_target_users_fail() -> Result<()> {
         .build()?;
 
     let output = Command::new("su")
-        .args(["-c", "true", target_user])
+        .args([target_user, "-c", "true"])
         .as_user(USERNAME)
         .stdin(PASSWORD)
         .output(&env)?;
@@ -120,17 +120,18 @@ fn nopasswd_root() -> Result<()> {
     let env = Env("").user(USERNAME).build()?;
 
     Command::new("su")
-        .args(["-c", "true", USERNAME])
+        .args([USERNAME, "-c", "true"])
         .output(&env)?
         .assert_success()
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "su on FreeBSD doesn't require password if target user is self")]
 fn password_is_required_when_target_user_is_self() -> Result<()> {
     let env = Env("").user(USERNAME).build()?;
 
     let output = Command::new("su")
-        .args(["-c", "true", USERNAME])
+        .args([USERNAME, "-c", "true"])
         .as_user(USERNAME)
         .output(&env)?;
 

--- a/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/mod.rs
@@ -247,7 +247,7 @@ fn sigwinch_works(use_pty: bool) -> Result<()> {
     assert_eq!(lines.len(), 3);
     // Assert that the terminal size that sudo sees the first time matches the original terminal size.
     assert_eq!(lines[0], lines[1]);
-    // ASsert that the terminal size that sudo sees the second time has actually changed to the
+    // Assert that the terminal size that sudo sees the second time has actually changed to the
     // value set by `change-size.sh`.
     assert_eq!(lines[2].trim(), "42 69");
 

--- a/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/print-sizes.sh
+++ b/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/print-sizes.sh
@@ -1,5 +1,5 @@
 # Save the name of the current tty so `change-size.sh` can read it.
-tty > /tmp/tty_path 
+tty > /tmp/tty_path
 # Print the current terminal size
 stty size
 # Print the terminal size, wait for `change-size.sh` to run and then print the terminal size again.

--- a/test-framework/sudo-compliance-tests/src/sudo/env_reset.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/env_reset.rs
@@ -5,7 +5,7 @@ use sudo_test::{Command, Env, User};
 
 use crate::{
     helpers, Result, SUDOERS_ROOT_ALL_NOPASSWD, SUDO_ENV_DEFAULT_PATH, SUDO_ENV_DEFAULT_TERM,
-    USERNAME,
+    SUDO_RS_IS_UNSTABLE, USERNAME,
 };
 
 // NOTE if 'env_reset' is not in `/etc/sudoers` it is enabled by default
@@ -24,7 +24,7 @@ fn some_vars_are_set() -> Result<()> {
 
     // run sudo in an empty environment
     let stdout = Command::new("env")
-        .args(["-i", &sudo_abs_path, &env_abs_path])
+        .args(["-i", SUDO_RS_IS_UNSTABLE, &sudo_abs_path, &env_abs_path])
         .output(&env)?
         .stdout()?;
     let mut sudo_env = helpers::parse_env_output(&stdout)?;
@@ -115,7 +115,14 @@ fn user_dependent_vars() -> Result<()> {
 
     // run sudo in an empty environment
     let stdout = Command::new("env")
-        .args(["-i", &sudo_abs_path, "-u", USERNAME, &env_abs_path])
+        .args([
+            "-i",
+            SUDO_RS_IS_UNSTABLE,
+            &sudo_abs_path,
+            "-u",
+            USERNAME,
+            &env_abs_path,
+        ])
         .output(&env)?
         .stdout()?;
     let mut sudo_env = helpers::parse_env_output(&stdout)?;
@@ -169,6 +176,7 @@ fn some_vars_are_preserved() -> Result<()> {
     let stdout = Command::new("env")
         .args([
             "-i",
+            SUDO_RS_IS_UNSTABLE,
             &format!("HOME={home}"),
             &format!("MAIL={mail}"),
             &format!("SHELL={shell}"),
@@ -223,6 +231,7 @@ fn vars_whose_values_start_with_parentheses_are_removed() -> Result<()> {
     let stdout = Command::new("env")
         .args([
             "-i",
+            SUDO_RS_IS_UNSTABLE,
             "DISPLAY=() display",
             "PATH=() path",
             "TERM=() term",

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/credential_caching.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/credential_caching.rs
@@ -12,7 +12,7 @@ fn it_works() -> Result<()> {
 
     let output = Command::new("sh")
         .arg("-c")
-        .arg(format!("echo {PASSWORD} | sudo -S -l; sudo -l"))
+        .arg(format!("echo {PASSWORD} | sudo -S -l; sudo -l && true"))
         .as_user(USERNAME)
         .output(&env)?;
 
@@ -42,7 +42,7 @@ fn credential_shared_with_non_list_sudo() -> Result<()> {
     Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -S -l 2>/dev/null >/tmp/stdout1.txt; sudo true"
+            "echo {PASSWORD} | sudo -S -l 2>/dev/null >/tmp/stdout1.txt; sudo true && true"
         ))
         .as_user(USERNAME)
         .output(&env)?

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_non_interactive.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_non_interactive.rs
@@ -43,7 +43,7 @@ fn flag_remove_timestamp_plus_command_fails() -> Result<()> {
     let output = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -S true 2>/dev/null; sudo -n -k true"
+            "echo {PASSWORD} | sudo -S true 2>/dev/null; sudo -n -k true && true"
         ))
         .as_user(USERNAME)
         .output(&env)?;
@@ -99,7 +99,7 @@ fn cached_credential() -> Result<()> {
 
     Command::new("sh")
         .arg("-c")
-        .arg(format!("echo {PASSWORD} | sudo -S true; sudo -n true"))
+        .arg(format!("echo {PASSWORD} | sudo -S true; sudo -n true && true"))
         .as_user(USERNAME)
         .output(&env)?
         .assert_success()

--- a/test-framework/sudo-compliance-tests/src/sudo/sudo_ps1.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudo_ps1.rs
@@ -1,6 +1,6 @@
 use sudo_test::{Command, Env};
 
-use crate::{helpers, EnvList, Result, SUDOERS_ROOT_ALL_NOPASSWD};
+use crate::{helpers, EnvList, Result, SUDOERS_ROOT_ALL_NOPASSWD, SUDO_RS_IS_UNSTABLE};
 
 // see 'environment' section in `man sudo`
 // "SUDO_PS1: If set, PS1 will be set to its value for the program being run."
@@ -14,7 +14,7 @@ fn ps1_env_var_is_set_when_sudo_ps1_is_set() -> Result<()> {
 
     // run sudo in an empty environment
     let stdout = Command::new("env")
-        .args(["-i"])
+        .args(["-i", SUDO_RS_IS_UNSTABLE])
         .arg(format!("SUDO_PS1={ps1}"))
         .args([&sudo_abs_path, &env_abs_path])
         .output(&env)?
@@ -36,7 +36,7 @@ fn ps1_env_var_is_not_set_when_sudo_ps1_is_set_and_flag_login_is_used() -> Resul
 
     // run sudo in an empty environment
     let stdout = Command::new("env")
-        .args(["-i"])
+        .args(["-i", SUDO_RS_IS_UNSTABLE])
         .arg("SUDO_PS1=abc")
         .args([&sudo_abs_path, "-i", &env_abs_path])
         .output(&env)?
@@ -60,7 +60,7 @@ fn can_start_with_parentheses() -> Result<()> {
 
     // run sudo in an empty environment
     let stdout = Command::new("env")
-        .args(["-i"])
+        .args(["-i", SUDO_RS_IS_UNSTABLE])
         .arg(format!("SUDO_PS1={ps1}"))
         .args([&sudo_abs_path, &env_abs_path])
         .output(&env)?

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/timestamp_timeout.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/timestamp_timeout.rs
@@ -15,7 +15,7 @@ Defaults timestamp_timeout=0.1"
     // try to sudo without a password
     Command::new("sh")
         .arg("-c")
-        .arg(format!("echo {PASSWORD} | sudo -S true; sudo true"))
+        .arg(format!("echo {PASSWORD} | sudo -S true; sudo true && true"))
         .as_user(USERNAME)
         .output(&env)?
         .assert_success()?;
@@ -38,7 +38,7 @@ Defaults timestamp_timeout=0.1"
     let output = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -S true; sleep 10; sudo true"
+            "echo {PASSWORD} | sudo -S true; sleep 10; sudo true && true"
         ))
         .as_user(USERNAME)
         .output(&env)?;
@@ -69,7 +69,7 @@ Defaults timestamp_timeout=0"
     // try to sudo without a password
     let output = Command::new("sh")
         .arg("-c")
-        .arg(format!("echo {PASSWORD} | sudo -S true; sudo true"))
+        .arg(format!("echo {PASSWORD} | sudo -S true; sudo true && true"))
         .as_user(USERNAME)
         .output(&env)?;
 

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
@@ -173,7 +173,7 @@ fn negation_excludes_group_members() -> Result<()> {
 
 #[test]
 fn negation_is_order_sensitive() -> Result<()> {
-    // negated items at the start of a specifier list  are meaningless
+    // negated items at the start of a specifier list are meaningless
     let env = Env("!ghost, %users ALL=(ALL:ALL) NOPASSWD: ALL")
         // the primary group of all new users is `users`
         .user("ferris")

--- a/test-framework/sudo-compliance-tests/src/sudo/timestamp.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/timestamp.rs
@@ -1,6 +1,6 @@
 use sudo_test::{Command, Env, User};
 
-use crate::{Result, PASSWORD, USERNAME};
+use crate::{Result, PASSWORD, SUDO_RS_IS_UNSTABLE, USERNAME};
 
 mod remove;
 mod reset;
@@ -132,7 +132,7 @@ fn cached_credential_not_shared_with_target_user_that_are_not_self() -> Result<(
     let output = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -u {second_target_user} -S true; sudo -u {second_target_user} sudo -S true"
+            "echo {PASSWORD} | sudo -u {second_target_user} -S true; sudo -u {second_target_user} env '{SUDO_RS_IS_UNSTABLE}' sudo -S true"
         ))
         .as_user(USERNAME)
         .output(&env)?;
@@ -164,7 +164,7 @@ fn cached_credential_shared_with_target_user_that_is_self_on_the_same_tty() -> R
     Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -S true; sudo -u {USERNAME} sudo -n true"
+            "echo {PASSWORD} | sudo -S true; sudo -u {USERNAME} env '{SUDO_RS_IS_UNSTABLE}' sudo -n true"
         ))
         .as_user(USERNAME)
         .tty(true)

--- a/test-framework/sudo-compliance-tests/src/sudo/timestamp.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/timestamp.rs
@@ -14,7 +14,7 @@ fn credential_caching_works() -> Result<()> {
 
     Command::new("sh")
         .arg("-c")
-        .arg(format!("set -e; echo {PASSWORD} | sudo -S true; sudo true"))
+        .arg(format!("set -e; echo {PASSWORD} | sudo -S true; sudo true && true"))
         .as_user(USERNAME)
         .output(&env)?
         .assert_success()
@@ -28,7 +28,7 @@ fn by_default_credential_caching_is_local() -> Result<()> {
 
     Command::new("sh")
         .arg("-c")
-        .arg(format!("set -e; echo {PASSWORD} | sudo -S true"))
+        .arg(format!("set -e; echo {PASSWORD} | sudo -S true && true"))
         .as_user(USERNAME)
         .output(&env)?
         .assert_success()?;
@@ -60,7 +60,7 @@ fn credential_cache_is_shared_with_child_shell() -> Result<()> {
     Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "set -e; echo {PASSWORD} | sudo -S true; sh -c 'sudo true'"
+            "set -e; echo {PASSWORD} | sudo -S true; sh -c 'sudo true && true' && true"
         ))
         .as_user(USERNAME)
         // XXX unclear why this and the tests that follow need a pseudo-TTY allocation to pass
@@ -78,7 +78,7 @@ fn credential_cache_is_shared_with_parent_shell() -> Result<()> {
     Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "set -e; sh -c 'echo {PASSWORD} | sudo -S true'; sudo true"
+            "set -e; sh -c 'echo {PASSWORD} | sudo -S true && true'; sudo true && true"
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -95,7 +95,7 @@ fn credential_cache_is_shared_between_sibling_shells() -> Result<()> {
     Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "set -e; sh -c 'echo {PASSWORD} | sudo -S true'; sh -c 'sudo true'"
+            "set -e; sh -c 'echo {PASSWORD} | sudo -S true && true'; sh -c 'sudo true' && true"
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -114,7 +114,7 @@ fn cached_credential_applies_to_all_target_users() -> Result<()> {
     Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "set -e; echo {PASSWORD} | sudo -S true; sudo -u {second_target_user} true"
+            "set -e; echo {PASSWORD} | sudo -S true; sudo -u {second_target_user} true && true"
         ))
         .as_user(USERNAME)
         .output(&env)?
@@ -132,7 +132,7 @@ fn cached_credential_not_shared_with_target_user_that_are_not_self() -> Result<(
     let output = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -u {second_target_user} -S true; sudo -u {second_target_user} env '{SUDO_RS_IS_UNSTABLE}' sudo -S true"
+            "echo {PASSWORD} | sudo -u {second_target_user} -S true; sudo -u {second_target_user} env '{SUDO_RS_IS_UNSTABLE}' sudo -S true && true"
         ))
         .as_user(USERNAME)
         .output(&env)?;
@@ -164,7 +164,7 @@ fn cached_credential_shared_with_target_user_that_is_self_on_the_same_tty() -> R
     Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -S true; sudo -u {USERNAME} env '{SUDO_RS_IS_UNSTABLE}' sudo -n true"
+            "echo {PASSWORD} | sudo -S true; sudo -u {USERNAME} env '{SUDO_RS_IS_UNSTABLE}' sudo -n true && true"
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -186,7 +186,7 @@ fn cached_credential_not_shared_with_self_across_ttys() -> Result<()> {
     let output = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -S true; sudo -u {USERNAME} sudo -n true"
+            "echo {PASSWORD} | sudo -S true; sudo -u {USERNAME} sudo -n true && true"
         ))
         .as_user(USERNAME)
         .tty(true)

--- a/test-framework/sudo-compliance-tests/src/sudo/timestamp/remove.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/timestamp/remove.rs
@@ -13,7 +13,7 @@ fn is_limited_to_a_single_user() -> Result<()> {
     let child = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -S true; touch /tmp/barrier1; until [ -f /tmp/barrier2 ]; do sleep 1; done; sudo -S true"
+            "echo {PASSWORD} | sudo -S true; touch /tmp/barrier1; until [ -f /tmp/barrier2 ]; do sleep 1; done; sudo -S true && true"
         ))
         .as_user(USERNAME)
         .spawn(&env)?;
@@ -37,7 +37,7 @@ fn has_a_user_global_effect() -> Result<()> {
     let child = Command::new("sh")
     .arg("-c")
     .arg(format!(
-        "echo {PASSWORD} | sudo -S true; touch /tmp/barrier1; until [ -f /tmp/barrier2 ]; do sleep 1; done; echo | sudo -S true"
+        "echo {PASSWORD} | sudo -S true; touch /tmp/barrier1; until [ -f /tmp/barrier2 ]; do sleep 1; done; echo | sudo -S true && true"
     ))
     .as_user(USERNAME)
     .spawn(&env)?;
@@ -76,7 +76,7 @@ fn also_works_locally() -> Result<()> {
     let output = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -S true; sudo -K; sudo true"
+            "echo {PASSWORD} | sudo -S true; sudo -K; sudo true && true"
         ))
         .as_user(USERNAME)
         .output(&env)?;

--- a/test-framework/sudo-compliance-tests/src/sudo/timestamp/reset.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/timestamp/reset.rs
@@ -14,7 +14,7 @@ fn it_works() -> Result<()> {
     let output = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -S true; sudo -k; sudo true"
+            "echo {PASSWORD} | sudo -S true; sudo -k; sudo true && true"
         ))
         .as_user(USERNAME)
         .output(&env)?;
@@ -41,7 +41,7 @@ fn has_a_local_effect() -> Result<()> {
     let child = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "set -e; echo {PASSWORD} | sudo -S true; touch /tmp/barrier1; until [ -f /tmp/barrier2 ]; do sleep 1; done; sudo true"
+            "set -e; echo {PASSWORD} | sudo -S true; touch /tmp/barrier1; until [ -f /tmp/barrier2 ]; do sleep 1; done; sudo true && true"
         ))
         .as_user(USERNAME)
         .spawn(&env)?;
@@ -64,7 +64,7 @@ fn with_command_prompts_for_password() -> Result<()> {
 
     let output = Command::new("sh")
         .arg("-c")
-        .arg(format!("echo {PASSWORD} | sudo -S true; sudo -k true"))
+        .arg(format!("echo {PASSWORD} | sudo -S true; sudo -k true && true"))
         .as_user(USERNAME)
         .output(&env)?;
 
@@ -100,7 +100,7 @@ fn with_command_failure_does_not_invalidate_credential_cache() -> Result<()> {
     Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -S true; sudo -k true; [ $? -eq 1 ] || exit 2; sudo true"
+            "echo {PASSWORD} | sudo -S true; sudo -k true; [ $? -eq 1 ] || exit 2; sudo true && true"
         ))
         .as_user(USERNAME)
         .output(&env)?
@@ -122,7 +122,7 @@ fn with_command_success_does_not_invalidate_credential_cache() -> Result<()> {
     Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -S true; echo {PASSWORD} | sudo -k -S true; sudo true"
+            "echo {PASSWORD} | sudo -S true; echo {PASSWORD} | sudo -k -S true; sudo true && true"
         ))
         .as_user(USERNAME)
         .output(&env)?
@@ -138,7 +138,7 @@ fn with_command_does_not_cache_credentials() -> Result<()> {
     let output = Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "echo {PASSWORD} | sudo -k -S true 2>/dev/null || exit 2; sudo true"
+            "echo {PASSWORD} | sudo -k -S true 2>/dev/null || exit 2; sudo true && true"
         ))
         .as_user(USERNAME)
         .output(&env)?;

--- a/test-framework/sudo-compliance-tests/src/sudo/timestamp/validate.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/timestamp/validate.rs
@@ -17,7 +17,7 @@ Defaults timestamp_timeout=0.1"
     Command::new("sh")
     .arg("-c")
     .arg(format!(
-        "set -e; echo {PASSWORD} | sudo -S true; for i in $(seq 1 5); do sleep 3; sudo -v; done; sudo true"
+        "set -e; echo {PASSWORD} | sudo -S true; for i in $(seq 1 5); do sleep 3; sudo -v; done; sudo true && true"
     ))
     .as_user(USERNAME)
     .output(&env)?

--- a/test-framework/sudo-compliance-tests/src/sudo/use_pty.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/use_pty.rs
@@ -16,7 +16,7 @@ fn fixture() -> Result<Processes> {
     let env = Env([SUDOERS_ALL_ALL_NOPASSWD, "Defaults use_pty"]).build()?;
 
     let child = Command::new("sudo")
-        .args(["sh", "-c", "touch /tmp/barrier; sleep 3"])
+        .args(["sh", "-c", "touch /tmp/barrier; sleep 3; true"])
         .tty(true)
         .spawn(&env)?;
 

--- a/test-framework/sudo-test/src/ours.Dockerfile
+++ b/test-framework/sudo-test/src/ours.Dockerfile
@@ -7,9 +7,9 @@ WORKDIR /usr/src/sudo
 COPY . .
 RUN --mount=type=cache,target=/usr/src/sudo/target cargo build --locked --features="dev" --bins && mkdir -p build && cp target/debug/sudo build/sudo && cp target/debug/su build/su && cp target/debug/visudo build/visudo
 # set setuid on install
-RUN install --mode 4755 build/sudo /usr/bin/sudo
-RUN install --mode 4755 build/su /usr/bin/su
-RUN install --mode 755 build/visudo /usr/sbin/visudo
+RUN install -m 4755 build/sudo /usr/bin/sudo && \
+    install -m 4755 build/su /usr/bin/su && \
+    install -m 755 build/visudo /usr/sbin/visudo
 # `apt-get install sudo` creates this directory; creating it in the image saves us the work of creating it in each compliance test
 RUN mkdir -p /etc/sudoers.d
 # remove build dependencies


### PR DESCRIPTION
A future PR will add support for actually running the compliance test suite on FreeBSD, but I would like to clean up my changes for this first. Until then this reduces the diff of my freebsd branch.

Part of https://github.com/trifectatechfoundation/sudo-rs/issues/869