### PR TITLE
Make it run on FreeBSD

### DIFF
--- a/src/su/mod.rs
+++ b/src/su/mod.rs
@@ -24,7 +24,12 @@ fn authenticate(
     user: &str,
     login: bool,
 ) -> Result<PamContext<CLIConverser>, Error> {
-    let context = if login { "su-l" } else { "su" };
+    // FIXME make it configurable by the packager
+    let context = if login && cfg!(target_os = "linux") {
+        "su-l"
+    } else {
+        "su"
+    };
     let use_stdin = true;
     let mut pam = PamContext::builder_cli("su", use_stdin, false)
         .target_user(user)

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -48,14 +48,17 @@ you are unsure how to do this then this software is not suited for you at this t
 const VERSION: &str = std::env!("CARGO_PKG_VERSION");
 
 pub(crate) fn candidate_sudoers_file() -> &'static Path {
-    let pb_rs: &'static Path = Path::new("/etc/sudoers-rs");
-    if pb_rs.exists() {
-        dev_info!("Running with /etc/sudoers-rs file");
+    let pb_rs = Path::new("/etc/sudoers-rs");
+    let file = if pb_rs.exists() {
         pb_rs
+    } else if cfg!(target_os = "freebsd") {
+        // FIXME maybe make this configurable by the packager?
+        Path::new("/usr/local/etc/sudoers")
     } else {
-        dev_info!("Running with /etc/sudoers file");
         Path::new("/etc/sudoers")
-    }
+    };
+    dev_info!("Running with {} file", file.display());
+    file
 }
 
 #[derive(Default)]

--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -111,7 +111,12 @@ pub fn init_pam(
     auth_user: &str,
     requesting_user: &str,
 ) -> PamResult<PamContext<CLIConverser>> {
-    let service_name = if is_login_shell { "sudo-i" } else { "sudo" };
+    // FIXME make it configurable by the packager
+    let service_name = if is_login_shell && cfg!(target_os = "linux") {
+        "sudo-i"
+    } else {
+        "sudo"
+    };
     let mut pam = PamContext::builder_cli("sudo", use_stdin, non_interactive)
         .service_name(service_name)
         .build()?;

--- a/src/system/kernel.rs
+++ b/src/system/kernel.rs
@@ -5,6 +5,10 @@ use std::mem::zeroed;
 use crate::common::Error;
 
 pub fn kernel_check(major: u32, minor: u32) -> Result<(), Error> {
+    if cfg!(target_os = "freebsd") {
+        return Ok(());
+    }
+
     let mut utsname: libc::utsname = unsafe { zeroed() };
 
     if unsafe { libc::uname(&mut utsname) } != 0 {

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -88,6 +88,7 @@ fn sudo_uses_correct_service_file() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't use sudo-i PAM context")]
 fn sudo_dash_i_uses_correct_service_file() -> Result<()> {
     let env = Env("ALL ALL=(ALL:ALL) ALL")
         .file("/etc/pam.d/sudo-i", "auth sufficient pam_permit.so")


### PR DESCRIPTION
There are still a bunch of things that need to be fixed for FreeBSD with some potentially having a security impact, so don't rely on this in production yet. For this reason you need to set `SUDO_RS_IS_UNSTABLE` when trying to use it on FreeBSD.

Together with https://github.com/trifectatechfoundation/sudo-rs/pull/904 and https://github.com/trifectatechfoundation/sudo-rs/pull/905 this results in:

```
test result: FAILED. 562 passed; 84 failed; 62 ignored; 0 measured; 0 filtered out; finished in 785.26s

error: test failed, to rerun pass `-p sudo-compliance-tests --lib`
```

Part of https://github.com/trifectatechfoundation/sudo-rs/issues/869