### PR TITLE
Third batch of FreeBSD changes for the compliance test suite

### DIFF
--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -261,8 +261,12 @@ mod tests {
             fork_for_test(|| {
                 // Open a new pseudoterminal.
                 let leader = Pty::open().unwrap().leader;
-                // The pty leader should not have a foreground process group yet.
-                assert_eq!(leader.tcgetpgrp().unwrap().inner(), 0);
+                // On FreeBSD this returns an unspecified PID when there is no foreground process
+                // group, so skip this check on FreeBSD.
+                if cfg!(not(target_os = "freebsd")) {
+                    // The pty leader should not have a foreground process group yet.
+                    assert_eq!(leader.tcgetpgrp().unwrap().inner(), 0);
+                }
                 // Create a new session so we can change the controlling terminal.
                 setsid().unwrap();
                 // Set the pty leader as the controlling terminal.

--- a/test-framework/e2e-tests/src/su/flag_pty.rs
+++ b/test-framework/e2e-tests/src/su/flag_pty.rs
@@ -1,5 +1,5 @@
 use sudo_test::{
-    helpers::{self, PsAuxEntry},
+    helpers::{self, PsAuxEntry, PRINT_PTY_OWNER},
     Command, Env,
 };
 
@@ -122,7 +122,7 @@ fn pty_owner() -> Result<()> {
 
     let stdout = Command::new("su")
         .args(["--pty", "-c"])
-        .arg("stat $(tty) --format '%U %G'")
+        .arg(PRINT_PTY_OWNER)
         .tty(true)
         .output(&env)?
         .stdout()?;

--- a/test-framework/sudo-compliance-tests/src/su.rs
+++ b/test-framework/sudo-compliance-tests/src/su.rs
@@ -126,7 +126,10 @@ fn nopasswd_root() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "su on FreeBSD doesn't require password if target user is self")]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "su on FreeBSD doesn't require password if target user is self"
+)]
 fn password_is_required_when_target_user_is_self() -> Result<()> {
     let env = Env("").user(USERNAME).build()?;
 

--- a/test-framework/sudo-compliance-tests/src/su/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/su/pam.rs
@@ -77,6 +77,7 @@ fn being_root_has_no_precedence_over_pam_deny() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't use /etc/pam.d/su-l")]
 fn su_uses_correct_service_file() -> Result<()> {
     let env = Env("")
         .file("/etc/pam.d/su", "auth sufficient pam_permit.so")
@@ -92,6 +93,7 @@ fn su_uses_correct_service_file() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't use /etc/pam.d/su-l")]
 fn su_dash_l_uses_correct_service_file() -> Result<()> {
     let env = Env("")
         .file("/etc/pam.d/su-l", "auth sufficient pam_permit.so")

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
@@ -1,4 +1,4 @@
-use sudo_test::{Command, Env, BIN_LS, BIN_TRUE, BIN_FALSE};
+use sudo_test::{Command, Env, BIN_FALSE, BIN_LS, BIN_TRUE};
 
 use crate::{Result, HOSTNAME};
 
@@ -189,9 +189,7 @@ fn cwd_path() -> Result<()> {
 
 #[test]
 fn cwd_multiple_commands() -> Result<()> {
-    let stdout = sudo_list_of(&format!(
-        " ALL  ALL  = CWD = * {BIN_TRUE} ,  {BIN_FALSE} "
-    ))?;
+    let stdout = sudo_list_of(&format!(" ALL  ALL  = CWD = * {BIN_TRUE} ,  {BIN_FALSE} "))?;
     assert_snapshot!(stdout);
     Ok(())
 }
@@ -216,9 +214,7 @@ fn cwd_override() -> Result<()> {
 
 #[test]
 fn cwd_not_in_first_position() -> Result<()> {
-    let stdout = sudo_list_of(&format!(
-        " ALL  ALL  = {BIN_TRUE} , CWD = * {BIN_FALSE} "
-    ))?;
+    let stdout = sudo_list_of(&format!(" ALL  ALL  = {BIN_TRUE} , CWD = * {BIN_FALSE} "))?;
     assert_snapshot!(stdout);
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_non_interactive.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_non_interactive.rs
@@ -99,7 +99,9 @@ fn cached_credential() -> Result<()> {
 
     Command::new("sh")
         .arg("-c")
-        .arg(format!("echo {PASSWORD} | sudo -S true; sudo -n true && true"))
+        .arg(format!(
+            "echo {PASSWORD} | sudo -S true; sudo -n true && true"
+        ))
         .as_user(USERNAME)
         .output(&env)?
         .assert_success()

--- a/test-framework/sudo-compliance-tests/src/sudo/misc.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/misc.rs
@@ -1,4 +1,4 @@
-use sudo_test::{Command, Env};
+use sudo_test::{helpers::assert_ls_output, Command, Env};
 
 use crate::{Result, PANIC_EXIT_CODE, SUDOERS_ALL_ALL_NOPASSWD, USERNAME};
 
@@ -168,17 +168,7 @@ fn works_when_invoked_through_a_symlink() -> Result<()> {
         .output(&env)?
         .stdout()?;
 
-    // lrwxrwxrwx 1 ferris users
-    eprintln!("{ls_output}");
-
-    // symlink has not the setuid bit set
-    let stat_output = Command::new("stat")
-        .args(["-c", "%a", symlink_path])
-        .output(&env)?
-        .stdout()?;
-
-    // 777
-    eprintln!("{stat_output}");
+    assert_ls_output(&ls_output, "lrwxrwxrwx", "ferris", "users");
 
     // still, we expect sudo to work because the executable behind the symlink has the right
     // ownership and permissions

--- a/test-framework/sudo-compliance-tests/src/sudo/misc.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/misc.rs
@@ -168,7 +168,11 @@ fn works_when_invoked_through_a_symlink() -> Result<()> {
         .output(&env)?
         .stdout()?;
 
-    assert_ls_output(&ls_output, "lrwxrwxrwx", "ferris", "users");
+    if cfg!(target_os = "freebsd") {
+        assert_ls_output(&ls_output, "lrwx------", "ferris", "wheel");
+    } else {
+        assert_ls_output(&ls_output, "lrwxrwxrwx", "ferris", "users");
+    }
 
     // still, we expect sudo to work because the executable behind the symlink has the right
     // ownership and permissions

--- a/test-framework/sudo-compliance-tests/src/sudo/nopasswd.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/nopasswd.rs
@@ -62,11 +62,9 @@ fn nopasswd_tag() -> Result<()> {
 
 #[test]
 fn nopasswd_tag_for_command() -> Result<()> {
-    let env = Env(format!(
-        "{USERNAME}    ALL=(ALL:ALL) NOPASSWD: {BIN_TRUE}"
-    ))
-    .user(USERNAME)
-    .build()?;
+    let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) NOPASSWD: {BIN_TRUE}"))
+        .user(USERNAME)
+        .build()?;
 
     Command::new("sudo")
         .arg("true")
@@ -78,9 +76,11 @@ fn nopasswd_tag_for_command() -> Result<()> {
 #[test]
 #[ignore = "gh530"]
 fn run_sudo_l_flag_without_pwd_if_one_nopasswd_is_set() -> Result<()> {
-    let env = Env(format!("ALL ALL=(ALL:ALL) NOPASSWD: {BIN_TRUE}, PASSWD: {BIN_LS}"))
-        .user(USERNAME)
-        .build()?;
+    let env = Env(format!(
+        "ALL ALL=(ALL:ALL) NOPASSWD: {BIN_TRUE}, PASSWD: {BIN_LS}"
+    ))
+    .user(USERNAME)
+    .build()?;
 
     let output = Command::new("sudo")
         .arg("-l")

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -88,7 +88,10 @@ fn sudo_uses_correct_service_file() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't use sudo-i PAM context")]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "FreeBSD doesn't use sudo-i PAM context"
+)]
 fn sudo_dash_i_uses_correct_service_file() -> Result<()> {
     let env = Env("ALL ALL=(ALL:ALL) ALL")
         .file("/etc/pam.d/sudo-i", "auth sufficient pam_permit.so")

--- a/test-framework/sudo-compliance-tests/src/sudo/pass_auth.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pass_auth.rs
@@ -5,4 +5,7 @@
 mod stdin;
 mod tty;
 
-const MAX_PAM_RESPONSE_SIZE: usize = 512;
+#[cfg(not(target_os = "freebsd"))]
+const MAX_PASSWORD_SIZE: usize = 511; // MAX_PAM_RESPONSE_SIZE - 1 null byte
+#[cfg(target_os = "freebsd")]
+const MAX_PASSWORD_SIZE: usize = 128;

--- a/test-framework/sudo-compliance-tests/src/sudo/pass_auth/stdin.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pass_auth/stdin.rs
@@ -3,7 +3,7 @@ use sudo_test::{Command, Env, User};
 
 use crate::{Result, PASSWORD, USERNAME};
 
-use super::MAX_PAM_RESPONSE_SIZE;
+use super::MAX_PASSWORD_SIZE;
 
 #[test]
 fn correct_password() -> Result<()> {
@@ -67,7 +67,7 @@ fn no_password() -> Result<()> {
 
 #[test]
 fn longest_possible_password_works() -> Result<()> {
-    let password = "a".repeat(MAX_PAM_RESPONSE_SIZE - 1 /* null byte */);
+    let password = "a".repeat(MAX_PASSWORD_SIZE);
 
     let env = Env("ALL ALL=(ALL:ALL) ALL")
         .user(User(USERNAME).password(&password))
@@ -85,7 +85,7 @@ fn longest_possible_password_works() -> Result<()> {
 fn input_longer_than_max_pam_response_size_is_handled_gracefully() -> Result<()> {
     let env = Env("ALL ALL=(ALL:ALL) ALL").user(USERNAME).build()?;
 
-    let input = "a".repeat(5 * MAX_PAM_RESPONSE_SIZE / 2);
+    let input = "a".repeat(5 * MAX_PASSWORD_SIZE / 2);
     let output = Command::new("sudo")
         .args(["-S", "true"])
         .stdin(input)
@@ -108,12 +108,12 @@ fn input_longer_than_max_pam_response_size_is_handled_gracefully() -> Result<()>
 
 #[test]
 fn input_longer_than_password_should_not_be_accepted_as_correct_password() -> Result<()> {
-    let password = "a".repeat(MAX_PAM_RESPONSE_SIZE - 1 /* null byte */);
+    let password = "a".repeat(MAX_PASSWORD_SIZE);
     let env = Env("ALL ALL=(ALL:ALL) ALL")
         .user(User(USERNAME).password(password))
         .build()?;
 
-    let input_sizes = [MAX_PAM_RESPONSE_SIZE, MAX_PAM_RESPONSE_SIZE + 1];
+    let input_sizes = [MAX_PASSWORD_SIZE + 1, MAX_PASSWORD_SIZE + 2];
 
     for input_size in input_sizes {
         let input = "a".repeat(input_size);

--- a/test-framework/sudo-compliance-tests/src/sudo/pass_auth/tty.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pass_auth/tty.rs
@@ -2,7 +2,7 @@ use sudo_test::{Command, Env, User};
 
 use crate::{Result, PASSWORD, USERNAME};
 
-use super::MAX_PAM_RESPONSE_SIZE;
+use super::MAX_PASSWORD_SIZE;
 
 #[test]
 #[ignore = "gh414"]
@@ -68,7 +68,7 @@ fn no_tty() -> Result<()> {
 
 #[test]
 fn longest_possible_password_works() -> Result<()> {
-    let password = "a".repeat(MAX_PAM_RESPONSE_SIZE - 1 /* null byte */);
+    let password = "a".repeat(MAX_PASSWORD_SIZE);
 
     let env = Env("ALL ALL=(ALL:ALL) ALL")
         .user(User(USERNAME).password(&password))
@@ -83,12 +83,12 @@ fn longest_possible_password_works() -> Result<()> {
 
 #[test]
 fn input_longer_than_password_should_not_be_accepted_as_correct_password() -> Result<()> {
-    let password = "a".repeat(MAX_PAM_RESPONSE_SIZE - 1 /* null byte */);
+    let password = "a".repeat(MAX_PASSWORD_SIZE);
     let env = Env("ALL ALL=(ALL:ALL) ALL")
         .user(User(USERNAME).password(password))
         .build()?;
 
-    let input_sizes = [MAX_PAM_RESPONSE_SIZE, MAX_PAM_RESPONSE_SIZE + 1];
+    let input_sizes = [MAX_PASSWORD_SIZE + 1, MAX_PASSWORD_SIZE + 2];
 
     for input_size in input_sizes {
         let input = "a".repeat(input_size);

--- a/test-framework/sudo-compliance-tests/src/sudo/path_search.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/path_search.rs
@@ -83,11 +83,12 @@ fn ignores_path_for_qualified_commands() -> Result<()> {
 
 #[test]
 fn paths_are_matched_using_realpath_in_sudoers() -> Result<()> {
-    let env = Env(["ALL ALL = /bin/true"]).build()?;
+    let env = Env(["ALL ALL = /tmp/bin/true"]).build()?;
 
-    // this test assumes /bin is a symbolic link for /usr/bin, which is the
-    // case on Debian bookworm; if it fails for original sudo, either change the
-    // dockerfile or explicitly create a symbolic link
+    Command::new("ln")
+        .args(["-s", "/usr/bin", "/tmp/bin"])
+        .output(&env)?
+        .assert_success()?;
 
     Command::new("sudo")
         .arg("/usr/bin/true")
@@ -101,12 +102,13 @@ fn paths_are_matched_using_realpath_in_sudoers() -> Result<()> {
 fn paths_are_matched_using_realpath_in_arguments() -> Result<()> {
     let env = Env(["ALL ALL = /usr/bin/true"]).build()?;
 
-    // this test assumes /bin is a symbolic link for /usr/bin, which is the
-    // case on Debian bookworm; if it fails for original sudo, either change the
-    // dockerfile or explicitly create a symbolic link
+    Command::new("ln")
+        .args(["-s", "/usr/bin", "/tmp/bin"])
+        .output(&env)?
+        .assert_success()?;
 
     Command::new("sudo")
-        .arg("/bin/true")
+        .arg("/tmp/bin/true")
         .output(&env)?
         .assert_success()?;
 

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd.rs
@@ -93,12 +93,9 @@ fn different() -> Result<()> {
         .output(&env)?
         .assert_success()?;
 
-    let output = Command::new("sudo")
-        .args([BIN_LS, "/root"])
-        .output(&env)?
-        .stdout()?;
+    let output = Command::new("sudo").args([BIN_LS, "/root"]).output(&env)?;
 
-    assert_eq!("", output);
+    assert!(output.status().success());
 
     Ok(())
 }
@@ -150,12 +147,9 @@ fn runas_override() -> Result<()> {
     .user(USERNAME)
     .build()?;
 
-    let stdout = Command::new("sudo")
-        .args([BIN_LS, "/root"])
-        .output(&env)?
-        .stdout()?;
+    let output = Command::new("sudo").args([BIN_LS, "/root"]).output(&env)?;
 
-    assert_eq!("", stdout);
+    assert!(output.status().success());
 
     let output = Command::new("sudo")
         .args(["-u", USERNAME, BIN_LS])

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
@@ -378,9 +378,7 @@ fn runas_override() -> Result<()> {
     .user("ferris")
     .build()?;
 
-    let output = Command::new("sudo")
-        .args([BIN_LS, "/root"])
-        .output(&env)?;
+    let output = Command::new("sudo").args([BIN_LS, "/root"]).output(&env)?;
     assert!(output.status().success());
 
     let output = Command::new("sudo")

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/include.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/include.rs
@@ -1,4 +1,4 @@
-use sudo_test::{Command, Env, TextFile, ETC_DIR};
+use sudo_test::{Command, Env, TextFile, ETC_DIR, ETC_PARENT_DIR};
 
 use crate::{Result, SUDOERS_ALL_ALL_NOPASSWD, USERNAME};
 
@@ -258,7 +258,10 @@ fn hostname_expansion() -> Result<()> {
 #[test]
 fn relative_path_parent_directory() -> Result<()> {
     let env = Env("@include ../sudoers2")
-        .file("/sudoers2", SUDOERS_ALL_ALL_NOPASSWD)
+        .file(
+            format!("{ETC_PARENT_DIR}/sudoers2"),
+            SUDOERS_ALL_ALL_NOPASSWD,
+        )
         .build()?;
 
     Command::new("sudo")

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/includedir.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/includedir.rs
@@ -262,6 +262,10 @@ fn whitespace_in_name_double_quotes() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "zfs on freebsd doesn't allow creating files with backslashes"
+)]
 fn backslash_in_name_escaped() -> Result<()> {
     let env = Env(r"@includedir /etc/sudo\\ers.d")
         .directory(r"/etc/sudo\ers.d")
@@ -275,6 +279,10 @@ fn backslash_in_name_escaped() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "zfs on freebsd doesn't allow creating files with backslashes"
+)]
 fn backslash_in_name_double_quotes() -> Result<()> {
     let env = Env(r#"@includedir "/etc/sudo\ers.d""#)
         .directory(r"/etc/sudo\ers.d")

--- a/test-framework/sudo-compliance-tests/src/sudo/timestamp.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/timestamp.rs
@@ -14,7 +14,9 @@ fn credential_caching_works() -> Result<()> {
 
     Command::new("sh")
         .arg("-c")
-        .arg(format!("set -e; echo {PASSWORD} | sudo -S true; sudo true && true"))
+        .arg(format!(
+            "set -e; echo {PASSWORD} | sudo -S true; sudo true && true"
+        ))
         .as_user(USERNAME)
         .output(&env)?
         .assert_success()

--- a/test-framework/sudo-compliance-tests/src/sudo/timestamp/reset.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/timestamp/reset.rs
@@ -64,7 +64,9 @@ fn with_command_prompts_for_password() -> Result<()> {
 
     let output = Command::new("sh")
         .arg("-c")
-        .arg(format!("echo {PASSWORD} | sudo -S true; sudo -k true && true"))
+        .arg(format!(
+            "echo {PASSWORD} | sudo -S true; sudo -k true && true"
+        ))
         .as_user(USERNAME)
         .output(&env)?;
 

--- a/test-framework/sudo-compliance-tests/src/sudo/use_pty.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/use_pty.rs
@@ -1,5 +1,5 @@
 use sudo_test::{
-    helpers::{self, PsAuxEntry},
+    helpers::{self, PsAuxEntry, PRINT_PTY_OWNER},
     Command, Env,
 };
 
@@ -119,7 +119,7 @@ fn pty_owner() -> Result<()> {
     let env = Env([SUDOERS_ALL_ALL_NOPASSWD, "Defaults use_pty"]).build()?;
 
     let stdout = Command::new("sudo")
-        .args(["sh", "-c", "stat $(tty) --format '%U %G'"])
+        .args(["sh", "-c", PRINT_PTY_OWNER])
         .tty(true)
         .output(&env)?
         .stdout()?;

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -1,6 +1,8 @@
 use std::{thread, time::Duration};
 
-use sudo_test::{Command, Env, TextFile, ETC_DIR, ETC_SUDOERS, ROOT_GROUP};
+use sudo_test::{
+    helpers::assert_ls_output, Command, Env, TextFile, ETC_DIR, ETC_SUDOERS, ROOT_GROUP,
+};
 
 use crate::{Result, PANIC_EXIT_CODE, SUDOERS_ALL_ALL_NOPASSWD};
 
@@ -78,7 +80,7 @@ fn creates_sudoers_file_with_default_ownership_and_perms_if_it_doesnt_exist() ->
         .output(&env)?
         .stdout()?;
 
-    assert!(ls_output.starts_with(&format!("-r--r----- 1 root {ROOT_GROUP}")));
+    assert_ls_output(&ls_output, "-r--r-----", "root", ROOT_GROUP);
 
     Ok(())
 }
@@ -163,7 +165,7 @@ ls -l /tmp/sudoers-*/sudoers > {LOGS_PATH}"#
 
     let ls_output = Command::new("cat").arg(LOGS_PATH).output(&env)?.stdout()?;
 
-    assert!(ls_output.starts_with(&format!("-rwx------ 1 root {ROOT_GROUP}")));
+    assert_ls_output(&ls_output, "-rwx------", "root", ROOT_GROUP);
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
@@ -208,7 +208,16 @@ fn regular_user_can_create_file() -> Result<()> {
         .output(&env)?
         .stdout()?;
 
-    assert_ls_output(&ls_output, "-rw-r-----", USERNAME, "users");
+    assert_ls_output(
+        &ls_output,
+        "-rw-r-----",
+        USERNAME,
+        if cfg!(target_os = "freebsd") {
+            "wheel"
+        } else {
+            "users"
+        },
+    );
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
@@ -1,4 +1,4 @@
-use sudo_test::{Command, Env, TextFile, ROOT_GROUP};
+use sudo_test::{helpers::assert_ls_output, Command, Env, TextFile, ROOT_GROUP};
 
 use crate::{
     visudo::{CHMOD_EXEC, DEFAULT_EDITOR, EDITOR_TRUE, ETC_SUDOERS, LOGS_PATH, TMP_SUDOERS},
@@ -34,7 +34,7 @@ fn creates_sudoers_file_with_default_ownership_and_perms_if_it_doesnt_exist() ->
         .output(&env)?
         .stdout()?;
 
-    assert!(ls_output.starts_with(&format!("-rw-r----- 1 root {ROOT_GROUP}")));
+    assert_ls_output(&ls_output, "-rw-r-----", "root", ROOT_GROUP);
 
     Ok(())
 }
@@ -208,7 +208,7 @@ fn regular_user_can_create_file() -> Result<()> {
         .output(&env)?
         .stdout()?;
 
-    assert!(ls_output.starts_with(&format!("-rw-r----- 1 {USERNAME} users")));
+    assert_ls_output(&ls_output, "-rw-r-----", USERNAME, "users");
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/visudo/include.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/include.rs
@@ -15,7 +15,10 @@ fn prompt() -> Result<()> {
 
     let output = Command::new("visudo").output(&env)?;
 
-    assert_contains!(output.stdout()?, format!("press return to edit {ETC_DIR}/sudoers2:"));
+    assert_contains!(
+        output.stdout()?,
+        format!("press return to edit {ETC_DIR}/sudoers2:")
+    );
 
     Ok(())
 }
@@ -250,8 +253,10 @@ cat /tmp/scratchpad >> {LOGS_PATH}"
 
 #[test]
 fn does_not_edit_files_in_includedir_directories() -> Result<()> {
-    let env = Env(format!("# 1
-    @includedir {ETC_DIR}/sudoers.d"))
+    let env = Env(format!(
+        "# 1
+    @includedir {ETC_DIR}/sudoers.d"
+    ))
     .file(format!("{ETC_DIR}/sudoers.d/a"), "# 2")
     .file(
         DEFAULT_EDITOR,

--- a/test-framework/sudo-test/src/constants.rs
+++ b/test-framework/sudo-test/src/constants.rs
@@ -1,3 +1,11 @@
+/// The parent of the directory where sudo will look for the sudoers file.
+#[cfg(not(target_os = "freebsd"))]
+pub const ETC_PARENT_DIR: &str = "/";
+
+/// The parent of the directory where sudo will look for the sudoers file.
+#[cfg(target_os = "freebsd")]
+pub const ETC_PARENT_DIR: &str = "/usr/local/";
+
 /// The directory where sudo will look for the sudoers file.
 #[cfg(not(target_os = "freebsd"))]
 pub const ETC_DIR: &str = "/etc";

--- a/test-framework/sudo-test/src/helpers.rs
+++ b/test-framework/sudo-test/src/helpers.rs
@@ -71,11 +71,7 @@ impl PsAuxEntry {
         } else if cfg!(target_os = "freebsd") {
             // On FreeBSD the PTY is either ? or - when there is no pty, or is an integer
             // potentially prefixed by v.
-            if self.tty == "?" || self.tty == "-" {
-                false
-            } else {
-                true
-            }
+            !(self.tty == "?" || self.tty == "-")
         } else {
             unimplemented!()
         }

--- a/test-framework/sudo-test/src/helpers.rs
+++ b/test-framework/sudo-test/src/helpers.rs
@@ -8,6 +8,20 @@ pub const PRINT_PTY_OWNER: &str = "stat $(tty) --format '%U %G'";
 #[cfg(target_os = "freebsd")]
 pub const PRINT_PTY_OWNER: &str = "stat -f '%Su %Sg' $(tty)";
 
+/// Check that the ls output matches the expectation while being insensitive to the exact output of
+/// the system ls version.
+#[track_caller]
+pub fn assert_ls_output(ls_output: &str, mode: &str, user: &str, group: &str) {
+    let parts = ls_output
+        .split(' ')
+        .filter(|part| !part.is_empty()) // FreeBSD ls often uses multiple spaces as seperator
+        .collect::<Vec<_>>();
+
+    assert_eq!(parts[0], mode);
+    assert_eq!(parts[2], user);
+    assert_eq!(parts[3], group);
+}
+
 /// parse the output of `ps aux`
 pub fn parse_ps_aux(ps_aux: &str) -> Vec<PsAuxEntry> {
     let mut entries = vec![];

--- a/test-framework/sudo-test/src/helpers.rs
+++ b/test-framework/sudo-test/src/helpers.rs
@@ -1,5 +1,13 @@
 //! Test helpers
 
+/// A command which will print the owner of it's TTY in the format "username group"
+#[cfg(target_os = "linux")]
+pub const PRINT_PTY_OWNER: &str = "stat $(tty) --format '%U %G'";
+
+/// A command which will print the owner of it's TTY in the format "username group"
+#[cfg(target_os = "freebsd")]
+pub const PRINT_PTY_OWNER: &str = "stat -f '%Su %Sg' $(tty)";
+
 /// parse the output of `ps aux`
 pub fn parse_ps_aux(ps_aux: &str) -> Vec<PsAuxEntry> {
     let mut entries = vec![];


### PR DESCRIPTION
```
test result: FAILED. 582 passed; 60 failed; 66 ignored; 0 measured; 0 filtered out; finished in 833.12s

error: test failed, to rerun pass `-p sudo-compliance-tests --lib`
```

Part of https://github.com/trifectatechfoundation/sudo-rs/issues/869