### PR TITLE
Remove some outdated snapshot files

### DIFF
--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/alias_given_specific_command_then_other_command_is_not_allowed.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/alias_given_specific_command_then_other_command_is_not_allowed.snap
@@ -1,5 +1,0 @@
----
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
-expression: stderr
----
-Sorry, user root is not allowed to execute '/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/even_more_negation_combination.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/even_more_negation_combination.snap
@@ -1,5 +1,0 @@
----
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
-expression: stderr
----
-Sorry, user root is not allowed to execute '/bin/ls' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/negation_combination.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/negation_combination.snap
@@ -1,5 +1,0 @@
----
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
-expression: stderr
----
-

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/different_aliases_user_and_group_fails_when_both_are_passed.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/different_aliases_user_and_group_fails_when_both_are_passed.snap
@@ -1,5 +1,0 @@
----
-source: sudo-compliance-tests/src/sudoers/runas_alias.rs
-expression: stderr
----
-[sudo] password for ferris: Sorry, user ferris is not allowed to execute '/usr/bin/true' as otheruser:rustaceans on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/user_and_group_failing_also_when_given_different_aliases.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/user_and_group_failing_also_when_given_different_aliases.snap
@@ -1,5 +1,0 @@
----
-source: sudo-compliance-tests/src/sudoers/runas_alias.rs
-expression: stderr
----
-[sudo] password for ferris: Sorry, user ferris is not allowed to execute '/bin/true' as otheruser:rustaceans on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/user_and_group_failing_also_when_given_different_aliases_each.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/user_and_group_failing_also_when_given_different_aliases_each.snap
@@ -1,5 +1,0 @@
----
-source: sudo-compliance-tests/src/sudoers/runas_alias.rs
-expression: stderr
----
-[sudo] password for ferris: Sorry, user ferris is not allowed to execute '/bin/true' as otheruser:rustaceans on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/user_and_group_fails_when_both_are_passed.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/user_and_group_fails_when_both_are_passed.snap
@@ -1,5 +1,0 @@
----
-source: sudo-compliance-tests/src/sudoers/runas_alias.rs
-expression: stderr
----
-[sudo] password for ferris: Sorry, user ferris is not allowed to execute '/usr/bin/true' as otheruser:rustaceans on [host].


### PR DESCRIPTION
At least some them are likely caused by tests moving to another file and thus putting snapshots in another directory.