### PR TITLE
Add some modifications to CI recommended by SSF

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 name: CI
 
+permissions: read-all
+
 on:
   push:
     branches:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,20 +19,20 @@ jobs:
       SUDO_TEST_VERBOSE_DOCKER_BUILD: 1
       CI: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: set up docker buildx
         run: docker buildx create --name builder --use
 
       - name: cache docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: /tmp/.buildx-cache
           key: docker-buildx-rs-${{ github.sha }}
           restore-keys: docker-buildx-rs-
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
         with:
           shared-key: "compliance-tests"
           workspaces: |
@@ -56,13 +56,13 @@ jobs:
       SUDO_TEST_VERBOSE_DOCKER_BUILD: 1
       CI: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: set up docker buildx
         run: docker buildx create --name builder --use
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
         with:
           shared-key: "compliance-tests"
           workspaces: |
@@ -87,20 +87,20 @@ jobs:
       SUDO_TEST_VERBOSE_DOCKER_BUILD: 1
       CI: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: set up docker buildx
         run: docker buildx create --name builder --use
 
       - name: cache docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
         with:
           path: /tmp/.buildx-cache
           key: docker-buildx-rs-${{ github.sha }}
           restore-keys: docker-buildx-rs-
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
         with:
           shared-key: "compliance-tests"
           workspaces: |
@@ -133,10 +133,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
         with:
           shared-key: "compliance-tests"
           workspaces: |
@@ -162,13 +162,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install llvm-tools component
         run: rustup component add llvm-tools
 
       - name: Add cargo-llvm-cov
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@ddaadeb8971af08eaa9bdad7ba96eb721ed2aafd
         with:
           tool: cargo-llvm-cov
 
@@ -178,7 +178,7 @@ jobs:
           sudo apt install libpam0g-dev
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
         with:
           shared-key: "stable"
 
@@ -192,7 +192,7 @@ jobs:
         run: cargo llvm-cov --workspace --all-features --all-targets --release --lcov --output-path lcov.info
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a
         with:
           files: lcov.info
 
@@ -200,7 +200,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install nightly rust
         run: |
@@ -213,7 +213,7 @@ jobs:
           sudo apt install libpam0g-dev
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
         with:
           shared-key: "nightly"
 
@@ -233,7 +233,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install rust 1.70
         run: rustup override set 1.70
@@ -244,7 +244,7 @@ jobs:
           sudo apt install libpam0g-dev
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
         with:
           shared-key: "msrv"
 
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install nightly rust and miri
         run: |
@@ -276,7 +276,7 @@ jobs:
           sudo apt install libpam0g-dev
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
         with:
           shared-key: miri
 
@@ -290,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install dependencies
         run: |
@@ -298,7 +298,7 @@ jobs:
           sudo apt install libpam0g-dev
 
       - name: Install rust-bindgen
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@ddaadeb8971af08eaa9bdad7ba96eb721ed2aafd
         with:
           tool: bindgen-cli@0.70.1
 
@@ -316,7 +316,7 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Run rustfmt
         run: cargo fmt --all -- --check
@@ -327,10 +327,10 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
         with:
           shared-key: "stable"
 
@@ -346,10 +346,10 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
         with:
           shared-key: "stable"
 
@@ -363,10 +363,10 @@ jobs:
     needs: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@ddaadeb8971af08eaa9bdad7ba96eb721ed2aafd
         with:
           tool: cargo-audit
 


### PR DESCRIPTION
* Explicitly set permissions on our actions to 'read' (this was already managed elsewhere, but scorecard likes to see it)
* Pin our CI actions by hash. Note that this is a version bump for Codecov, taiki-e/install and actions/cache and a neutral change for rust-cache and actions/checkout. The Dockerfiles for our test-framework are *not* pinned deliberately. That'll dock us some points, but it feels a bit silly to pin them.
* Add a dependabot file. We've decided to update whatever few dependencies sudo-rs has manually, but it's nice for our CI dependencies.