### PR TITLE
Fifth batch of FreeBSD changes for the compliance test suite

### DIFF
--- a/test-framework/sudo-compliance-tests/src/su/limits.rs
+++ b/test-framework/sudo-compliance-tests/src/su/limits.rs
@@ -3,6 +3,7 @@ use sudo_test::{Command, Env, User};
 use crate::{Result, PASSWORD, USERNAME};
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't support /etc/security")]
 fn etc_security_limits_rules_apply_according_to_the_target_user() -> Result<()> {
     let target_user = "ghost";
     let original = "2048";

--- a/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/mod.rs
@@ -257,7 +257,7 @@ fn sigwinch_works(use_pty: bool) -> Result<()> {
 #[test]
 #[cfg_attr(
     target_os = "freebsd",
-    ignore = "podman on freebsd puts each docker exec command in a jail with separate /dev/pts"
+    ignore = "gh924: podman on freebsd puts each docker exec command in a jail with separate /dev/pts"
 )]
 fn sigwinch_works_pty() -> Result<()> {
     sigwinch_works(true)
@@ -266,7 +266,7 @@ fn sigwinch_works_pty() -> Result<()> {
 #[test]
 #[cfg_attr(
     target_os = "freebsd",
-    ignore = "podman on freebsd puts each docker exec command in a jail with separate /dev/pts"
+    ignore = "gh924: podman on freebsd puts each docker exec command in a jail with separate /dev/pts"
 )]
 fn sigwinch_works_no_pty() -> Result<()> {
     sigwinch_works(false)

--- a/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/mod.rs
@@ -255,11 +255,19 @@ fn sigwinch_works(use_pty: bool) -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "podman on freebsd puts each docker exec command in a jail with separate /dev/pts"
+)]
 fn sigwinch_works_pty() -> Result<()> {
     sigwinch_works(true)
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "podman on freebsd puts each docker exec command in a jail with separate /dev/pts"
+)]
 fn sigwinch_works_no_pty() -> Result<()> {
     sigwinch_works(false)
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_login.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_login.rs
@@ -188,10 +188,10 @@ echo $@";
 #[test]
 fn shell_is_invoked_as_a_login_shell() -> Result<()> {
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
-        .user(User(USERNAME).shell("/bin/bash"))
+        .user(User(USERNAME).shell("/bin/sh"))
         .build()?;
 
-    let expected = "-bash";
+    let expected = "-sh";
     let actual = Command::new("sudo")
         .args(["-u", "ferris", "-i", "echo", "$0"])
         .output(&env)?

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_shell.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_shell.rs
@@ -172,13 +172,13 @@ fn shell_is_not_invoked_as_a_login_shell() -> Result<()> {
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD).build()?;
 
     let actual = Command::new("env")
-        .args(["SHELL=/bin/bash", "sudo", "-s", "echo", "$0"])
+        .args(["SHELL=/bin/sh", "sudo", "-s", "echo", "$0"])
         .output(&env)?
         .stdout()?;
 
     // man bash says "A login shell is one whose first character of argument zero is a -"
-    assert_ne!("-bash", actual);
-    assert_eq!("/bin/bash", actual);
+    assert_ne!("-sh", actual);
+    assert_eq!("/bin/sh", actual);
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/pam/env.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam/env.rs
@@ -28,6 +28,7 @@ fn remove_comments_and_whitespace(contents: &str) -> String {
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn stock_pam_d_sudo() -> Result<()> {
     let env = Env("").build()?;
 
@@ -70,6 +71,7 @@ fn stock_pam_d_sudo() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn preserves_pam_env() -> Result<()> {
     let set_name = "SET_VAR";
     let set_value = "set";
@@ -101,6 +103,7 @@ fn preserves_pam_env() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn pam_env_has_precedence_over_callers_env() -> Result<()> {
     let set_name = "SET_VAR";
     let set_value = "set";
@@ -180,16 +183,19 @@ fn env_list_has_precendece_over_pam_env(env_list: EnvList) -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn env_keep_has_precedence_over_pam_env() -> Result<()> {
     env_list_has_precendece_over_pam_env(EnvList::Keep)
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn env_check_has_precedence_over_pam_env() -> Result<()> {
     env_list_has_precendece_over_pam_env(EnvList::Check)
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn var_rejected_by_env_check_falls_back_to_pam_env_value() -> Result<()> {
     let set_name = "SET_VAR";
     let set_value = "set";
@@ -233,6 +239,7 @@ fn var_rejected_by_env_check_falls_back_to_pam_env_value() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn default_and_override_pam_env_vars_are_parentheses_checked_but_set_vars_are_not() -> Result<()> {
     let set_name = "SET_VAR";
     let set_value = "() set";
@@ -264,6 +271,7 @@ fn default_and_override_pam_env_vars_are_parentheses_checked_but_set_vars_are_no
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn pam_env_vars_are_not_env_checked() -> Result<()> {
     let set_name = "SET_VAR";
     let set_value = "%set";

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/secure_path.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/secure_path.rs
@@ -37,12 +37,11 @@ ALL ALL=(ALL:ALL) NOPASSWD: ALL")
     .file(path, TextFile("#!/bin/sh").chmod("100"))
     .build()?;
 
-    let match_in_relative_path_when_path_is_unset = "unset PATH; cd /bin; /usr/bin/sudo true";
+    // `true` is in `/usr/bin/`
+    let match_in_relative_path_when_path_is_unset = "unset PATH; cd /usr/bin; /usr/bin/sudo true";
     let match_in_absolute_path_when_path_is_unset = "unset PATH; cd /; /usr/bin/sudo my-script";
-    // `true` is in `/usr/bin/true`
-    let match_in_relative_path_when_path_is_set = "export PATH=/usr/bin; cd /bin; sudo true";
-    // default PATH does not include `/root`
-    let match_in_absolute_path_when_path_is_set = "cd /; /usr/bin/sudo my-script";
+    let match_in_relative_path_when_path_is_set = "export PATH=/tmp; cd /usr/bin; /usr/bin/sudo true";
+    let match_in_absolute_path_when_path_is_set = "export PATH=/tmp; cd /; /usr/bin/sudo my-script";
 
     let scripts = [
         match_in_relative_path_when_path_is_unset,

--- a/test-framework/sudo-test/src/constants.rs
+++ b/test-framework/sudo-test/src/constants.rs
@@ -51,3 +51,11 @@ pub const BIN_TRUE: &str = "/usr/bin/true";
 
 /// The path to the `false` binary.
 pub const BIN_FALSE: &str = "/usr/bin/false";
+
+/// The path to the `bash` binary.
+#[cfg(not(target_os = "freebsd"))]
+pub const BIN_BASH: &str = "/usr/bin/bash";
+
+/// The path to the `bash` binary.
+#[cfg(target_os = "freebsd")]
+pub const BIN_BASH: &str = "/usr/local/bin/bash";


### PR DESCRIPTION
```
test result: FAILED. 608 passed; 22 failed; 77 ignored; 0 measured; 0 filtered out; finished in 940.01s

error: test failed, to rerun pass `-p sudo-compliance-tests --lib`
```

Part of https://github.com/trifectatechfoundation/sudo-rs/issues/869