### PR TITLE
Add basic FreeBSD CI using Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,13 @@
+task:
+  name: Cirrus CI / freebsd unit tests
+  freebsd_instance:
+    image_family: freebsd-14-1
+    memory: 2GB
+  setup_rust_script:
+    - pkg install -y git-tiny
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh -y --profile=minimal
+  test_script:
+    - . $HOME/.cargo/env
+    # We skip a couple of tests which fail when running as root.
+    - cargo test --workspace --all-features --all-targets --release -- --skip group_as_non_root --skip test_secure_open_cookie_file

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: Cirrus CI / freebsd unit tests
   freebsd_instance:
-    image_family: freebsd-14-1
+    image_family: freebsd-14-2
     memory: 2GB
   setup_rust_script:
     - pkg install -y git-tiny


### PR DESCRIPTION
This currently only runs unit tests and not the compliance tests.

Cirrus CI is the only CI provider I'm aware of which supports FreeBSD out of the box. It does have the disadvantage though that on the free tier it can take several minutes before a CI job actually starts.