### PR TITLE
Treat conversation error as authentication failure

### DIFF
--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -150,12 +150,15 @@ pub fn attempt_authenticate<C: Converser>(
             }
 
             // there was an authentication error, we can retry
-            Err(PamError::Pam(PamErrorType::AuthError | PamErrorType::ConversationError, _)) => {
+            Err(PamError::Pam(
+                err_type @ (PamErrorType::AuthError | PamErrorType::ConversationError),
+                _,
+            )) => {
                 max_tries -= 1;
-                if max_tries == 0 {
-                    return Err(Error::MaxAuthAttempts(current_try));
-                } else if non_interactive {
+                if non_interactive || err_type == PamErrorType::ConversationError {
                     return Err(Error::InteractionRequired);
+                } else if max_tries == 0 {
+                    return Err(Error::MaxAuthAttempts(current_try));
                 } else {
                     user_warn!("Authentication failed, try again.");
                 }

--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -150,7 +150,7 @@ pub fn attempt_authenticate<C: Converser>(
             }
 
             // there was an authentication error, we can retry
-            Err(PamError::Pam(PamErrorType::AuthError, _)) => {
+            Err(PamError::Pam(PamErrorType::AuthError | PamErrorType::ConversationError, _)) => {
                 max_tries -= 1;
                 if max_tries == 0 {
                     return Err(Error::MaxAuthAttempts(current_try));


### PR DESCRIPTION
On FreeBSD PAM returns a conversation error when there is nowhere to read the password from.

```
test result: FAILED. 620 passed; 10 failed; 77 ignored; 0 measured; 0 filtered out; finished in 352.25s

error: test failed, to rerun pass `-p sudo-compliance-tests --lib`
```

Part of https://github.com/trifectatechfoundation/sudo-rs/issues/869