### PR TITLE
Elbow grease to help development.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.4-dev] - 2025-mm-dd
+
+### Changed
+- Portability: sudo-rs now works on FreeBSD!
+
+### Fixed
+- Bug in syslog writer could cause sudo to hang (#856)
+
 ## [0.2.3] - 2024-07-11
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "sudo-rs"
-version = "0.2.3"
+version = "0.2.4-dev"
 dependencies = [
  "glob",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sudo-rs"
 description = "A memory safe implementation of sudo and su."
-version = "0.2.3"
+version = "0.2.4-dev"
 license = "Apache-2.0 OR MIT"
 edition = "2021"
 repository = "https://github.com/trifectatechfoundation/sudo-rs"

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -45,7 +45,11 @@ you are unsure how to do this then this software is not suited for you at this t
     }
 }
 
-const VERSION: &str = std::env!("CARGO_PKG_VERSION");
+const VERSION: &str = if let Some(version_override) = std::option_env!("SUDO_RS_VERSION") {
+    version_override
+} else {
+    std::env!("CARGO_PKG_VERSION")
+};
 
 pub(crate) fn candidate_sudoers_file() -> &'static Path {
     let pb_rs = Path::new("/etc/sudoers-rs");

--- a/src/system/wait.rs
+++ b/src/system/wait.rs
@@ -169,6 +169,7 @@ mod tests {
 
     #[test]
     fn exit_status() {
+        #[allow(clippy::zombie_processes)]
         let command = std::process::Command::new("sh")
             .args(["-c", "sleep 0.1; exit 42"])
             .spawn()
@@ -196,6 +197,7 @@ mod tests {
 
     #[test]
     fn signals() {
+        #[allow(clippy::zombie_processes)]
         let command = std::process::Command::new("sh")
             .args(["-c", "sleep 1; exit 42"])
             .spawn()
@@ -225,6 +227,7 @@ mod tests {
 
     #[test]
     fn no_hang() {
+        #[allow(clippy::zombie_processes)]
         let command = std::process::Command::new("sh")
             .args(["-c", "sleep 0.1; exit 42"])
             .spawn()

--- a/util/update-version.sh
+++ b/util/update-version.sh
@@ -2,10 +2,9 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 PROJECT_DIR=$(dirname "$SCRIPT_DIR")
-NEW_VERSION="$1"
 
 # Fetch current version
-CURRENT_VERSION=$(sed -n '/version\s*=\s*"\([^"]*\)"/{s//\1/p;q}' "$PROJECT_DIR/Cargo.toml")
+CURRENT_VERSION=$(sed -n '/^version\s*=\s*"\([^"]*\)"/{s//\1/p;q}' "$PROJECT_DIR/Cargo.toml")
 
 # Fetch new version from changelog
 NEW_VERSION=$(grep -m1 '^##' "$PROJECT_DIR"/CHANGELOG.md | grep -o "\[[0-9]\+.[0-9]\+.[0-9]\+\]" | tr -d '[]')


### PR DESCRIPTION
Normally we do a lot of modification right before the release. But during development it's actually quite nice to already keep a changelog and bump the version number.

This PR also adds the ability to modify the version number for a build from the environment.

This also bumps clippy to a new version.