### PR TITLE
Add SETENV support

### DIFF
--- a/src/sudo/env/environment.rs
+++ b/src/sudo/env/environment.rs
@@ -238,6 +238,18 @@ pub fn get_target_environment(
     Ok(environment)
 }
 
+/// Extend the environment with user-supplied info
+pub fn dangerous_extend<S>(env: &mut Environment, user_override: impl IntoIterator<Item = (S, S)>)
+where
+    S: Into<OsString>,
+{
+    env.extend(
+        user_override
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into())),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{is_safe_tz, should_keep, PATH_ZONEINFO};

--- a/src/sudo/env/environment.rs
+++ b/src/sudo/env/environment.rs
@@ -67,7 +67,9 @@ fn add_extra_env(
         entry.insert(format!("{PATH_MAILDIR}/{}", context.target_user.name).into());
     }
     // The current SHELL variable should determine the shell to run when -s is passed, if none set use passwd entry
-    environment.insert("SHELL".into(), context.target_user.shell.clone().into());
+    if let Entry::Vacant(entry) = environment.entry("SHELL".into()) {
+        entry.insert(context.target_user.shell.clone().into());
+    }
     // HOME' Set to the home directory of the target user if -i or -H are specified, env_reset or always_set_home are
     // set in sudoers, or when the -s option is specified and set_home is set in sudoers.
     // Since we always want to do env_reset -> always set HOME

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -136,6 +136,7 @@ impl<Policy: PolicyPlugin, Auth: AuthPlugin> Pipeline<Policy, Auth> {
             must_authenticate,
             prior_validity,
             allowed_attempts,
+            ..
         }: AuthorizationAllowed,
     ) -> Result<(), Error> {
         let scope = RecordScope::for_process(&Process::new());

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -82,7 +82,7 @@ impl Pipeline<SudoersPolicy, PamAuthenticator<CLIConverser>> {
             sudoers.check_list_permission(&*context.current_user, &context.hostname, list_request);
         match judgement.authorization() {
             Authorization::Allowed(auth) => {
-                self.auth_and_update_record_file(context, auth)?;
+                self.auth_and_update_record_file(context, &auth)?;
                 Ok(ControlFlow::Continue(()))
             }
 

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -347,11 +347,13 @@ impl Parse for MetaOrTag {
         };
 
         let result: Modifier = match keyword.as_str() {
+            // we do not support these, and that should make sudo-rs "fail safe"
             "INTERCEPT" | "NOEXEC" => unrecoverable!(
                 pos = start_pos,
                 stream,
                 "NOEXEC and INTERCEPT are not supported by sudo-rs"
             ),
+            // this is less fatal
             "LOG_INPUT" | "NOLOG_INPUT" | "LOG_OUTPUT" | "NOLOG_OUTPUT" | "MAIL" | "NOMAIL" => {
                 eprintln_ignore_io_error!(
                     "warning: {} tags are ignored by sudo-rs",
@@ -375,6 +377,17 @@ impl Parse for MetaOrTag {
                 let path: ChDir = expect_nonterminal(stream)?;
                 Box::new(move |tag| tag.cwd = Some(path.clone()))
             }
+            // we do not support these, and that should make sudo-rs "fail safe"
+            spec @ ("CHROOT" | "TIMEOUT" | "NOTBEFORE" | "NOTAFTER") => unrecoverable!(
+                pos = start_pos,
+                stream,
+                "{spec} is not supported by sudo-rs"
+            ),
+            "ROLE" | "TYPE" => unrecoverable!(
+                pos = start_pos,
+                stream,
+                "role based access control is not yet supported by sudo-rs"
+            ),
 
             "ALL" => return make(MetaOrTag(All)),
             alias => return make(MetaOrTag(Alias(alias.to_string()))),

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -348,7 +348,16 @@ fn distribute_tags(
                 f(tag);
             }
 
-            Some((last_runas, (tag.clone(), cmd)))
+            let this_tag = match cmd {
+                Qualified::Allow(Meta::All) if tag.env != EnvironmentControl::Nosetenv => Tag {
+                    // "ALL" has an implicit "SETENV" that doesn't distribute
+                    env: EnvironmentControl::Setenv,
+                    ..tag.clone()
+                },
+                _ => tag.clone(),
+            };
+
+            Some((last_runas, (this_tag, cmd)))
         },
     )
 }

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -40,6 +40,7 @@ pub struct AuthorizationAllowed {
     pub must_authenticate: bool,
     pub allowed_attempts: u16,
     pub prior_validity: Duration,
+    pub trust_environment: bool,
 }
 
 #[must_use]
@@ -57,6 +58,7 @@ impl Policy for Judgement {
             let valid_seconds = self.settings.int_value["timestamp_timeout"];
             Authorization::Allowed(AuthorizationAllowed {
                 must_authenticate: tag.needs_passwd(),
+                trust_environment: tag.allows_setenv(),
                 allowed_attempts,
                 prior_validity: Duration::seconds(valid_seconds),
             })
@@ -107,6 +109,7 @@ impl PreJudgementPolicy for Sudoers {
     fn validate_authorization(&self) -> Authorization {
         Authorization::Allowed(AuthorizationAllowed {
             must_authenticate: true,
+            trust_environment: false,
             allowed_attempts: self.settings.int_value["passwd_tries"].try_into().unwrap(),
             prior_validity: Duration::seconds(self.settings.int_value["timestamp_timeout"]),
         })
@@ -139,6 +142,7 @@ mod test {
             judge.authorization(),
             Authorization::Allowed(AuthorizationAllowed {
                 must_authenticate: true,
+                trust_environment: false,
                 allowed_attempts: 3,
                 prior_validity: Duration::minutes(15),
             })
@@ -148,6 +152,7 @@ mod test {
             judge.authorization(),
             Authorization::Allowed(AuthorizationAllowed {
                 must_authenticate: false,
+                trust_environment: false,
                 allowed_attempts: 3,
                 prior_validity: Duration::minutes(15),
             })


### PR DESCRIPTION
Closes #760

Also Closes #546, since we add parsing+warning support for things like `NOEXEC` and `TIMEOUT`.

This does *not* add support for `--preserve-env` or `--preserve-env=VAR`. I think the former needs some more discussion since it is the same as disabling `env_reset`. The latter is not controversial for us but better part of a separate PR.

This can be reviewed commit-by-commit if desired.