### PR TITLE
Add target group as first gid when specified

### DIFF
--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -36,7 +36,7 @@ pub struct Context {
     pub chdir: Option<SudoPath>,
     pub command: CommandAndArguments,
     pub target_user: User,
-    pub target_group: Group,
+    pub target_group: Option<Group>,
     pub stdin: bool,
     pub non_interactive: bool,
     pub use_session_records: bool,

--- a/src/exec/interface.rs
+++ b/src/exec/interface.rs
@@ -16,7 +16,7 @@ pub trait RunOptions {
     fn is_login(&self) -> bool;
     fn user(&self) -> &User;
     fn requesting_user(&self) -> &User;
-    fn group(&self) -> &Group;
+    fn group(&self) -> Option<&Group>;
     fn pid(&self) -> ProcessId;
 
     fn use_pty(&self) -> bool;
@@ -55,8 +55,8 @@ impl RunOptions for Context {
         &self.current_user
     }
 
-    fn group(&self) -> &Group {
-        &self.target_group
+    fn group(&self) -> Option<&Group> {
+        self.target_group.as_ref()
     }
 
     fn pid(&self) -> ProcessId {

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -76,7 +76,7 @@ pub fn run_command(
     set_target_user(
         &mut command,
         options.user().clone(),
-        options.group().clone(),
+        options.group().cloned(),
     );
 
     // change current directory if necessary.

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -124,11 +124,11 @@ fn create_test_context(sudo_options: &SudoRunOptions) -> Context {
         } else {
             root_user
         },
-        target_group: if sudo_options.user.as_deref() == Some("test") {
+        target_group: Some(if sudo_options.user.as_deref() == Some("test") {
             current_group
         } else {
             root_group
-        },
+        }),
         launch: crate::common::context::LaunchType::Direct,
         chdir: sudo_options.chdir.clone(),
         stdin: sudo_options.stdin,

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -101,7 +101,7 @@ impl PolicyPlugin for SudoersPolicy {
             &context.hostname,
             crate::sudoers::Request {
                 user: &context.target_user,
-                group: &context.target_group,
+                group: context.target_group.as_ref(),
                 command: &context.command.command,
                 arguments: &context.command.arguments,
             },

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -76,7 +76,7 @@ impl Pipeline<SudoersPolicy, PamAuthenticator<CLIConverser>> {
     ) -> Result<ControlFlow<(), ()>, Error> {
         let list_request = ListRequest {
             target_user: &context.target_user,
-            target_group: &context.target_group,
+            target_group: context.target_group.as_ref(),
         };
         let judgement =
             sudoers.check_list_permission(&*context.current_user, &context.hostname, list_request);
@@ -128,7 +128,7 @@ fn check_other_users_list_perms(
 ) -> Result<(), Error> {
     let list_request = ListRequest {
         target_user: &context.target_user,
-        target_group: &context.target_group,
+        target_group: context.target_group.as_ref(),
     };
     let judgement = sudoers.check_list_permission(other_user, &context.hostname, list_request);
 
@@ -154,7 +154,7 @@ fn check_sudo_command_perms(
 
     let request = Request {
         user: &context.target_user,
-        group: &context.target_group,
+        group: context.target_group.as_ref(),
         command: &context.command.command,
         arguments: &context.command.arguments,
     };

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -93,7 +93,7 @@ fn permission_test() {
         ([$($sudo:expr),*], $user:expr => $req:expr, $server:expr; $command:expr) => {
             let (Sudoers { rules,aliases,settings }, _) = analyze(Path::new("/etc/fakesudoers"), sudoer![$($sudo),*]);
             let cmdvec = $command.split_whitespace().map(String::from).collect::<Vec<_>>();
-            let req = Request { user: $req.0, group: $req.1, command: &realpath(cmdvec[0].as_ref()), arguments: &cmdvec[1..].to_vec() };
+            let req = Request { user: $req.0, group: Some($req.1), command: &realpath(cmdvec[0].as_ref()), arguments: &cmdvec[1..].to_vec() };
             assert_eq!(Sudoers { rules, aliases, settings }.check(&Named($user), &system::Hostname::fake($server), req).flags, None);
         }
     }
@@ -102,7 +102,7 @@ fn permission_test() {
         ([$($sudo:expr),*], $user:expr => $req:expr, $server:expr; $command:expr $(=> [$($key:ident : $val:expr),*])?) => {
             let (Sudoers { rules,aliases,settings }, _) = analyze(Path::new("/etc/fakesudoers"), sudoer![$($sudo),*]);
             let cmdvec = $command.split_whitespace().map(String::from).collect::<Vec<_>>();
-            let req = Request { user: $req.0, group: $req.1, command: &realpath(cmdvec[0].as_ref()), arguments: &cmdvec[1..].to_vec() };
+            let req = Request { user: $req.0, group: Some($req.1), command: &realpath(cmdvec[0].as_ref()), arguments: &cmdvec[1..].to_vec() };
             let result = Sudoers { rules, aliases, settings }.check(&Named($user), &system::Hostname::fake($server), req).flags;
             assert!(!result.is_none());
             $(

--- a/test-framework/sudo-compliance-tests/src/su/flag_group.rs
+++ b/test-framework/sudo-compliance-tests/src/su/flag_group.rs
@@ -81,7 +81,11 @@ fn when_specified_more_than_once_all_groups_are_added_to_group_list() -> Result<
         .output(&env)?
         .stdout()?;
 
-    assert_eq!(format!("{gid2} {gid1}"), actual);
+    if cfg!(target_os = "freebsd") {
+        assert_eq!(format!("{gid2} {gid1} {gid2}"), actual);
+    } else {
+        assert_eq!(format!("{gid2} {gid1}"), actual);
+    }
 
     Ok(())
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/misc.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/misc.rs
@@ -217,7 +217,6 @@ fn does_not_panic_on_io_errors_cli_error() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh771"]
 fn long_username() -> Result<()> {
     // `useradd` limits usernames to 32 characters
     // directly write to `/etc/passwd` to work around this limitation


### PR DESCRIPTION
On FreeBSD the first gid in the setgroups list is the effective gid. And the groups list should contain this gid a second time to avoid losing it when running a setgid program according to the man page of setgroups.

This somehow causes the group in when_specified_more_than_once_all_groups_are_added_to_group_list to be duplicated. I can't check correctness of this duplication against original su as on FreeBSD su doesn't provide an option to specify groups.

This fixes the following test failures:

```
---- su::flag_group::when_specified_more_than_once_all_groups_are_added_to_group_list stdout ----
thread 'su::flag_group::when_specified_more_than_once_all_groups_are_added_to_group_list' panicked at sudo-compliance-tests/src/su/flag_group.rs:84:5:
assertion `left == right` failed
  left: "1001 1000"
 right: "1001"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- sudo::flag_group::adds_group_to_groups_output stdout ----
thread 'sudo::flag_group::adds_group_to_groups_output' panicked at sudo-compliance-tests/src/sudo/flag_group.rs:74:9:
assertion failed: `(left == right)`

Diff < left / right > :
 {
<    "users",
     "secondary-group",
>    "ferris",
>    "users",
 }
```

Part of https://github.com/trifectatechfoundation/sudo-rs/issues/869