### PR TITLE
Add effective group as the first element in the call to `set groups`

### DIFF
--- a/src/su/context.rs
+++ b/src/su/context.rs
@@ -112,7 +112,7 @@ impl SuContext {
 
             // last argument is the primary group
             group = primary_group.clone();
-            user.groups.push(primary_group.gid);
+            user.groups.insert(0, primary_group.gid);
         }
 
         // add additional group if current user is root

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -276,8 +276,15 @@ pub fn set_target_user(
 ) {
     use std::os::unix::process::CommandExt;
 
-    // add target group to list of additional groups if not present
-    if !target_user.groups.contains(&target_group.gid) {
+    if let Some(index) = target_user
+        .groups
+        .iter()
+        .position(|id| id == &target_group.gid)
+    {
+        // make sure the requested group id is the first in the list (necessary on FreeBSD)
+        target_user.groups.swap(0, index)
+    } else {
+        // add target group to list of additional groups if not present
         target_user.groups.insert(0, target_group.gid);
     }
 

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -278,7 +278,7 @@ pub fn set_target_user(
 
     // add target group to list of additional groups if not present
     if !target_user.groups.contains(&target_group.gid) {
-        target_user.groups.push(target_group.gid);
+        target_user.groups.insert(0, target_group.gid);
     }
 
     // we need to do this in a `pre_exec` call since the `groups` method in `process::Command` is unstable


### PR DESCRIPTION
This is my proposed alternative to PR #936. It's clear that inserting the effective group needs to happen at the start, not the end of the list; but the proposed solution there makes the rest of the policy module too dependent command line flags (and doesn't seem to solve the issue in case someone decides to use `-g` to add the currently effective group).