### PR TITLE
Revert "always give 'interaction is required' once if a conversation error occurred"

### DIFF
--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -150,15 +150,12 @@ pub fn attempt_authenticate<C: Converser>(
             }
 
             // there was an authentication error, we can retry
-            Err(PamError::Pam(
-                err_type @ (PamErrorType::AuthError | PamErrorType::ConversationError),
-                _,
-            )) => {
+            Err(PamError::Pam(PamErrorType::AuthError | PamErrorType::ConversationError, _)) => {
                 max_tries -= 1;
-                if non_interactive || err_type == PamErrorType::ConversationError {
-                    return Err(Error::InteractionRequired);
-                } else if max_tries == 0 {
+                if max_tries == 0 {
                     return Err(Error::MaxAuthAttempts(current_try));
+                } else if non_interactive {
+                    return Err(Error::InteractionRequired);
                 } else {
                     user_warn!("Authentication failed, try again.");
                 }


### PR DESCRIPTION
This reverts commit fd3cfecebc4f6b9f26e623440205a9c2b88e6395.

Turns out that this commit causes a fair amount of test failures on FreeBSD. Together with https://github.com/trifectatechfoundation/sudo-rs/pull/937 this PR fixes all test failures on Freebsd.

```
failures:

---- sudo::flag_list::credential_caching::flag_reset_timestamp stdout ----
thread 'sudo::flag_list::credential_caching::flag_reset_timestamp' panicked at sudo-compliance-tests/src/sudo/flag_list/credential_caching.rs:96:5:
"sudo-rs: interactive authentication is required" did not contain "sudo: Authentication failed"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- sudo::pass_auth::tty::no_tty stdout ----
thread 'sudo::pass_auth::tty::no_tty' panicked at sudo-compliance-tests/src/sudo/pass_auth/tty.rs:64:5:
"sudo-rs: interactive authentication is required" did not contain "Maximum 3 incorrect authentication attempts"

---- sudo::sudoers::timestamp_timeout::zero_always_prompts_for_password stdout ----
thread 'sudo::sudoers::timestamp_timeout::zero_always_prompts_for_password' panicked at sudo-compliance-tests/src/sudo/sudoers/timestamp_timeout.rs:84:5:
"[sudo: authenticate] Password:sudo-rs: interactive authentication is required" did not contain "incorrect authentication attempt"

---- sudo::sudoers::timestamp_timeout::nonzero stdout ----
thread 'sudo::sudoers::timestamp_timeout::nonzero' panicked at sudo-compliance-tests/src/sudo/sudoers/timestamp_timeout.rs:54:5:
"[sudo: authenticate] Password:sudo-rs: interactive authentication is required" did not contain "incorrect authentication attempt"

---- sudo::timestamp::by_default_credential_caching_is_local stdout ----
thread 'sudo::timestamp::by_default_credential_caching_is_local' panicked at sudo-compliance-tests/src/sudo/timestamp.rs:51:5:
"sudo-rs: interactive authentication is required" did not contain "incorrect authentication attempt"

---- sudo::timestamp::remove::also_works_locally stdout ----
thread 'sudo::timestamp::remove::also_works_locally' panicked at sudo-compliance-tests/src/sudo/timestamp/remove.rs:92:5:
"[sudo: authenticate] Password:sudo-rs: interactive authentication is required" did not contain "Authentication failed"

---- sudo::timestamp::reset::it_works stdout ----
thread 'sudo::timestamp::reset::it_works' panicked at sudo-compliance-tests/src/sudo/timestamp/reset.rs:30:5:
"[sudo: authenticate] Password:sudo-rs: interactive authentication is required" did not contain "incorrect authentication attempt"

---- sudo::timestamp::reset::with_command_prompts_for_password stdout ----
thread 'sudo::timestamp::reset::with_command_prompts_for_password' panicked at sudo-compliance-tests/src/sudo/timestamp/reset.rs:81:5:
"[sudo: authenticate] Password:sudo-rs: interactive authentication is required" did not contain "incorrect authentication attempt"

---- sudo::timestamp::reset::with_command_does_not_cache_credentials stdout ----
thread 'sudo::timestamp::reset::with_command_does_not_cache_credentials' panicked at sudo-compliance-tests/src/sudo/timestamp/reset.rs:156:5:
"sudo-rs: interactive authentication is required" did not contain "Authentication failed"

---- sudo::timestamp::validate::prompts_for_password stdout ----
thread 'sudo::timestamp::validate::prompts_for_password' panicked at sudo-compliance-tests/src/sudo/timestamp/validate.rs:46:5:
"sudo-rs: interactive authentication is required" did not contain "incorrect authentication attempt"

failures:
    sudo::flag_list::credential_caching::flag_reset_timestamp
    sudo::pass_auth::tty::no_tty
    sudo::sudoers::timestamp_timeout::nonzero
    sudo::sudoers::timestamp_timeout::zero_always_prompts_for_password
    sudo::timestamp::by_default_credential_caching_is_local
    sudo::timestamp::remove::also_works_locally
    sudo::timestamp::reset::it_works
    sudo::timestamp::reset::with_command_does_not_cache_credentials
    sudo::timestamp::reset::with_command_prompts_for_password
    sudo::timestamp::validate::prompts_for_password

test result: FAILED. 620 passed; 10 failed; 81 ignored; 0 measured; 0 filtered out; finished in 794.44s
```