### PR TITLE
Add a testing only feature for running as unprivileged user

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ dev = []
 strip = "symbols"
 lto = true
 opt-level = "s"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(unprivileged_for_testing_only)'] }

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -13,6 +13,7 @@ pub enum Error {
         other_user: Option<SudoString>,
     },
     SelfCheck,
+    SelfCheckMustBeUnprivileged,
     KernelCheck,
     CommandNotFound(PathBuf),
     InvalidCommand(PathBuf),
@@ -59,6 +60,10 @@ impl fmt::Display for Error {
             Error::SelfCheck => {
                 f.write_str("sudo must be owned by uid 0 and have the setuid bit set")
             }
+            Error::SelfCheckMustBeUnprivileged => f.write_str(
+                "when the unprivileged-for-testing-only feature is enabled \
+                 sudo may not run as root and may not have the setuid bit set",
+            ),
             Error::KernelCheck => f.write_str("sudo-rs needs a Linux kernel newer than v5.9"),
             Error::CommandNotFound(p) => write!(f, "'{}': command not found", p.display()),
             Error::InvalidCommand(p) => write!(f, "'{}': invalid command", p.display()),

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -37,6 +37,10 @@ pub fn secure_open_cookie_file(path: impl AsRef<Path>) -> io::Result<File> {
 }
 
 fn checks(path: &Path, meta: Metadata) -> io::Result<()> {
+    if cfg!(unprivileged_for_testing_only) {
+        return Ok(());
+    }
+
     let error = |msg| Error::new(ErrorKind::PermissionDenied, msg);
 
     let path_mode = meta.permissions().mode();


### PR DESCRIPTION
This feature must never be used in production. To ensure this, it needs to be enabled using RUSTFLAGS rather than as cargo feature, there is a compile error for using it with debug assertions enabled and we also check for setuid and being root at runtime and refuse to run in either case.

It would also be possible to keep this in a side branch from which you can cherry-pick when you want to do this kind of testing if the risk of someone using this in production is still considered too big despite the countermeasures against this.