### PR TITLE
Better handling when /etc/group misses an entry for the primary group of the user

### DIFF
--- a/src/common/resolve.rs
+++ b/src/common/resolve.rs
@@ -112,7 +112,7 @@ pub(crate) fn resolve_target_user_and_group(
         // when -u is specified but -g is not specified, default -g to the primary group of the specified user
         (Some(_), None) => {
             if let Some(user) = &target_user {
-                target_group = Group::from_gid(user.gid)?;
+                target_group = Some(user.primary_group()?);
             }
         }
         // when no -u or -g is specified, default to root:root
@@ -279,7 +279,7 @@ mod tests {
         // fallback to root
         let (user, group) = resolve_target_user_and_group(&None, &None, &current_user).unwrap();
         assert_eq!(user.name, "root");
-        assert_eq!(group.name, ROOT_GROUP_NAME);
+        assert_eq!(group.name.unwrap(), ROOT_GROUP_NAME);
 
         // unknown user
         let result =
@@ -296,7 +296,7 @@ mod tests {
             resolve_target_user_and_group(&None, &Some(ROOT_GROUP_NAME.into()), &current_user)
                 .unwrap();
         assert_eq!(user.name, current_user.name);
-        assert_eq!(group.name, ROOT_GROUP_NAME);
+        assert_eq!(group.name.unwrap(), ROOT_GROUP_NAME);
 
         // fallback to current users group when no group specified
         let (user, group) =

--- a/src/su/context.rs
+++ b/src/su/context.rs
@@ -99,8 +99,7 @@ impl SuContext {
         }
 
         // resolve target group
-        let mut group =
-            Group::from_gid(user.gid)?.ok_or_else(|| Error::GroupNotFound(user.gid.to_string()))?;
+        let mut group = user.primary_group()?;
 
         if !options.supp_group.is_empty() || !options.group.is_empty() {
             user.groups.clear();

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -96,7 +96,7 @@ fn create_test_context(sudo_options: &SudoRunOptions) -> Context {
 
     let current_group = Group {
         gid: GroupId::new(1000),
-        name: "test".to_string(),
+        name: Some("test".to_string()),
     };
 
     let root_user = User {
@@ -112,7 +112,7 @@ fn create_test_context(sudo_options: &SudoRunOptions) -> Context {
 
     let root_group = Group {
         gid: GroupId::new(0),
-        name: "root".to_string(),
+        name: Some("root".to_string()),
     };
 
     Context {

--- a/src/system/interface.rs
+++ b/src/system/interface.rs
@@ -160,7 +160,7 @@ impl UnixGroup for super::Group {
         self.gid
     }
     fn try_as_name(&self) -> Option<&str> {
-        Some(&self.name)
+        self.name.as_deref()
     }
 }
 

--- a/test-framework/sudo-compliance-tests/src/sudo/misc.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/misc.rs
@@ -240,7 +240,6 @@ fn long_username() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh771"]
 fn missing_primary_group() -> Result<()> {
     let username = "user";
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD).build()?;

--- a/test-framework/sudo-compliance-tests/src/sudo/misc.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/misc.rs
@@ -217,11 +217,32 @@ fn does_not_panic_on_io_errors_cli_error() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh771"]
 fn long_username() -> Result<()> {
     // `useradd` limits usernames to 32 characters
     // directly write to `/etc/passwd` to work around this limitation
     let username = "a".repeat(33);
+    let env = Env(SUDOERS_ALL_ALL_NOPASSWD).build()?;
+
+    Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "echo {username}:x:1000:1000::/tmp:/bin/sh >> /etc/passwd && echo {username}:x:1000: >> /etc/group"
+        ))
+        .output(&env)?
+        .assert_success()?;
+
+    Command::new("sudo")
+        .arg("-u")
+        .arg(username)
+        .arg("true")
+        .output(&env)?
+        .assert_success()
+}
+
+#[test]
+#[ignore = "gh771"]
+fn missing_primary_group() -> Result<()> {
+    let username = "user";
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD).build()?;
 
     Command::new("sh")


### PR DESCRIPTION
Also fix a test which wasn't intended to test this scenario and add a new test for this scenario.

Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/771