### PR TITLE
Disable network access for the containers

### DIFF
--- a/test-framework/sudo-test/src/docker.rs
+++ b/test-framework/sudo-test/src/docker.rs
@@ -60,6 +60,14 @@ impl Container {
     pub fn new_with_hostname(image: &str, hostname: Option<&str>) -> Result<Self> {
         let mut docker_run = docker_command();
         docker_run.args(["run", "--detach"]);
+        if !crate::is_original_sudo() {
+            // Disable network access for the containers. This removes the overhead of setting up a
+            // new network namespace and associated firewall rule adjustments. We still need to keep
+            // network access enabled for original sudo however as it needs to be able to resolve
+            // it's own hostname to a fully qualified domain name, which isn't possible with
+            // `--net=none`.
+            docker_run.arg("--net=none");
+        }
         if let Some(hostname) = hostname {
             docker_run.args(["--hostname", hostname]);
         }


### PR DESCRIPTION
Turns out setting up a network namespace and reconfiguring the firewall is pretty expensive. Disabling this setup brings down test times from ~210s to ~65s.