### PR TITLE
Add a bunch of safety docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ dev = []
 strip = "symbols"
 lto = true
 opt-level = "s"
+
+[lints.rust]
+unsafe_op_in_unsafe_fn = { level = "deny" }

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -83,6 +83,8 @@ pub fn run_command(
     if let Some(path) = path {
         let is_chdir = options.chdir().is_some();
 
+        // SAFETY: Chdir as used internally by set_current_dir is async-signal-safe. The logger we
+        // use is also async-signal-safe.
         unsafe {
             command.pre_exec(move || {
                 if let Err(err) = env::set_current_dir(&path) {


### PR DESCRIPTION
Also deny the `unsafe_op_in_unsafe_fn` lint. This lint is a hard error in the 2024 edition.

Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/863