### PR TITLE
Forbid unsafe_code lint for visudo and su

### DIFF
--- a/src/su/mod.rs
+++ b/src/su/mod.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use crate::common::error::Error;
 use crate::exec::{ExecOutput, ExitReason, RunOptions};
 use crate::log::user_warn;

--- a/src/system/file/mod.rs
+++ b/src/system/file/mod.rs
@@ -1,5 +1,7 @@
 mod chown;
 mod lock;
+mod tmpdir;
 
 pub(crate) use chown::Chown;
 pub(crate) use lock::FileLock;
+pub(crate) use tmpdir::create_temporary_dir;

--- a/src/system/file/tmpdir.rs
+++ b/src/system/file/tmpdir.rs
@@ -1,0 +1,18 @@
+use std::ffi::{CString, OsString};
+use std::io;
+use std::os::unix::ffi::OsStringExt;
+use std::path::PathBuf;
+
+pub(crate) fn create_temporary_dir() -> io::Result<PathBuf> {
+    let template = cstr!("/tmp/sudoers-XXXXXX").to_owned();
+
+    let ptr = unsafe { libc::mkdtemp(template.into_raw()) };
+
+    if ptr.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+
+    let path = OsString::from_vec(unsafe { CString::from_raw(ptr) }.into_bytes()).into();
+
+    Ok(path)
+}

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -1,11 +1,12 @@
+#![forbid(unsafe_code)]
+
 mod cli;
 mod help;
 
 use std::{
-    ffi::{CString, OsString},
     fs::{File, Permissions},
     io::{self, Read, Seek, Write},
-    os::unix::prelude::{MetadataExt, OsStringExt, PermissionsExt},
+    os::unix::prelude::{MetadataExt, PermissionsExt},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -15,7 +16,7 @@ use crate::{
     sudoers::Sudoers,
     system::{
         can_execute,
-        file::{Chown, FileLock},
+        file::{create_temporary_dir, Chown, FileLock},
         signal::{consts::*, register_handlers, SignalStream},
         User,
     },
@@ -321,18 +322,4 @@ fn editor_path_fallback() -> io::Result<PathBuf> {
         io::ErrorKind::NotFound,
         "cannot find text editor",
     ))
-}
-
-fn create_temporary_dir() -> io::Result<PathBuf> {
-    let template = cstr!("/tmp/sudoers-XXXXXX").to_owned();
-
-    let ptr = unsafe { libc::mkdtemp(template.into_raw()) };
-
-    if ptr.is_null() {
-        return Err(io::Error::last_os_error());
-    }
-
-    let path = OsString::from_vec(unsafe { CString::from_raw(ptr) }.into_bytes()).into();
-
-    Ok(path)
 }


### PR DESCRIPTION
The create_temporary_dir is moved to system::file as it uses unsafe and could be useful outside of visudo in the future.

Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/859