### PR TITLE
Only run ogsudo compliance tests if there was a change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,21 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
+  compliance-tests-detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      updated: ${{ steps.filter.outputs.test-framework }}
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+        id: filter
+        with:
+          filters: |
+            test-framework:
+              - 'test-framework/**'
+
   compliance-tests-og:
+    needs: compliance-tests-detect-changes
+    if: ${{ needs.compliance-tests-detect-changes.outputs.updated != 'false' }}
     runs-on: ubuntu-latest
     env:
       SUDO_TEST_VERBOSE_DOCKER_BUILD: 1
@@ -130,6 +144,8 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   compliance-tests-lint:
+    needs: compliance-tests-detect-changes
+    if: ${{ needs.compliance-tests-detect-changes.outputs.updated != 'false' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
There's no point in running the compliance tests on original sudo every time something changes in sudo-rs. This restricts the compliance-tests-lint and compliance-og-sudo to only run if there's a change in that part of the repository.

There is one potential downside to this: if an admin ever waves through a compliance-test change without waiting for the CI to finish (which should not happen), that'll become a failed CI state on `main`. But then the next commit/PR will give it a green checkmark. Is there a way for GitHub CI to "re-use" the result from `main` if a job is skipped?

Also, in case sudo gets a breaking change in the Debian stable (which is also highly unlikely) we'll also miss that until we make a change to the og-tests.

But those downsides to me seem acceptable:
- First scenario never happens: if there's a failed CI on main we've addressed that quickly
- Second scenario just goes against what Debian stable *is*. :-)