### PR TITLE
Appease clippy

### DIFF
--- a/src/common/string.rs
+++ b/src/common/string.rs
@@ -85,7 +85,7 @@ impl ops::Deref for SudoString {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
-        let num_bytes = self.inner.as_bytes().len();
+        let num_bytes = self.inner.len();
         &self.inner[..num_bytes - NULL_BYTE_UTF8_LEN]
     }
 }

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -455,7 +455,7 @@ fn in_group(user: &impl UnixUser, group: &impl UnixGroup) -> bool {
 fn match_group(group: &impl UnixGroup) -> impl Fn(&Identifier) -> bool + '_ {
     move |id| match id {
         Identifier::ID(num) => group.as_gid() == GroupId::new(*num),
-        Identifier::Name(name) => group.try_as_name().map_or(false, |s| name == s),
+        Identifier::Name(name) => group.try_as_name().is_some_and(|s| name == s),
     }
 }
 


### PR DESCRIPTION
Clippy doesn't complain about the `map_or(true, ..)`, but that's because `is_none_or` is sadly not available yet (for our MSRV)