### PR TITLE
Set some implicit options for og-sudo to match sudo-rs defaults

### DIFF
--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd/command_specified_not_by_absolute_path_is_rejected.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd/command_specified_not_by_absolute_path_is_rejected.snap
@@ -1,8 +1,8 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd.rs
 expression: stderr
 ---
-/etc/sudoers:1:19: expected a fully-qualified path name
+/etc/sudoers:2:19: expected a fully-qualified path name
 ALL ALL=(ALL:ALL) true
                   ^~~~
 root is not in the sudoers file.

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/command_specified_not_by_absolute_path_is_rejected.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/command_specified_not_by_absolute_path_is_rejected.snap
@@ -1,8 +1,8 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
 expression: stderr
 ---
-/etc/sudoers:1:24: expected a fully-qualified path name
+/etc/sudoers:2:24: expected a fully-qualified path name
 Cmnd_Alias CMDSGROUP = true, /usr/bin/ls
                        ^~~~
 Sorry, user root is not allowed to execute '/usr/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list.rs
@@ -83,7 +83,10 @@ fn lists_privileges_for_root() -> Result<()> {
     assert!(output.status().success());
 
     let expected = format!(
-        "User root may run the following commands on {hostname}:
+        "Matching Defaults entries for root on {hostname}:
+    !fqdn, !lecture, !mailerpath
+
+User root may run the following commands on {hostname}:
     (ALL : ALL) NOPASSWD: ALL"
     );
     let actual = output.stdout()?;
@@ -102,7 +105,10 @@ fn works_with_long_form_list_flag() -> Result<()> {
     assert!(output.status().success());
 
     let expected = format!(
-        "User root may run the following commands on {hostname}:
+        "Matching Defaults entries for root on {hostname}:
+    !fqdn, !lecture, !mailerpath
+
+User root may run the following commands on {hostname}:
     (ALL : ALL) NOPASSWD: ALL"
     );
     let actual = output.stdout()?;
@@ -128,7 +134,10 @@ fn lists_privileges_for_invoking_user_on_current_host() -> Result<()> {
     assert!(output.stderr().is_empty());
 
     let expected = format!(
-        "User {USERNAME} may run the following commands on {hostname}:
+        "Matching Defaults entries for {USERNAME} on {hostname}:
+    !fqdn, !lecture, !mailerpath
+
+User {USERNAME} may run the following commands on {hostname}:
     (ALL : ALL) NOPASSWD: ALL"
     );
     let actual = output.stdout()?;
@@ -153,7 +162,10 @@ fn works_with_uppercase_u_flag() -> Result<()> {
     assert!(output.stderr().is_empty());
 
     let expected = format!(
-        "User {USERNAME} may run the following commands on {hostname}:
+        "Matching Defaults entries for {USERNAME} on {hostname}:
+    !fqdn, !lecture, !mailerpath
+
+User {USERNAME} may run the following commands on {hostname}:
     (ALL : ALL) NOPASSWD: ALL"
     );
     let actual = output.stdout()?;
@@ -247,7 +259,10 @@ fn when_specified_multiple_times_uses_longer_format() -> Result<()> {
     assert!(output.stderr().is_empty());
 
     let expected = format!(
-        "User {USERNAME} may run the following commands on {hostname}:\n
+        "Matching Defaults entries for {USERNAME} on {hostname}:
+    !fqdn, !lecture, !mailerpath
+
+User {USERNAME} may run the following commands on {hostname}:\n
 Sudoers entry:
     RunAsUsers: ALL
     RunAsGroups: ALL
@@ -348,7 +363,10 @@ fn uppercase_u_flag_matches_on_first_component_of_sudoers_rules() -> Result<()> 
     assert!(output.stderr().is_empty());
 
     let expected = format!(
-        "User {USERNAME} may run the following commands on {hostname}:
+        "Matching Defaults entries for {USERNAME} on {hostname}:
+    !fqdn, !lecture, !mailerpath
+
+User {USERNAME} may run the following commands on {hostname}:
     ({USERNAME} : ALL) {BIN_TRUE}
     (ALL : ALL) {BIN_PWD}
     (root : ALL) {BIN_FALSE}

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/command_alias.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/command_alias.snap
@@ -2,6 +2,9 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/command_arguments.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/command_arguments.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 148
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/complex_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/complex_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 121
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_across_runas_groups.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 218
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_any.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_any.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 176
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_multiple_commands.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_multiple_commands.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 190
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_multiple_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_multiple_runas_groups.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 197
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_nopasswd.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 292
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_not_in_first_position.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_not_in_first_position.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 211
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_override.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 204
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_override_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_override_across_runas_groups.snap
@@ -2,6 +2,9 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_path.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_path.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 183
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/empty_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/empty_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 37
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/group_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 100
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/implicit_runas_group.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/implicit_runas_group.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 169
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_commands.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_commands.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 155
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_group_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 114
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_lines.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_lines.snap
@@ -2,6 +2,9 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_runas_groups.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 162
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_users_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_users_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 93
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/negated_command_alias.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/negated_command_alias.snap
@@ -2,6 +2,9 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/no_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/no_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 30
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 241
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_across_runas_groups.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 269
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_on_same_command.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_on_same_command.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 262
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_override.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 255
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_override_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_override_across_runas_groups.snap
@@ -2,6 +2,9 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/not_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/not_group_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 107
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/not_user_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/not_user_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 86
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 234
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd_across_runas_groups.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 276
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd_nopasswd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd_nopasswd_override.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 248
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_group_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_group_id_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 65
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_group_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 58
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_id_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 51
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_non_unix_group_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_non_unix_group_id_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 79
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_non_unix_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_non_unix_group_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 72
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_runas.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 44
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
 
 Sudoers entry:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/command_alias.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/command_alias.snap
@@ -2,5 +2,8 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) <BIN_LS>, /usr/bin/true, /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/command_arguments.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/command_arguments.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 90
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) /usr/bin/true a b c, /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/complex_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/complex_runas.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 83
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (!ferris, root : crabs, !root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_across_runas_groups.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 160
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) CWD=* /usr/bin/true
     (ferris) CWD=* /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_any.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_any.snap
@@ -1,7 +1,9 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 76
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) CWD=* /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_multiple_commands.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_multiple_commands.snap
@@ -1,7 +1,9 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 90
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) CWD=* /usr/bin/true, /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_multiple_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_multiple_runas_groups.snap
@@ -1,8 +1,10 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 97
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) CWD=* /usr/bin/true
     (ferris) CWD=* /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_nopasswd.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 235
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) CWD=* NOPASSWD: /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_not_in_first_position.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_not_in_first_position.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 146
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) /usr/bin/true, CWD=* /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_override.snap
@@ -1,7 +1,9 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 104
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) CWD=* /usr/bin/true, CWD=/home /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_override_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_override_across_runas_groups.snap
@@ -2,6 +2,9 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) CWD=* /usr/bin/true
     (ferris) CWD=* /usr/bin/false, CWD=/home <BIN_LS>

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_path.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_path.snap
@@ -1,7 +1,9 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 83
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) CWD=/home /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/empty_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/empty_runas.snap
@@ -1,7 +1,9 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 34
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/group_runas.snap
@@ -1,7 +1,9 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 48
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root : crabs) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/implicit_runas_group.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/implicit_runas_group.snap
@@ -1,8 +1,10 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 69
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) /usr/bin/true
     (ferris) /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_commands.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_commands.snap
@@ -1,7 +1,9 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 55
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) /usr/bin/true, /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_group_runas.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 76
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root : crabs, root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_lines.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_lines.snap
@@ -2,6 +2,9 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) /usr/bin/true, /usr/bin/false
     (root) <BIN_LS>

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_runas_groups.snap
@@ -1,8 +1,10 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 62
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) /usr/bin/true
     (ferris) /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_users_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_users_runas.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 55
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (ferris, root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/negated_command_alias.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/negated_command_alias.snap
@@ -2,5 +2,8 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) <BIN_LS>, !/usr/bin/true, /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/no_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/no_runas.snap
@@ -1,7 +1,9 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 27
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 160
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) NOPASSWD: /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_across_runas_groups.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 189
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) NOPASSWD: /usr/bin/true
     (ferris) NOPASSWD: /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_on_same_command.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_on_same_command.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 181
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) PASSWD: /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_override.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 174
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) NOPASSWD: /usr/bin/true, PASSWD: /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_override_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_override_across_runas_groups.snap
@@ -2,6 +2,9 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) NOPASSWD: /usr/bin/true
     (ferris) NOPASSWD: /usr/bin/false, PASSWD: <BIN_LS>

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/not_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/not_group_runas.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 69
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root : !crabs) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/not_user_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/not_user_runas.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 48
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (!ferris) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 153
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) PASSWD: /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd_across_runas_groups.snap
@@ -1,8 +1,10 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 196
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) PASSWD: /usr/bin/true
     (ferris) PASSWD: /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd_nopasswd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd_nopasswd_override.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 167
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (root) PASSWD: /usr/bin/true, NOPASSWD: /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_group_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_group_id_runas.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 62
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (%#0) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_group_runas.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 55
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (%root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_id_runas.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 48
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (#0) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_non_unix_group_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_non_unix_group_id_runas.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 76
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (%:#0) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_non_unix_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_non_unix_group_runas.snap
@@ -1,7 +1,9 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 69
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (%:root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_runas.snap
@@ -1,7 +1,9 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 41
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
+Matching Defaults entries for root on container:
+    !fqdn, !lecture, !mailerpath
+
 User root may run the following commands on container:
     (ferris) ALL

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -1,7 +1,8 @@
 use std::{thread, time::Duration};
 
 use sudo_test::{
-    helpers::assert_ls_output, Command, Env, TextFile, ETC_DIR, ETC_SUDOERS, ROOT_GROUP,
+    helpers::assert_ls_output, Command, Env, EnvNoImplicit, TextFile, ETC_DIR, ETC_SUDOERS,
+    ROOT_GROUP,
 };
 
 use crate::{Result, PANIC_EXIT_CODE, SUDOERS_ALL_ALL_NOPASSWD};
@@ -207,7 +208,7 @@ echo '{expected}' >> $2"#
 #[test]
 fn stderr_message_when_file_is_not_modified() -> Result<()> {
     let expected = SUDOERS_ALL_ALL_NOPASSWD;
-    let env = Env(expected)
+    let env = EnvNoImplicit(expected)
         .file(
             DEFAULT_EDITOR,
             TextFile(
@@ -244,7 +245,7 @@ fn stderr_message_when_file_is_not_modified() -> Result<()> {
 #[test]
 fn does_not_save_the_file_if_there_are_syntax_errors() -> Result<()> {
     let expected = SUDOERS_ALL_ALL_NOPASSWD;
-    let env = Env(expected)
+    let env = EnvNoImplicit(expected)
         .file(
             DEFAULT_EDITOR,
             TextFile(
@@ -274,7 +275,7 @@ echo 'this is fine' > $2",
 #[test]
 fn editor_exits_with_a_nonzero_code() -> Result<()> {
     let expected = SUDOERS_ALL_ALL_NOPASSWD;
-    let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
+    let env = EnvNoImplicit(SUDOERS_ALL_ALL_NOPASSWD)
         .file(
             DEFAULT_EDITOR,
             TextFile(
@@ -332,7 +333,7 @@ rm $2",
 #[test]
 fn temp_file_initial_contents() -> Result<()> {
     let expected = SUDOERS_ALL_ALL_NOPASSWD;
-    let env = Env(expected)
+    let env = EnvNoImplicit(expected)
         .file(
             DEFAULT_EDITOR,
             TextFile(format!(

--- a/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/flag_file.rs
@@ -1,3 +1,4 @@
+use sudo_test::EnvNoImplicit;
 use sudo_test::{helpers::assert_ls_output, Command, Env, TextFile, ROOT_GROUP};
 
 use crate::{
@@ -133,7 +134,7 @@ echo '{expected}' > $2"#
 fn etc_sudoers_is_not_modified() -> Result<()> {
     let expected = SUDOERS_ALL_ALL_NOPASSWD;
     let unexpected = SUDOERS_ROOT_ALL;
-    let env = Env(expected)
+    let env = EnvNoImplicit(expected)
         .file(
             DEFAULT_EDITOR,
             TextFile(format!(

--- a/test-framework/sudo-compliance-tests/src/visudo/what_now_prompt.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/what_now_prompt.rs
@@ -1,4 +1,4 @@
-use sudo_test::{Command, Env, TextFile};
+use sudo_test::{Command, Env, EnvNoImplicit, TextFile};
 
 use crate::{
     visudo::{CHMOD_EXEC, DEFAULT_EDITOR, ETC_SUDOERS, LOGS_PATH},
@@ -54,7 +54,7 @@ fn on_e_re_edits() -> Result<()> {
 #[test]
 fn on_x_closes_without_saving_changes() -> Result<()> {
     let expected = SUDOERS_ALL_ALL_NOPASSWD;
-    let env = Env(expected)
+    let env = EnvNoImplicit(expected)
         .file(DEFAULT_EDITOR, TextFile(editor()).chmod(CHMOD_EXEC))
         .build()?;
 

--- a/test-framework/sudo-test/src/docker.rs
+++ b/test-framework/sudo-test/src/docker.rs
@@ -60,14 +60,10 @@ impl Container {
     pub fn new_with_hostname(image: &str, hostname: Option<&str>) -> Result<Self> {
         let mut docker_run = docker_command();
         docker_run.args(["run", "--detach"]);
-        if !crate::is_original_sudo() {
-            // Disable network access for the containers. This removes the overhead of setting up a
-            // new network namespace and associated firewall rule adjustments. We still need to keep
-            // network access enabled for original sudo however as it needs to be able to resolve
-            // it's own hostname to a fully qualified domain name, which isn't possible with
-            // `--net=none`.
-            docker_run.arg("--net=none");
-        }
+        // Disable network access for the containers. This removes the overhead
+        // of setting up a new network namespace and associated firewall rule
+        // adjustments.
+        docker_run.arg("--net=none");
         if let Some(hostname) = hostname {
             docker_run.args(["--hostname", hostname]);
         }

--- a/test-framework/sudo-test/src/lib.rs
+++ b/test-framework/sudo-test/src/lib.rs
@@ -70,6 +70,24 @@ pub struct Env {
 #[allow(non_snake_case)]
 pub fn Env(sudoers: impl Into<TextFile>) -> EnvBuilder {
     let mut builder = EnvBuilder::default();
+    let mut sudoers: TextFile = sudoers.into();
+    // Change a couple of flags to match the defaults of sudo-rs. In particular some sudo builds
+    // have lecture or mailing enabled by default while sudo-rs doesn't implement those at all.
+    // And fqdn breaks when --net=none passed to docker and sudo-rs doesn't implement it either.
+    sudoers.contents.insert_str(0, "Defaults !fqdn, !lecture, !mailerpath\n");
+    builder.file(ETC_SUDOERS, sudoers);
+    if cfg!(target_os = "freebsd") {
+        // Many tests expect the users group to exist, but FreeBSD doesn't actually use it.
+        builder.group("users");
+    }
+    builder
+}
+
+/// creates a new test environment builder that contains the specified `/etc/sudoers` file without
+/// any implicit extra rules
+#[allow(non_snake_case)]
+pub fn EnvNoImplicit(sudoers: impl Into<TextFile>) -> EnvBuilder {
+    let mut builder = EnvBuilder::default();
     builder.file(ETC_SUDOERS, sudoers);
     if cfg!(target_os = "freebsd") {
         // Many tests expect the users group to exist, but FreeBSD doesn't actually use it.


### PR DESCRIPTION
This fixes 7 compliance tests with original sudo on FreeBSD. And it allows the compliance test for original sudo to work with `--net=none`.