### PR TITLE
Couple of misc refactors

### DIFF
--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -198,7 +198,7 @@ impl Sudo {
 ///            | #<numerical id>
 /// ```
 impl Parse for Identifier {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         if accept_if(|c| c == '#', stream).is_some() {
             let Digits(guid) = expect_nonterminal(stream)?;
             make(Identifier::ID(guid))
@@ -219,7 +219,7 @@ impl Many for Identifier {}
 /// This computes the correct negation with multiple exclamation marks in the parsing stage so we
 /// are not bothered by it later.
 impl<T: Parse + UserFriendly> Parse for Qualified<T> {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         if is_syntax('!', stream)? {
             let mut neg = true;
             while is_syntax('!', stream)? {
@@ -245,7 +245,7 @@ impl<T: Many> Many for Qualified<T> {
 
 /// Helper function for parsing `Meta<T>` things where T is not a token
 fn parse_meta<T: Parse>(
-    stream: &mut impl CharStream,
+    stream: &mut CharStream,
     embed: impl FnOnce(SudoString) -> T,
 ) -> Parsed<Meta<T>> {
     if let Some(meta) = try_nonterminal(stream)? {
@@ -261,7 +261,7 @@ fn parse_meta<T: Parse>(
 
 /// Since Identifier is not a token, add the parser for `Meta<Identifier>`
 impl Parse for Meta<Identifier> {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         parse_meta(stream, Identifier::Name)
     }
 }
@@ -274,7 +274,7 @@ impl Parse for Meta<Identifier> {
 ///          | +netgroup
 /// ```
 impl Parse for UserSpecifier {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         let userspec = if accept_if(|c| c == '%', stream).is_some() {
             let ctor = if accept_if(|c| c == ':', stream).is_some() {
                 UserSpecifier::NonunixGroup
@@ -299,7 +299,7 @@ impl Many for UserSpecifier {}
 
 /// UserSpecifier is not a token, implement the parser for `Meta<UserSpecifier>`
 impl Parse for Meta<UserSpecifier> {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         parse_meta(stream, |name| UserSpecifier::User(Identifier::Name(name)))
     }
 }
@@ -309,7 +309,7 @@ impl Parse for Meta<UserSpecifier> {
 /// runas = "(", userlist, (":", grouplist?)?, ")"
 /// ```
 impl Parse for RunAs {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         try_syntax('(', stream)?;
         let users = try_nonterminal(stream).unwrap_or_default();
         let groups = maybe(try_syntax(':', stream).and_then(|_| try_nonterminal(stream)))?
@@ -336,7 +336,7 @@ pub type Modifier = Box<dyn Fn(&mut Tag)>;
 // to be more general, we impl Parse for Meta<Tag> so a future tag like "AFOOBAR" can be added with no problem
 
 impl Parse for MetaOrTag {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         use Meta::*;
 
         let start_pos = stream.get_pos();
@@ -402,7 +402,7 @@ impl Parse for MetaOrTag {
 /// commandspec = [tag modifiers]*, command
 /// ```
 impl Parse for CommandSpec {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         let mut tags = vec![];
         while let Some(MetaOrTag(keyword)) = try_nonterminal(stream)? {
             use Qualified::Allow;
@@ -450,7 +450,7 @@ impl Parse for CommandSpec {
 /// (host,runas,commandspec) = hostlist, "=", [runas?, commandspec]+
 /// ```
 impl Parse for (SpecList<Hostname>, Vec<(Option<RunAs>, CommandSpec)>) {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         let hosts = try_nonterminal(stream)?;
         expect_syntax('=', stream)?;
         let runas_cmds = expect_nonterminal(stream)?;
@@ -471,7 +471,7 @@ impl Many for (SpecList<Hostname>, Vec<(Option<RunAs>, CommandSpec)>) {
 /// (runas,commandspec) = runas?, commandspec
 /// ```
 impl Parse for (Option<RunAs>, CommandSpec) {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         let runas: Option<RunAs> = try_nonterminal(stream)?;
         let cmd = if runas.is_some() {
             expect_nonterminal(stream)?
@@ -502,7 +502,7 @@ impl Parse for Sudo {
     //   "User_Alias, user machine = command"
     // but accept:
     //   "user, User_Alias machine = command"; this does the same
-    fn parse(stream: &mut impl CharStream) -> Parsed<Sudo> {
+    fn parse(stream: &mut CharStream) -> Parsed<Sudo> {
         if accept_if(|c| c == '@', stream).is_some() {
             return parse_include(stream);
         }
@@ -553,8 +553,8 @@ impl Parse for Sudo {
 }
 
 /// Parse the include/include dir part that comes after the '#' or '@' prefix symbol
-fn parse_include(stream: &mut impl CharStream) -> Parsed<Sudo> {
-    fn get_path(stream: &mut impl CharStream) -> Parsed<String> {
+fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
+    fn get_path(stream: &mut CharStream) -> Parsed<String> {
         if accept_if(|c| c == '"', stream).is_some() {
             let QuotedInclude(path) = expect_nonterminal(stream)?;
             expect_syntax('"', stream)?;
@@ -593,7 +593,7 @@ where
     T: UserFriendly,
     Meta<T>: Parse + Many,
 {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         let begin_pos = stream.get_pos();
         let AliasName(name) = try_nonterminal(stream)?;
         if name == "ALL" {
@@ -615,7 +615,7 @@ impl<T> Many for Def<T> {
 
 fn get_directive(
     perhaps_keyword: &Spec<UserSpecifier>,
-    stream: &mut impl CharStream,
+    stream: &mut CharStream,
 ) -> Parsed<Directive> {
     use super::ast::Directive::*;
     use super::ast::Meta::*;
@@ -640,7 +640,7 @@ fn get_directive(
 /// parameter = name [+-]?= ...
 /// ```
 impl Parse for defaults::SettingsModifier {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         let id_pos = stream.get_pos();
 
         // Parse multiple entries enclosed in quotes (for list-like Defaults-settings)

--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -11,7 +11,7 @@
 //!
 //! ```ignore
 //! impl<T: Parse> Parse for LinkedList<T> {
-//!     fn parse(stream: &mut impl CharStream) -> Parsed<LinkedList<T>> {
+//!     fn parse(stream: &mut CharStream) -> Parsed<LinkedList<T>> {
 //!         let x = try_nonterminal(stream)?;
 //!         let mut tail = if is_syntax('+', stream)? {
 //!             expect_nonterminal(stream)?
@@ -77,7 +77,7 @@ pub use super::char_stream::CharStream;
 /// advanced beyond the accepted part of the input. i.e. if some input is consumed the method
 /// *MUST* be producing a `Some` value.
 pub trait Parse {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self>
+    fn parse(stream: &mut CharStream) -> Parsed<Self>
     where
         Self: Sized;
 }
@@ -87,7 +87,7 @@ pub trait Parse {
 /// (this can facilitate an easy switch to a different method of stream representation in the future).
 /// Unlike `Parse` implementations this *does not* consume trailing whitespace.
 /// This function is modelled on `next_if` on `std::Peekable`.
-pub fn accept_if(predicate: impl Fn(char) -> bool, stream: &mut impl CharStream) -> Option<char> {
+pub fn accept_if(predicate: impl Fn(char) -> bool, stream: &mut CharStream) -> Option<char> {
     let c = stream.peek()?;
     if predicate(c) {
         stream.advance();
@@ -110,7 +110,7 @@ struct Comment;
 /// Accept zero or more whitespace characters; fails if the whitespace is not "leading" to something
 /// (which can be used to detect end-of-input).
 impl Parse for LeadingWhitespace {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         let eat_space = |stream: &mut _| accept_if(|c| "\t ".contains(c), stream);
         while eat_space(stream).is_some() {}
 
@@ -126,7 +126,7 @@ impl Parse for LeadingWhitespace {
 /// always succeeds (unless some serious error occurs). This parser also accepts comments,
 /// since those can form part of trailing white space.
 impl Parse for TrailingWhitespace {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         loop {
             let _ = LeadingWhitespace::parse(stream); // don't propagate any errors
 
@@ -147,27 +147,27 @@ impl Parse for TrailingWhitespace {
 
 /// Parses a comment
 impl Parse for Comment {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         accept_if(|c| c == '#', stream).ok_or(Status::Reject)?;
         while accept_if(|c| c != '\n', stream).is_some() {}
         make(Comment {})
     }
 }
 
-fn skip_trailing_whitespace(stream: &mut impl CharStream) -> Parsed<()> {
+fn skip_trailing_whitespace(stream: &mut CharStream) -> Parsed<()> {
     TrailingWhitespace::parse(stream)?;
     make(())
 }
 
 /// Adheres to the contract of the [Parse] trait, accepts one character and consumes trailing whitespace.
-pub fn try_syntax(syntax: char, stream: &mut impl CharStream) -> Parsed<()> {
+pub fn try_syntax(syntax: char, stream: &mut CharStream) -> Parsed<()> {
     accept_if(|c| c == syntax, stream).ok_or(Status::Reject)?;
     skip_trailing_whitespace(stream)?;
     make(())
 }
 
 /// Similar to [try_syntax], but aborts parsing if the expected character is not found.
-pub fn expect_syntax(syntax: char, stream: &mut impl CharStream) -> Parsed<()> {
+pub fn expect_syntax(syntax: char, stream: &mut CharStream) -> Parsed<()> {
     if try_syntax(syntax, stream).is_err() {
         let str = if let Some(c) = stream.peek() {
             c.to_string()
@@ -180,14 +180,14 @@ pub fn expect_syntax(syntax: char, stream: &mut impl CharStream) -> Parsed<()> {
 }
 
 /// Convenience function: usually try_syntax is called as a test criterion; if this returns true, the input was consumed.
-pub fn is_syntax(syntax: char, stream: &mut impl CharStream) -> Parsed<bool> {
+pub fn is_syntax(syntax: char, stream: &mut CharStream) -> Parsed<bool> {
     let result = maybe(try_syntax(syntax, stream))?;
     make(result.is_some())
 }
 
 /// Interface for working with types that implement the [Parse] trait; this allows parsing to use
 /// type inference. Use this instead of calling [Parse::parse] directly.
-pub fn try_nonterminal<T: Parse>(stream: &mut impl CharStream) -> Parsed<T> {
+pub fn try_nonterminal<T: Parse>(stream: &mut CharStream) -> Parsed<T> {
     let result = T::parse(stream)?;
     skip_trailing_whitespace(stream)?;
     make(result)
@@ -197,7 +197,7 @@ pub fn try_nonterminal<T: Parse>(stream: &mut impl CharStream) -> Parsed<T> {
 /// the given type or gives a fatal parse error if this did not succeed.
 use super::ast_names::UserFriendly;
 
-pub fn expect_nonterminal<T: Parse + UserFriendly>(stream: &mut impl CharStream) -> Parsed<T> {
+pub fn expect_nonterminal<T: Parse + UserFriendly>(stream: &mut CharStream) -> Parsed<T> {
     let begin_pos = stream.get_pos();
     match try_nonterminal(stream) {
         Err(Status::Reject) => {
@@ -228,10 +228,10 @@ pub trait Token: Sized {
 
 /// Implementation of the [Parse] trait for anything that implements [Token]
 impl<T: Token> Parse for T {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         fn accept_escaped<T: Token>(
             pred: fn(char) -> bool,
-            stream: &mut impl CharStream,
+            stream: &mut CharStream,
         ) -> Parsed<char> {
             const ESCAPE: char = '\\';
             if T::ALLOW_ESCAPE && accept_if(|c| c == ESCAPE, stream).is_some() {
@@ -267,7 +267,7 @@ impl<T: Token> Parse for T {
 
 /// Parser for `Option<T>` (this can be used to make the code more readable)
 impl<T: Parse> Parse for Option<T> {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         maybe(T::parse(stream))
     }
 }
@@ -276,7 +276,7 @@ impl<T: Parse> Parse for Option<T> {
 pub(super) fn parse_list<T: Parse + UserFriendly>(
     sep_by: char,
     max: usize,
-    stream: &mut impl CharStream,
+    stream: &mut CharStream,
 ) -> Parsed<Vec<T>> {
     let mut elems = Vec::new();
     elems.push(try_nonterminal(stream)?);
@@ -300,13 +300,13 @@ pub trait Many {
 /// Generic implementation for parsing multiple items of a type `T` that implements the [Parse] and
 /// [Many] traits.
 impl<T: Parse + Many + UserFriendly> Parse for Vec<T> {
-    fn parse(stream: &mut impl CharStream) -> Parsed<Self> {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
         parse_list(T::SEP, T::LIMIT, stream)
     }
 }
 
 /// Entry point utility function; parse a `Vec<T>` but with fatal error recovery per line
-pub fn parse_lines<T, Stream: CharStream>(stream: &mut Stream) -> Vec<Parsed<T>>
+pub fn parse_lines<T>(stream: &mut CharStream) -> Vec<Parsed<T>>
 where
     T: Parse + UserFriendly,
 {
@@ -329,7 +329,7 @@ where
                 } else {
                     "garbage at end of line"
                 };
-                let error = |stream: &mut Stream| unrecoverable!(stream, "{msg}");
+                let error = |stream: &mut CharStream| unrecoverable!(stream, "{msg}");
                 result.push(error(stream));
             }
             while accept_if(|c| c != '\n', stream).is_some() {}
@@ -340,10 +340,7 @@ where
 }
 
 #[cfg(test)]
-use super::char_stream::PeekableWithPos;
-
-#[cfg(test)]
-fn expect_complete<T: Parse>(stream: &mut impl CharStream) -> Parsed<T> {
+fn expect_complete<T: Parse>(stream: &mut CharStream) -> Parsed<T> {
     let result = expect_nonterminal(stream)?;
     if let Some(c) = stream.peek() {
         unrecoverable!(stream, "garbage at end of line: {c}")
@@ -355,7 +352,7 @@ fn expect_complete<T: Parse>(stream: &mut impl CharStream) -> Parsed<T> {
 /// AST constructors by hand.
 #[cfg(test)]
 pub fn parse_string<T: Parse>(text: &str) -> Parsed<T> {
-    expect_complete(&mut PeekableWithPos::new(text.chars()))
+    expect_complete(&mut CharStream::new(text.chars()))
 }
 
 #[cfg(test)]
@@ -391,7 +388,7 @@ mod test {
 
     #[test]
     fn lines_test() {
-        let input = |text: &str| parse_lines(&mut PeekableWithPos::new(text.chars()));
+        let input = |text: &str| parse_lines(&mut CharStream::new(text.chars()));
 
         let s = |text: &str| Ok(text.to_string());
         assert_eq!(input("hello\nworld\n"), vec![s("hello"), s("world")]);

--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -340,6 +340,9 @@ where
 }
 
 #[cfg(test)]
+use super::char_stream::PeekableWithPos;
+
+#[cfg(test)]
 fn expect_complete<T: Parse>(stream: &mut impl CharStream) -> Parsed<T> {
     let result = expect_nonterminal(stream)?;
     if let Some(c) = stream.peek() {
@@ -352,7 +355,7 @@ fn expect_complete<T: Parse>(stream: &mut impl CharStream) -> Parsed<T> {
 /// AST constructors by hand.
 #[cfg(test)]
 pub fn parse_string<T: Parse>(text: &str) -> Parsed<T> {
-    expect_complete(&mut text.chars().peekable())
+    expect_complete(&mut PeekableWithPos::new(text.chars()))
 }
 
 #[cfg(test)]
@@ -388,7 +391,7 @@ mod test {
 
     #[test]
     fn lines_test() {
-        let input = |text: &str| parse_lines(&mut text.chars().peekable());
+        let input = |text: &str| parse_lines(&mut PeekableWithPos::new(text.chars()));
 
         let s = |text: &str| Ok(text.to_string());
         assert_eq!(input("hello\nworld\n"), vec![s("hello"), s("world")]);

--- a/src/sudoers/char_stream.rs
+++ b/src/sudoers/char_stream.rs
@@ -4,14 +4,14 @@ pub trait CharStream {
     fn get_pos(&self) -> (usize, usize);
 }
 
-pub struct PeekableWithPos<Iter: Iterator> {
-    iter: std::iter::Peekable<Iter>,
+pub struct PeekableWithPos<'a> {
+    iter: std::iter::Peekable<std::str::Chars<'a>>,
     line: usize,
     col: usize,
 }
 
-impl<Iter: Iterator<Item = char>> PeekableWithPos<Iter> {
-    pub fn new(src: Iter) -> Self {
+impl<'a> PeekableWithPos<'a> {
+    pub fn new(src: std::str::Chars<'a>) -> Self {
         PeekableWithPos {
             iter: src.peekable(),
             line: 1,
@@ -20,7 +20,7 @@ impl<Iter: Iterator<Item = char>> PeekableWithPos<Iter> {
     }
 }
 
-impl<Iter: Iterator<Item = char>> CharStream for PeekableWithPos<Iter> {
+impl CharStream for PeekableWithPos<'_> {
     fn advance(&mut self) {
         match self.iter.next() {
             Some('\n') => {
@@ -42,27 +42,12 @@ impl<Iter: Iterator<Item = char>> CharStream for PeekableWithPos<Iter> {
 }
 
 #[cfg(test)]
-impl<Iter: Iterator<Item = char>> CharStream for std::iter::Peekable<Iter> {
-    fn advance(&mut self) {
-        self.next();
-    }
-
-    fn peek(&mut self) -> Option<char> {
-        self.peek().cloned()
-    }
-
-    fn get_pos(&self) -> (usize, usize) {
-        (0, 0)
-    }
-}
-
-#[cfg(test)]
 mod test {
     use super::*;
 
     #[test]
     fn test_iter() {
-        let mut stream = PeekableWithPos::<std::str::Chars>::new("12\n3\n".chars());
+        let mut stream = PeekableWithPos::new("12\n3\n".chars());
         assert_eq!(stream.peek(), Some('1'));
         stream.advance();
         assert_eq!(stream.peek(), Some('2'));

--- a/src/sudoers/char_stream.rs
+++ b/src/sudoers/char_stream.rs
@@ -1,18 +1,12 @@
-pub trait CharStream {
-    fn advance(&mut self);
-    fn peek(&mut self) -> Option<char>;
-    fn get_pos(&self) -> (usize, usize);
-}
-
-pub struct PeekableWithPos<'a> {
+pub struct CharStream<'a> {
     iter: std::iter::Peekable<std::str::Chars<'a>>,
     line: usize,
     col: usize,
 }
 
-impl<'a> PeekableWithPos<'a> {
+impl<'a> CharStream<'a> {
     pub fn new(src: std::str::Chars<'a>) -> Self {
-        PeekableWithPos {
+        CharStream {
             iter: src.peekable(),
             line: 1,
             col: 1,
@@ -20,8 +14,8 @@ impl<'a> PeekableWithPos<'a> {
     }
 }
 
-impl CharStream for PeekableWithPos<'_> {
-    fn advance(&mut self) {
+impl CharStream<'_> {
+    pub fn advance(&mut self) {
         match self.iter.next() {
             Some('\n') => {
                 self.line += 1;
@@ -32,11 +26,11 @@ impl CharStream for PeekableWithPos<'_> {
         }
     }
 
-    fn peek(&mut self) -> Option<char> {
+    pub fn peek(&mut self) -> Option<char> {
         self.iter.peek().cloned()
     }
 
-    fn get_pos(&self) -> (usize, usize) {
+    pub fn get_pos(&self) -> (usize, usize) {
         (self.line, self.col)
     }
 }
@@ -47,7 +41,7 @@ mod test {
 
     #[test]
     fn test_iter() {
-        let mut stream = PeekableWithPos::new("12\n3\n".chars());
+        let mut stream = CharStream::new("12\n3\n".chars());
         assert_eq!(stream.peek(), Some('1'));
         stream.advance();
         assert_eq!(stream.peek(), Some('2'));

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -268,7 +268,7 @@ fn read_sudoers<R: io::Read>(mut reader: R) -> io::Result<Vec<basic_parser::Pars
 
     use basic_parser::parse_lines;
     use char_stream::*;
-    Ok(parse_lines(&mut PeekableWithPos::new(buffer.chars())))
+    Ok(parse_lines(&mut CharStream::new(buffer.chars())))
 }
 
 fn open_sudoers(path: &Path) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -386,11 +386,11 @@ where
 {
     let mut result = None;
     for item in items {
-        let (judgement, who) = match item.clone().to_inner() {
+        let (judgement, who) = match item.as_inner() {
             Qualified::Forbid(x) => (false, x),
             Qualified::Allow(x) => (true, x),
         };
-        let info = || item.to_info();
+        let info = || item.into_info();
         match who {
             Meta::All => result = judgement.then(info),
             Meta::Only(ident) if matches(ident) => result = judgement.then(info),
@@ -413,8 +413,8 @@ where
 trait WithInfo: Clone {
     type Item;
     type Info;
-    fn to_inner(self) -> Self::Item;
-    fn to_info(self) -> Self::Info;
+    fn as_inner(&self) -> Self::Item;
+    fn into_info(self) -> Self::Info;
 }
 
 /// A specific interface for `Spec<T>` --- we can't make a generic one;
@@ -422,20 +422,20 @@ trait WithInfo: Clone {
 impl<'a, T> WithInfo for &'a Spec<T> {
     type Item = &'a Spec<T>;
     type Info = ();
-    fn to_inner(self) -> &'a Spec<T> {
+    fn as_inner(&self) -> &'a Spec<T> {
         self
     }
-    fn to_info(self) {}
+    fn into_info(self) {}
 }
 
 /// A commandspec can be "tagged"
 impl<'a> WithInfo for (Tag, &'a Spec<Command>) {
     type Item = &'a Spec<Command>;
     type Info = Tag;
-    fn to_inner(self) -> &'a Spec<Command> {
+    fn as_inner(&self) -> &'a Spec<Command> {
         self.1
     }
-    fn to_info(self) -> Tag {
+    fn into_info(self) -> Tag {
         self.0
     }
 }

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -1,6 +1,7 @@
 use std::ffi::CStr;
 
 use super::ast;
+use super::char_stream::PeekableWithPos;
 use super::*;
 use basic_parser::{parse_eval, parse_lines, parse_string};
 
@@ -57,7 +58,7 @@ macro_rules! request {
 
 macro_rules! sudoer {
     ($($e:expr),*) => {
-        parse_lines(&mut [$($e),*, ""].join("\n").chars().peekable())
+        parse_lines(&mut PeekableWithPos::new([$($e),*, ""].join("\n").chars()))
             .into_iter()
             .map(|x| Ok::<_,basic_parser::Status>(x.unwrap()))
     }
@@ -71,7 +72,7 @@ fn parse_line(s: &str) -> Sudo {
 
 /// Returns `None` if a syntax error is encountered
 fn try_parse_line(s: &str) -> Option<Sudo> {
-    parse_lines(&mut [s, ""].join("").chars().peekable())
+    parse_lines(&mut PeekableWithPos::new([s, ""].join("").chars()))
         .into_iter()
         .next()?
         .ok()

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -1,7 +1,7 @@
 use std::ffi::CStr;
 
 use super::ast;
-use super::char_stream::PeekableWithPos;
+use super::char_stream::CharStream;
 use super::*;
 use basic_parser::{parse_eval, parse_lines, parse_string};
 
@@ -58,7 +58,7 @@ macro_rules! request {
 
 macro_rules! sudoer {
     ($($e:expr),*) => {
-        parse_lines(&mut PeekableWithPos::new([$($e),*, ""].join("\n").chars()))
+        parse_lines(&mut CharStream::new([$($e),*, ""].join("\n").chars()))
             .into_iter()
             .map(|x| Ok::<_,basic_parser::Status>(x.unwrap()))
     }
@@ -72,7 +72,7 @@ fn parse_line(s: &str) -> Sudo {
 
 /// Returns `None` if a syntax error is encountered
 fn try_parse_line(s: &str) -> Option<Sudo> {
-    parse_lines(&mut PeekableWithPos::new([s, ""].join("").chars()))
+    parse_lines(&mut CharStream::new([s, ""].join("").chars()))
         .into_iter()
         .next()?
         .ok()

--- a/src/system/interface.rs
+++ b/src/system/interface.rs
@@ -111,21 +111,11 @@ impl FromStr for UserId {
 /// (which we may decide over time), as well as to make explicit what functionality a user-representation must have; this
 /// interface is not set in stone and "easy" to change.
 pub trait UnixUser {
-    fn has_name(&self, _name: &str) -> bool {
-        false
-    }
-    fn has_uid(&self, _uid: UserId) -> bool {
-        false
-    }
-    fn is_root(&self) -> bool {
-        false
-    }
-    fn in_group_by_name(&self, _name: &CStr) -> bool {
-        false
-    }
-    fn in_group_by_gid(&self, _gid: GroupId) -> bool {
-        false
-    }
+    fn has_name(&self, _name: &str) -> bool;
+    fn has_uid(&self, _uid: UserId) -> bool;
+    fn is_root(&self) -> bool;
+    fn in_group_by_name(&self, _name: &CStr) -> bool;
+    fn in_group_by_gid(&self, _gid: GroupId) -> bool;
 }
 
 pub trait UnixGroup {
@@ -204,15 +194,5 @@ mod test {
             GroupId::new(0),
         );
         test_group(group(cstr!("daemon")), "daemon", GroupId::new(1));
-    }
-
-    impl UnixUser for () {}
-
-    #[test]
-    fn test_default() {
-        assert!(!().has_name("root"));
-        assert!(!().has_uid(UserId::ROOT));
-        assert!(!().is_root());
-        assert!(!().in_group_by_name(cstr!("root")));
     }
 }


### PR DESCRIPTION
* In the sudoers parser use a single fixed stream type. There is no need to be generic over the type of character stream.
* Remove defaults for the UnixUser trait methods. They aren't used outside of a test anyway.