### PR TITLE
Refactor pipeline

### DIFF
--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -62,7 +62,7 @@ pub enum LaunchType {
 impl Context {
     pub fn build_from_options(
         sudo_options: OptionsForContext,
-        path: String,
+        secure_path: Option<&str>,
     ) -> Result<Context, Error> {
         let hostname = Hostname::resolve();
         let current_user = CurrentUser::resolve()?;
@@ -76,7 +76,18 @@ impl Context {
                 // FIXME `Default` is being used as `Option::None`
                 Default::default()
             }
-            _ => CommandAndArguments::build_from_args(shell, sudo_options.positional_args, &path),
+            _ => {
+                let system_path;
+
+                let path = if let Some(path) = secure_path {
+                    path
+                } else {
+                    system_path = std::env::var("PATH").unwrap_or_default();
+                    system_path.as_ref()
+                };
+
+                CommandAndArguments::build_from_args(shell, sudo_options.positional_args, path)
+            }
         };
 
         Ok(Context {
@@ -117,7 +128,7 @@ mod tests {
             .unwrap();
         let path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
         let (ctx_opts, _pipe_opts) = options.into();
-        let context = Context::build_from_options(ctx_opts, path.to_string()).unwrap();
+        let context = Context::build_from_options(ctx_opts, Some(path)).unwrap();
 
         let mut target_environment = HashMap::new();
         target_environment.insert("SUDO_USER".to_string(), context.current_user.name.clone());

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -102,7 +102,6 @@ impl Context {
 mod tests {
     use crate::{
         sudo::SudoAction,
-        sudoers::AuthenticatingUser,
         system::{interface::UserId, Hostname},
     };
     use std::collections::HashMap;

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -1,6 +1,5 @@
 use crate::common::resolve::AuthUser;
 use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2};
-use crate::sudoers::AuthenticatingUser;
 use crate::system::{Group, Hostname, Process, User};
 
 use super::resolve::CurrentUser;
@@ -64,14 +63,9 @@ impl Context {
     pub fn build_from_options(
         sudo_options: OptionsForContext,
         path: String,
-        auth_user: AuthenticatingUser,
     ) -> Result<Context, Error> {
         let hostname = Hostname::resolve();
         let current_user = CurrentUser::resolve()?;
-        let auth_user = match auth_user {
-            AuthenticatingUser::InvokingUser => AuthUser::from_current_user(current_user.clone()),
-            AuthenticatingUser::Root => AuthUser::resolve_root_for_rootpw()?,
-        };
         let (target_user, target_group) =
             resolve_target_user_and_group(&sudo_options.user, &sudo_options.group, &current_user)?;
         let (launch, shell) = resolve_launch_and_shell(&sudo_options, &current_user, &target_user);
@@ -89,7 +83,6 @@ impl Context {
             hostname,
             command,
             current_user,
-            auth_user,
             target_user,
             target_group,
             use_session_records: !sudo_options.reset_timestamp,
@@ -98,6 +91,7 @@ impl Context {
             stdin: sudo_options.stdin,
             non_interactive: sudo_options.non_interactive,
             process: Process::new(),
+            auth_user: AuthUser::resolve_root_for_rootpw()?,
             use_pty: true,
             password_feedback: false,
         })
@@ -124,12 +118,7 @@ mod tests {
             .unwrap();
         let path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
         let (ctx_opts, _pipe_opts) = options.into();
-        let context = Context::build_from_options(
-            ctx_opts,
-            path.to_string(),
-            AuthenticatingUser::InvokingUser,
-        )
-        .unwrap();
+        let context = Context::build_from_options(ctx_opts, path.to_string()).unwrap();
 
         let mut target_environment = HashMap::new();
         target_environment.insert("SUDO_USER".to_string(), context.current_user.name.clone());

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -1,4 +1,3 @@
-use crate::common::resolve::AuthUser;
 use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2};
 use crate::system::{Group, Hostname, Process, User};
 
@@ -44,7 +43,6 @@ pub struct Context {
     // system
     pub hostname: Hostname,
     pub current_user: CurrentUser,
-    pub auth_user: AuthUser,
     pub process: Process,
     // policy
     pub use_pty: bool,
@@ -102,7 +100,6 @@ impl Context {
             stdin: sudo_options.stdin,
             non_interactive: sudo_options.non_interactive,
             process: Process::new(),
-            auth_user: AuthUser::resolve_root_for_rootpw()?,
             use_pty: true,
             password_feedback: false,
         })

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -162,14 +162,21 @@ fn test_environment_variable_filtering() {
             .try_into_run()
             .ok()
             .unwrap();
-        let settings = crate::sudoers::Judgement::default();
+        let settings = crate::defaults::Settings::default();
         let context = create_test_context(&options);
         let resulting_env = get_target_environment(
             initial_env.clone(),
             HashMap::new(),
             Vec::new(),
             &context,
-            &settings,
+            &crate::sudoers::Restrictions {
+                env_keep: settings.env_keep(),
+                env_check: settings.env_check(),
+                path: settings.secure_path(),
+                use_pty: true,
+                chdir: crate::sudoers::DirChange::Strict(None),
+                trust_environment: false,
+            },
         )
         .unwrap();
 

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -1,4 +1,4 @@
-use crate::common::resolve::{AuthUser, CurrentUser};
+use crate::common::resolve::CurrentUser;
 use crate::common::{CommandAndArguments, Context};
 use crate::sudo::{
     cli::{SudoAction, SudoRunOptions},
@@ -94,8 +94,6 @@ fn create_test_context(sudo_options: &SudoRunOptions) -> Context {
         groups: vec![],
     });
 
-    let auth_user = AuthUser::from_current_user(current_user.clone());
-
     let current_group = Group {
         gid: GroupId::new(1000),
         name: Some("test".to_string()),
@@ -121,7 +119,6 @@ fn create_test_context(sudo_options: &SudoRunOptions) -> Context {
         hostname: Hostname::fake("test-ubuntu"),
         command,
         current_user: current_user.clone(),
-        auth_user,
         target_user: if sudo_options.user.as_deref() == Some("test") {
             current_user.into()
         } else {

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -24,7 +24,8 @@ impl<Auth: super::AuthPlugin> Pipeline<Auth> {
         let original_command = cmd_opts.positional_args.first().cloned();
 
         let sudoers = super::read_sudoers()?;
-        let mut context = super::build_context(cmd_opts.into(), &sudoers)?;
+
+        let mut context = Context::build_from_options(cmd_opts.into(), sudoers.secure_path())?;
 
         if original_command.is_some() && !context.command.resolved {
             return Err(Error::CommandNotFound(context.command.command));

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -4,7 +4,7 @@ use crate::{
     common::{Context, Error},
     pam::CLIConverser,
     sudo::{cli::SudoListOptions, pam::PamAuthenticator, SudoersPolicy},
-    sudoers::{Authorization, ListRequest, Policy, Request, Sudoers},
+    sudoers::{Authorization, ListRequest, Request, Sudoers},
     system::{interface::UserId, User},
 };
 

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -1,10 +1,10 @@
 use std::{borrow::Cow, ops::ControlFlow, path::Path};
 
 use crate::{
-    common::{resolve::AuthUser, Context, Error},
+    common::{Context, Error},
     pam::CLIConverser,
     sudo::{cli::SudoListOptions, pam::PamAuthenticator, SudoersPolicy},
-    sudoers::{AuthenticatingUser, Authorization, ListRequest, Policy, Request, Sudoers},
+    sudoers::{Authorization, ListRequest, Policy, Request, Sudoers},
     system::{interface::UserId, User},
 };
 
@@ -81,13 +81,7 @@ impl Pipeline<SudoersPolicy, PamAuthenticator<CLIConverser>> {
         let judgement =
             sudoers.check_list_permission(&*context.current_user, &context.hostname, list_request);
         match judgement.authorization() {
-            Authorization::Allowed(auth) => {
-                context.auth_user = match auth.credential {
-                    AuthenticatingUser::InvokingUser => {
-                        AuthUser::from_current_user(context.current_user.clone())
-                    }
-                    AuthenticatingUser::Root => AuthUser::resolve_root_for_rootpw()?,
-                };
+            Authorization::Allowed(auth, _) => {
                 self.auth_and_update_record_file(context, &auth)?;
                 Ok(ControlFlow::Continue(()))
             }

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -54,6 +54,7 @@ pub struct ListRequest<'a, User: UnixUser, Group: UnixGroup> {
 }
 
 #[derive(Default)]
+#[cfg_attr(test, derive(Clone))]
 pub struct Judgement {
     flags: Option<Tag>,
     settings: Settings,
@@ -62,7 +63,8 @@ pub struct Judgement {
 mod policy;
 
 pub use policy::{
-    AuthenticatingUser, Authorization, AuthorizationAllowed, DirChange, Policy, PreJudgementPolicy,
+    AuthenticatingUser, Authentication, Authorization, DirChange, Policy, PreJudgementPolicy,
+    Restrictions,
 };
 
 pub use self::entry::Entry;

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -62,10 +62,7 @@ pub struct Judgement {
 
 mod policy;
 
-pub use policy::{
-    AuthenticatingUser, Authentication, Authorization, DirChange, Policy, PreJudgementPolicy,
-    Restrictions,
-};
+pub use policy::{AuthenticatingUser, Authentication, Authorization, DirChange, Restrictions};
 
 pub use self::entry::Entry;
 

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -11,39 +11,54 @@ use crate::system::time::Duration;
 use std::collections::HashSet;
 
 pub trait Policy {
-    fn authorization(&self) -> Authorization {
+    fn authorization(&self) -> Authorization<Restrictions> {
         Authorization::Forbidden
     }
-
-    fn chdir(&self) -> DirChange {
-        DirChange::Strict(None)
-    }
-
-    fn env_keep(&self) -> &HashSet<String>;
-    fn env_check(&self) -> &HashSet<String>;
-
-    fn secure_path(&self) -> Option<String>;
-
-    fn use_pty(&self) -> bool;
-    fn pwfeedback(&self) -> bool;
 }
 
 #[must_use]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[repr(u32)]
-pub enum Authorization {
-    Allowed(AuthorizationAllowed) = HARDENED_ENUM_VALUE_0,
+pub enum Authorization<T = ()> {
+    Allowed(Authentication, T) = HARDENED_ENUM_VALUE_0,
     Forbidden = HARDENED_ENUM_VALUE_1,
 }
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[must_use]
-pub struct AuthorizationAllowed {
+pub struct Authentication {
     pub must_authenticate: bool,
+    pub credential: AuthenticatingUser,
     pub allowed_attempts: u16,
     pub prior_validity: Duration,
+    pub pwfeedback: bool,
+}
+
+impl super::Settings {
+    fn to_auth(&self) -> Authentication {
+        Authentication {
+            must_authenticate: true,
+            allowed_attempts: self.passwd_tries().try_into().unwrap(),
+            prior_validity: Duration::seconds(self.timestamp_timeout()),
+            pwfeedback: self.pwfeedback(),
+            credential: if self.rootpw() {
+                AuthenticatingUser::Root
+            } else {
+                AuthenticatingUser::InvokingUser
+            },
+        }
+    }
+}
+
+#[must_use]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct Restrictions<'a> {
+    pub use_pty: bool,
     pub trust_environment: bool,
-    pub credential: AuthenticatingUser,
+    pub env_keep: &'a HashSet<String>,
+    pub env_check: &'a HashSet<String>,
+    pub chdir: DirChange<'a>,
+    pub path: Option<&'a str>,
 }
 
 #[must_use]
@@ -62,76 +77,43 @@ pub enum AuthenticatingUser {
 }
 
 impl Policy for Judgement {
-    fn authorization(&self) -> Authorization {
+    fn authorization(&self) -> Authorization<Restrictions> {
         if let Some(tag) = &self.flags {
-            let allowed_attempts = self.settings.passwd_tries().try_into().unwrap();
-            let valid_seconds = self.settings.timestamp_timeout();
-            Authorization::Allowed(AuthorizationAllowed {
-                must_authenticate: tag.needs_passwd(),
-                trust_environment: tag.allows_setenv(),
-                allowed_attempts,
-                prior_validity: Duration::seconds(valid_seconds),
-                credential: if self.settings.rootpw() {
-                    AuthenticatingUser::Root
-                } else {
-                    AuthenticatingUser::InvokingUser
+            Authorization::Allowed(
+                Authentication {
+                    must_authenticate: tag.needs_passwd(),
+                    ..self.settings.to_auth()
                 },
-            })
+                Restrictions {
+                    use_pty: self.settings.use_pty(),
+                    trust_environment: tag.allows_setenv(),
+                    env_keep: self.settings.env_keep(),
+                    env_check: self.settings.env_check(),
+                    chdir: match tag.cwd.as_ref() {
+                        None => DirChange::Strict(None),
+                        Some(super::ChDir::Any) => DirChange::Any,
+                        Some(super::ChDir::Path(path)) => DirChange::Strict(Some(path)),
+                    },
+                    path: self.settings.secure_path(),
+                },
+            )
         } else {
             Authorization::Forbidden
         }
-    }
-
-    fn env_keep(&self) -> &HashSet<String> {
-        self.settings.env_keep()
-    }
-
-    fn env_check(&self) -> &HashSet<String> {
-        self.settings.env_check()
-    }
-
-    fn chdir(&self) -> DirChange {
-        match self.flags.as_ref().expect("not authorized").cwd.as_ref() {
-            None => DirChange::Strict(None),
-            Some(super::ChDir::Any) => DirChange::Any,
-            Some(super::ChDir::Path(path)) => DirChange::Strict(Some(path)),
-        }
-    }
-
-    fn secure_path(&self) -> Option<String> {
-        self.settings.secure_path().as_ref().map(|s| s.to_string())
-    }
-
-    fn use_pty(&self) -> bool {
-        self.settings.use_pty()
-    }
-
-    fn pwfeedback(&self) -> bool {
-        self.settings.pwfeedback()
     }
 }
 
 pub trait PreJudgementPolicy {
     fn secure_path(&self) -> Option<String>;
-    fn validate_authorization(&self) -> Authorization;
+    fn validate_authorization(&self) -> Authorization<()>;
 }
 
 impl PreJudgementPolicy for Sudoers {
     fn secure_path(&self) -> Option<String> {
         self.settings.secure_path().as_ref().map(|s| s.to_string())
     }
-    fn validate_authorization(&self) -> Authorization {
-        Authorization::Allowed(AuthorizationAllowed {
-            must_authenticate: true,
-            trust_environment: false,
-            allowed_attempts: self.settings.passwd_tries().try_into().unwrap(),
-            prior_validity: Duration::seconds(self.settings.timestamp_timeout()),
-            credential: if self.settings.rootpw() {
-                AuthenticatingUser::Root
-            } else {
-                AuthenticatingUser::InvokingUser
-            },
-        })
+    fn validate_authorization(&self) -> Authorization<()> {
+        Authorization::Allowed(self.settings.to_auth(), ())
     }
 }
 
@@ -151,33 +133,41 @@ mod test {
         }
     }
 
-    // TODO: refactor the tag-updates to be more readable
     #[test]
     fn authority_xlat_test() {
         let mut judge: Judgement = Default::default();
         assert_eq!(judge.authorization(), Authorization::Forbidden);
         judge.mod_flag(|tag| tag.authenticate = Authenticate::Passwd);
+        let Authorization::Allowed(auth, restrictions) = judge.authorization() else {
+            panic!();
+        };
         assert_eq!(
-            judge.authorization(),
-            Authorization::Allowed(AuthorizationAllowed {
+            auth,
+            Authentication {
                 must_authenticate: true,
-                trust_environment: false,
                 allowed_attempts: 3,
                 prior_validity: Duration::minutes(15),
                 credential: AuthenticatingUser::InvokingUser,
-            })
+                pwfeedback: false,
+            },
         );
+
+        let mut judge = judge.clone();
         judge.mod_flag(|tag| tag.authenticate = Authenticate::Nopasswd);
+        let Authorization::Allowed(auth, restrictions2) = judge.authorization() else {
+            panic!();
+        };
         assert_eq!(
-            judge.authorization(),
-            Authorization::Allowed(AuthorizationAllowed {
+            auth,
+            Authentication {
                 must_authenticate: false,
-                trust_environment: false,
                 allowed_attempts: 3,
                 prior_validity: Duration::minutes(15),
                 credential: AuthenticatingUser::InvokingUser,
-            })
+                pwfeedback: false,
+            },
         );
+        assert_eq!(restrictions, restrictions2);
     }
 
     #[test]
@@ -186,12 +176,18 @@ mod test {
             flags: Some(Tag::default()),
             ..Default::default()
         };
-        assert_eq!(judge.chdir(), DirChange::Strict(None));
+        fn chdir(judge: &mut Judgement) -> DirChange {
+            let Authorization::Allowed(_, ctl) = judge.authorization() else {
+                panic!()
+            };
+            ctl.chdir
+        }
+        assert_eq!(chdir(&mut judge), DirChange::Strict(None));
         judge.mod_flag(|tag| tag.cwd = Some(ChDir::Any));
-        assert_eq!(judge.chdir(), DirChange::Any);
+        assert_eq!(chdir(&mut judge), DirChange::Any);
         judge.mod_flag(|tag| tag.cwd = Some(ChDir::Path("/usr".into())));
-        assert_eq!(judge.chdir(), (DirChange::Strict(Some(&"/usr".into()))));
+        assert_eq!(chdir(&mut judge), (DirChange::Strict(Some(&"/usr".into()))));
         judge.mod_flag(|tag| tag.cwd = Some(ChDir::Path("/bin".into())));
-        assert_eq!(judge.chdir(), (DirChange::Strict(Some(&"/bin".into()))));
+        assert_eq!(chdir(&mut judge), (DirChange::Strict(Some(&"/bin".into()))));
     }
 }

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -10,12 +10,6 @@ use crate::system::time::Duration;
 /// than just the sudoers file.
 use std::collections::HashSet;
 
-pub trait Policy {
-    fn authorization(&self) -> Authorization<Restrictions> {
-        Authorization::Forbidden
-    }
-}
-
 #[must_use]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[repr(u32)]
@@ -76,8 +70,8 @@ pub enum AuthenticatingUser {
     Root = HARDENED_ENUM_VALUE_1,
 }
 
-impl Policy for Judgement {
-    fn authorization(&self) -> Authorization<Restrictions> {
+impl Judgement {
+    pub fn authorization(&self) -> Authorization<Restrictions> {
         if let Some(tag) = &self.flags {
             Authorization::Allowed(
                 Authentication {
@@ -103,16 +97,12 @@ impl Policy for Judgement {
     }
 }
 
-pub trait PreJudgementPolicy {
-    fn secure_path(&self) -> Option<String>;
-    fn validate_authorization(&self) -> Authorization<()>;
-}
-
-impl PreJudgementPolicy for Sudoers {
-    fn secure_path(&self) -> Option<String> {
-        self.settings.secure_path().as_ref().map(|s| s.to_string())
+impl Sudoers {
+    pub fn secure_path(&self) -> Option<&str> {
+        self.settings.secure_path()
     }
-    fn validate_authorization(&self) -> Authorization<()> {
+
+    pub fn validate_authorization(&self) -> Authorization<()> {
         Authorization::Allowed(self.settings.to_auth(), ())
     }
 }


### PR DESCRIPTION
There was some anticipated generalisation (and thus abstraction) of the pipeline which never materialized (e.g. using the same pipeline for sudo, su and a potential doas-rs), since su and sudo were too different.

This got in the way of implementing #61 and also made the code sometimes hard to change

In the future, as sudo-rs gets more functionality, introducing this generalization isn't a bad idea, but then it's better to do that based on the actual needs instead of the pre-planned needs of the implementations.

*Take no thought for the morrow: for the morrow shall take thought for the things of itself.*

Preparatory part of #61 