### PR TITLE
Update all snapshots

### DIFF
--- a/test-framework/sudo-compliance-tests/src/snapshots/flag_group/unassigned_group_id_is_rejected-2.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/flag_group/unassigned_group_id_is_rejected-2.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/flag_group.rs
+source: sudo-compliance-tests/src/sudo/flag_group.rs
 expression: stderr
 ---
 sudo: unknown group #1234

--- a/test-framework/sudo-compliance-tests/src/snapshots/flag_group/unassigned_group_id_is_rejected.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/flag_group/unassigned_group_id_is_rejected.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/flag_group.rs
+source: sudo-compliance-tests/src/sudo/flag_group.rs
 expression: stderr
 ---
 sudo: unknown group #1234

--- a/test-framework/sudo-compliance-tests/src/snapshots/flag_login/if_home_directory_does_not_exist_executes_program_without_changing_the_working_directory-2.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/flag_login/if_home_directory_does_not_exist_executes_program_without_changing_the_working_directory-2.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/flag_login.rs
-expression: output.stderr()
+source: sudo-compliance-tests/src/sudo/flag_login.rs
+expression: stderr
 ---
 sudo: unable to change directory to /home/ferris: No such file or directory

--- a/test-framework/sudo-compliance-tests/src/snapshots/flag_login/if_home_directory_does_not_exist_executes_program_without_changing_the_working_directory.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/flag_login/if_home_directory_does_not_exist_executes_program_without_changing_the_working_directory.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/flag_login.rs
-expression: output.stderr()
+source: sudo-compliance-tests/src/sudo/flag_login.rs
+expression: stderr
 ---
 sudo: unable to change directory to /home/ferris: No such file or directory

--- a/test-framework/sudo-compliance-tests/src/snapshots/flag_login/insufficient_permissions_to_execute_shell.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/flag_login/insufficient_permissions_to_execute_shell.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/flag_login.rs
-expression: output.stderr()
+source: sudo-compliance-tests/src/sudo/flag_login.rs
+expression: stderr
 ---
 sudo: unable to execute /tmp/my-shell: Permission denied

--- a/test-framework/sudo-compliance-tests/src/snapshots/flag_login/shell_does_not_exist.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/flag_login/shell_does_not_exist.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/flag_login.rs
-expression: output.stderr()
+source: sudo-compliance-tests/src/sudo/flag_login.rs
+expression: stderr
 ---
 sudo: /tmp/my-shell: command not found

--- a/test-framework/sudo-compliance-tests/src/snapshots/flag_shell/shell_does_not_exist.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/flag_shell/shell_does_not_exist.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/flag_shell.rs
-expression: output.stderr()
+source: sudo-compliance-tests/src/sudo/flag_shell.rs
+expression: stderr
 ---
 sudo: /root/my-shell: command not found

--- a/test-framework/sudo-compliance-tests/src/snapshots/flag_shell/shell_is_not_executable.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/flag_shell/shell_is_not_executable.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/flag_shell.rs
-expression: output.stderr()
+source: sudo-compliance-tests/src/sudo/flag_shell.rs
+expression: stderr
 ---
 sudo: /root/my-shell: command not found

--- a/test-framework/sudo-compliance-tests/src/snapshots/flag_user/unassigned_user_id_is_rejected-2.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/flag_user/unassigned_user_id_is_rejected-2.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/flag_user.rs
+source: sudo-compliance-tests/src/sudo/flag_user.rs
 expression: stderr
 ---
 sudo: unknown user #1234

--- a/test-framework/sudo-compliance-tests/src/snapshots/flag_user/unassigned_user_id_is_rejected.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/flag_user/unassigned_user_id_is_rejected.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/flag_user.rs
+source: sudo-compliance-tests/src/sudo/flag_user.rs
 expression: stderr
 ---
 sudo: unknown user #1234

--- a/test-framework/sudo-compliance-tests/src/snapshots/misc/user_not_in_passwd_database_cannot_use_sudo.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/misc/user_not_in_passwd_database_cannot_use_sudo.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/misc.rs
-expression: output.stderr()
+source: sudo-compliance-tests/src/sudo/misc.rs
+expression: stderr
 ---
 sudo: you do not exist in the passwd database

--- a/test-framework/sudo-compliance-tests/src/snapshots/passwd/explicit_passwd_overrides_nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/passwd/explicit_passwd_overrides_nopasswd.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/passwd.rs
+source: sudo-compliance-tests/src/sudo/passwd.rs
 expression: stderr
 ---
 [sudo] password for ferris: 

--- a/test-framework/sudo-compliance-tests/src/snapshots/path_search/when_path_is_unset_does_not_search_in_default_path_set_for_command_execution.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/path_search/when_path_is_unset_does_not_search_in_default_path_set_for_command_execution.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/path_search.rs
-expression: output.stderr()
+source: sudo-compliance-tests/src/sudo/path_search.rs
+expression: stderr
 ---
 sudo: my-script: command not found

--- a/test-framework/sudo-compliance-tests/src/snapshots/secure_path/dash_dash_before_flag_is_an_error.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/secure_path/dash_dash_before_flag_is_an_error.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/cli.rs
-expression: output.stderr()
+source: sudo-compliance-tests/src/sudo/cli.rs
+expression: stderr
 ---
 sudo: -u: command not found

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd/command_specified_not_by_absolute_path_is_rejected.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd/command_specified_not_by_absolute_path_is_rejected.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd.rs
 expression: stderr
 ---
 /etc/sudoers:1:19: expected a fully-qualified path name

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd/given_specific_command_then_other_command_is_not_allowed.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd/given_specific_command_then_other_command_is_not_allowed.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd.rs
-expression: output.stderr()
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd.rs
+expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/another_negation_combination.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/another_negation_combination.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/combined_cmnd_aliases.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/combined_cmnd_aliases.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/command_alias_negation.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/command_alias_negation.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/command_specified_not_by_absolute_path_is_rejected.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/command_specified_not_by_absolute_path_is_rejected.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
 expression: stderr
 ---
 /etc/sudoers:1:24: expected a fully-qualified path name

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/negation_not_order_sensitive.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/negation_not_order_sensitive.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/ls' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/one_more_negation_combination.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/one_more_negation_combination.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/runas_override-2.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/runas_override-2.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/runas_override.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/runas_override.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/ls' as ferris on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/tripple_negation_combination-2.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/tripple_negation_combination-2.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/ls' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/tripple_negation_combination.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/tripple_negation_combination.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/unlisted_cmnd_fails.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/cmnd_alias/unlisted_cmnd_fails.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/cmnd_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/host_alias/combined_host_aliases.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/host_alias/combined_host_aliases.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/host_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
 expression: stderr
 ---
 root is not allowed to run sudo on mail.

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/host_alias/host_alias_negation.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/host_alias/host_alias_negation.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/host_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
 expression: stderr
 ---
 root is not allowed to run sudo on mail.

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/host_alias/negation_not_order_sensitive.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/host_alias/negation_not_order_sensitive.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/host_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
 expression: stderr
 ---
 root is not allowed to run sudo on mail.

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/host_alias/unlisted_host_fails.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/host_alias/unlisted_host_fails.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/host_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
 expression: stderr
 ---
 root is not allowed to run sudo on not_listed.

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/host_list/given_specific_hostname_then_sudo_from_different_hostname_is_rejected.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/host_list/given_specific_hostname_then_sudo_from_different_hostname_is_rejected.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/host_list.rs
+source: sudo-compliance-tests/src/sudo/sudoers/host_list.rs
 expression: stderr
 ---
 root is not allowed to run sudo on container.

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/host_list/negation_rejects.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/host_list/negation_rejects.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/host_list.rs
+source: sudo-compliance-tests/src/sudo/sudoers/host_list.rs
 expression: stderr
 ---
 root is not allowed to run sudo on container.

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/supplemental_group_matching.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/supplemental_group_matching.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/run_as.rs
+source: sudo-compliance-tests/src/sudo/sudoers/run_as.rs
 expression: stderr
 ---
 sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_empty_then_as_someone_else_is_not_allowed.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_empty_then_as_someone_else_is_not_allowed.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/run_as.rs
+source: sudo-compliance-tests/src/sudo/sudoers/run_as.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as ferris on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_only_group_is_specified_then_as_some_user_is_not_allowed-2.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_only_group_is_specified_then_as_some_user_is_not_allowed-2.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/run_as.rs
+source: sudo-compliance-tests/src/sudo/sudoers/run_as.rs
 expression: stderr
 ---
 Sorry, user ferris is not allowed to execute '/usr/bin/true' as ghost on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_only_group_is_specified_then_as_some_user_is_not_allowed.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_only_group_is_specified_then_as_some_user_is_not_allowed.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/run_as.rs
+source: sudo-compliance-tests/src/sudo/sudoers/run_as.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as ghost on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_specific_group_then_as_a_different_group_is_not_allowed-2.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_specific_group_then_as_a_different_group_is_not_allowed-2.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/run_as.rs
+source: sudo-compliance-tests/src/sudo/sudoers/run_as.rs
 expression: stderr
 ---
 Sorry, user ferris is not allowed to execute '/usr/bin/true' as ferris:ghosts on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_specific_group_then_as_a_different_group_is_not_allowed.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_specific_group_then_as_a_different_group_is_not_allowed.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/run_as.rs
+source: sudo-compliance-tests/src/sudo/sudoers/run_as.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as root:ghosts on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_specific_user_then_as_a_different_user_is_not_allowed.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_specific_user_then_as_a_different_user_is_not_allowed.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/run_as.rs
+source: sudo-compliance-tests/src/sudo/sudoers/run_as.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as ghost on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_specific_user_then_as_self_is_not_allowed.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/run_as/when_specific_user_then_as_self_is_not_allowed.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/run_as.rs
+source: sudo-compliance-tests/src/sudo/sudoers/run_as.rs
 expression: stderr
 ---
 Sorry, user root is not allowed to execute '/usr/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/negation_on_user.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/negation_on_user.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/runas_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
 expression: stderr
 ---
 [sudo] password for ferris: Sorry, user ferris is not allowed to execute '/usr/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/runas_alias_negation.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/runas_alias_negation.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/runas_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
 expression: stderr
 ---
 [sudo] password for ferris: Sorry, user ferris is not allowed to execute '/usr/bin/true' as root on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/when_only_groupname_is_given_user_arg_fails.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/when_only_groupname_is_given_user_arg_fails.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/runas_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
 expression: stderr
 ---
 [sudo] password for ferris: Sorry, user ferris is not allowed to execute '/usr/bin/true' as otheruser on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/when_only_username_is_given_group_arg_fails.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/when_only_username_is_given_group_arg_fails.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/runas_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
 expression: stderr
 ---
 [sudo] password for ferris: Sorry, user ferris is not allowed to execute '/usr/bin/true' as ferris:rustaceans on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/when_specific_user_then_as_a_different_user_is_not_allowed.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/runas_alias/when_specific_user_then_as_a_different_user_is_not_allowed.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/runas_alias.rs
+source: sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
 expression: stderr
 ---
 [sudo] password for ferris: Sorry, user ferris is not allowed to execute '/usr/bin/true' as ghost on [host].

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/secure_path/if_set_it_does_not_search_in_original_user_path.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/secure_path/if_set_it_does_not_search_in_original_user_path.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/secure_path.rs
-expression: output.stderr()
+source: sudo-compliance-tests/src/sudo/sudoers/secure_path.rs
+expression: stderr
 ---
 sudo: true: command not found

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/user_list/negated_subgroup.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/user_list/negated_subgroup.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/user_list.rs
+source: sudo-compliance-tests/src/sudo/sudoers/user_list.rs
 expression: output.stderr()
 ---
 ferris is not in the sudoers file.

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/user_list/negated_supergroup-2.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/user_list/negated_supergroup-2.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/user_list.rs
+source: sudo-compliance-tests/src/sudo/sudoers/user_list.rs
 expression: stderr
 ---
 ghost is not in the sudoers file.

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/user_list/negated_supergroup.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/user_list/negated_supergroup.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/user_list.rs
+source: sudo-compliance-tests/src/sudo/sudoers/user_list.rs
 expression: stderr
 ---
 ferris is not in the sudoers file.

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/user_list/negation_excludes_group_members.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/user_list/negation_excludes_group_members.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/user_list.rs
+source: sudo-compliance-tests/src/sudo/sudoers/user_list.rs
 expression: stderr
 ---
 ghost is not in the sudoers file.

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/user_list/no_match.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/user_list/no_match.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/user_list.rs
+source: sudo-compliance-tests/src/sudo/sudoers/user_list.rs
 expression: stderr
 ---
 root is not in the sudoers file.

--- a/test-framework/sudo-compliance-tests/src/snapshots/sudoers/user_list/user_alias_works.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/sudoers/user_list/user_alias_works.snap
@@ -1,5 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudoers/user_list.rs
+source: sudo-compliance-tests/src/sudo/sudoers/user_list.rs
 expression: stderr
 ---
 ghost is not in the sudoers file.

--- a/test-framework/sudo-compliance-tests/src/snapshots/visudo/temporary_file_is_deleted_during_edition.snap
+++ b/test-framework/sudo-compliance-tests/src/snapshots/visudo/temporary_file_is_deleted_during_edition.snap
@@ -1,5 +1,5 @@
 ---
 source: sudo-compliance-tests/src/visudo.rs
-expression: stderr
+expression: "stderr.replace(ETC_DIR, \"<ETC_DIR>\")"
 ---
 visudo: unable to re-open temporary file (/tmp/[mkdtemp]/sudoers), <ETC_DIR>/sudoers unchanged: No such file or directory (os error 2)

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/command_arguments.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/command_arguments.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 148
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/complex_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/complex_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 121
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_across_runas_groups.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 218
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_any.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_any.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 176
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_multiple_commands.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_multiple_commands.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 190
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_multiple_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_multiple_runas_groups.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 197
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_nopasswd.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 292
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_not_in_first_position.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_not_in_first_position.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 211
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_override.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 204
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_path.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_path.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 183
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/empty_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/empty_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 37
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/group_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 100
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/implicit_runas_group.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/implicit_runas_group.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 169
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_commands.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_commands.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 155
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_group_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 114
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_runas_groups.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 162
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_users_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_users_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 93
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/no_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/no_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 30
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 241
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_across_runas_groups.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 269
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_on_same_command.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_on_same_command.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 262
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_override.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 255
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/not_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/not_group_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 107
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/not_user_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/not_user_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 86
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 234
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd_across_runas_groups.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 276
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd_nopasswd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd_nopasswd_override.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 248
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_group_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_group_id_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 65
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_group_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 58
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_id_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 51
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_non_unix_group_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_non_unix_group_id_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 79
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_non_unix_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_non_unix_group_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 72
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
-assertion_line: 44
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/command_arguments.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/command_arguments.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 90
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/complex_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/complex_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 83
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_across_runas_groups.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 160
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_any.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_any.snap
@@ -1,6 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 76
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_multiple_commands.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_multiple_commands.snap
@@ -1,6 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 90
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_multiple_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_multiple_runas_groups.snap
@@ -1,6 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 97
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_nopasswd.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 235
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_not_in_first_position.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_not_in_first_position.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 146
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_override.snap
@@ -1,6 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 104
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_path.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_path.snap
@@ -1,6 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 83
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/empty_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/empty_runas.snap
@@ -1,6 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 34
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/group_runas.snap
@@ -1,6 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 48
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/implicit_runas_group.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/implicit_runas_group.snap
@@ -1,6 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 69
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_commands.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_commands.snap
@@ -1,6 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 55
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_group_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 76
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_runas_groups.snap
@@ -1,6 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 62
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_users_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_users_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 55
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/no_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/no_runas.snap
@@ -1,6 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 27
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 160
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_across_runas_groups.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 189
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_on_same_command.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_on_same_command.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 181
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_override.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 174
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/not_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/not_group_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 69
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/not_user_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/not_user_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 48
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 153
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd_across_runas_groups.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 196
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd_nopasswd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd_nopasswd_override.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 167
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_group_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_group_id_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 62
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_group_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 55
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_id_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 48
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_non_unix_group_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_non_unix_group_id_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 76
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_non_unix_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_non_unix_group_runas.snap
@@ -1,6 +1,5 @@
 ---
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
-assertion_line: 69
 expression: stdout
 ---
 User root may run the following commands on container:

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_runas.snap
@@ -1,6 +1,5 @@
 ---
-source: sudo-compliance-tests/src/sudo/flag_list/short_format.rs
-assertion_line: 41
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
 User root may run the following commands on container:


### PR DESCRIPTION
This was done by removing all snapshots and letting insta recreate them. This has updated the metadata header of many snapshots. This will reduce diffs for other PR's that need to change a snapshot as previously this header change would be included in said PR.