### PR TITLE
Reenable test

### DIFF
--- a/test-framework/sudo-compliance-tests/src/sudo/pass_auth/tty.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pass_auth/tty.rs
@@ -5,12 +5,7 @@ use crate::{Result, PASSWORD, USERNAME};
 use super::MAX_PASSWORD_SIZE;
 
 #[test]
-#[ignore = "gh414"]
 fn correct_password() -> Result<()> {
-    if !sudo_test::is_original_sudo() {
-        return Err("FIXME flaky test".into());
-    }
-
     let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) ALL"))
         .user(User(USERNAME).password(PASSWORD))
         .build()?;


### PR DESCRIPTION
Locally I didn't observe any flaky behavior. If it turns out to still be flaky after all we can always disable it again.

Closes https://github.com/trifectatechfoundation/sudo-rs/issues/414