### PR TITLE
Cleaning up `--list`

### DIFF
--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -18,13 +18,6 @@ pub enum Qualified<T> {
 }
 
 impl<T> Qualified<T> {
-    pub fn as_ref(&self) -> Qualified<&T> {
-        match self {
-            Qualified::Allow(item) => Qualified::Allow(item),
-            Qualified::Forbid(item) => Qualified::Forbid(item),
-        }
-    }
-
     #[cfg(test)]
     pub fn as_allow(&self) -> Option<&T> {
         if let Self::Allow(v) = self {

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -25,13 +25,6 @@ impl<T> Qualified<T> {
         }
     }
 
-    pub fn negate(&self) -> Qualified<&T> {
-        match self {
-            Qualified::Allow(item) => Qualified::Forbid(item),
-            Qualified::Forbid(item) => Qualified::Allow(item),
-        }
-    }
-
     #[cfg(test)]
     pub fn as_allow(&self) -> Option<&T> {
         if let Self::Allow(v) = self {

--- a/src/sudoers/entry.rs
+++ b/src/sudoers/entry.rs
@@ -15,13 +15,13 @@ use super::{
 mod verbose;
 
 pub struct Entry<'a> {
-    run_as: &'a RunAs,
+    run_as: Option<&'a RunAs>,
     cmd_specs: Vec<(Tag, Qualified<&'a Meta<Command>>)>,
 }
 
 impl<'a> Entry<'a> {
     pub(super) fn new(
-        run_as: &'a RunAs,
+        run_as: Option<&'a RunAs>,
         cmd_specs: Vec<(Tag, Qualified<&'a Meta<Command>>)>,
     ) -> Self {
         debug_assert!(!cmd_specs.is_empty());
@@ -34,9 +34,16 @@ impl<'a> Entry<'a> {
     }
 }
 
+static EMPTY_RUNAS: RunAs = RunAs {
+    users: Vec::new(),
+    groups: Vec::new(),
+};
+
 impl fmt::Display for Entry<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self { run_as, cmd_specs } = self;
+
+        let run_as = run_as.unwrap_or(&EMPTY_RUNAS);
 
         f.write_str("    (")?;
         write_users(run_as, f)?;

--- a/src/sudoers/entry.rs
+++ b/src/sudoers/entry.rs
@@ -20,14 +20,14 @@ mod verbose;
 
 pub struct Entry<'a> {
     run_as: Option<&'a RunAs>,
-    cmd_specs: Vec<(Tag, Qualified<&'a Meta<Command>>)>,
+    cmd_specs: Vec<(Tag, &'a Qualified<Meta<Command>>)>,
     cmd_alias: &'a [Def<Command>],
 }
 
 impl<'a> Entry<'a> {
     pub(super) fn new(
         run_as: Option<&'a RunAs>,
-        cmd_specs: Vec<(Tag, Qualified<&'a Meta<Command>>)>,
+        cmd_specs: Vec<(Tag, &'a Qualified<Meta<Command>>)>,
         cmd_alias: &'a [Def<Command>],
     ) -> Self {
         debug_assert!(!cmd_specs.is_empty());
@@ -220,7 +220,7 @@ fn write_tag(f: &mut fmt::Formatter, tag: &Tag, last_tag: Option<&Tag>) -> fmt::
 
 fn write_spec(
     f: &mut fmt::Formatter,
-    spec: &Qualified<&Meta<Command>>,
+    spec: &Qualified<Meta<Command>>,
     alias_list: &[Def<Command>],
     mut sign: bool,
     separator: &str,
@@ -257,7 +257,7 @@ fn write_spec(
                     if !is_first_iteration {
                         f.write_str(separator)?;
                     }
-                    write_spec(f, &spec.as_ref(), alias_list, sign, separator)?;
+                    write_spec(f, spec, alias_list, sign, separator)?;
                     is_first_iteration = false;
                 }
             } else {

--- a/src/sudoers/entry.rs
+++ b/src/sudoers/entry.rs
@@ -14,7 +14,6 @@ use self::verbose::Verbose;
 use super::{
     ast::{Authenticate, Def, RunAs, Tag},
     tokens::Command,
-    VecOrd,
 };
 
 mod verbose;
@@ -22,14 +21,14 @@ mod verbose;
 pub struct Entry<'a> {
     run_as: Option<&'a RunAs>,
     cmd_specs: Vec<(Tag, Qualified<&'a Meta<Command>>)>,
-    cmd_alias: &'a VecOrd<Def<Command>>,
+    cmd_alias: &'a [Def<Command>],
 }
 
 impl<'a> Entry<'a> {
     pub(super) fn new(
         run_as: Option<&'a RunAs>,
         cmd_specs: Vec<(Tag, Qualified<&'a Meta<Command>>)>,
-        cmd_alias: &'a VecOrd<Def<Command>>,
+        cmd_alias: &'a [Def<Command>],
     ) -> Self {
         debug_assert!(!cmd_specs.is_empty());
 
@@ -222,7 +221,7 @@ fn write_tag(f: &mut fmt::Formatter, tag: &Tag, last_tag: Option<&Tag>) -> fmt::
 fn write_spec(
     f: &mut fmt::Formatter,
     spec: &Qualified<&Meta<Command>>,
-    alias_list: &VecOrd<Def<Command>>,
+    alias_list: &[Def<Command>],
     mut sign: bool,
     separator: &str,
 ) -> fmt::Result {
@@ -252,8 +251,7 @@ fn write_spec(
         }
         Meta::Alias(alias) => {
             // this will terminate, since AliasTable has been checked by sanitize_alias_table
-            if let Some(Def(_, spec_list)) = super::elems(alias_list).find(|Def(id, _)| id == alias)
-            {
+            if let Some(Def(_, spec_list)) = alias_list.iter().find(|Def(id, _)| id == alias) {
                 let mut is_first_iteration = true;
                 for spec in spec_list {
                     if !is_first_iteration {

--- a/src/sudoers/entry/verbose.rs
+++ b/src/sudoers/entry/verbose.rs
@@ -6,12 +6,14 @@ use crate::sudoers::{
 };
 
 use super::Entry;
+use super::EMPTY_RUNAS;
 
 pub struct Verbose<'a>(pub Entry<'a>);
 
 impl fmt::Display for Verbose<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self(Entry { run_as, cmd_specs }) = self;
+        let run_as = run_as.unwrap_or(&EMPTY_RUNAS);
 
         let mut last_tag = None;
         for (tag, cmd_spec) in cmd_specs {

--- a/src/sudoers/entry/verbose.rs
+++ b/src/sudoers/entry/verbose.rs
@@ -11,7 +11,11 @@ pub struct Verbose<'a>(pub Entry<'a>);
 
 impl fmt::Display for Verbose<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self(Entry { run_as, cmd_specs }) = self;
+        let Self(Entry {
+            run_as,
+            cmd_specs,
+            cmd_alias,
+        }) = self;
 
         let root_runas = super::root_runas();
         let run_as = run_as.unwrap_or(&root_runas);
@@ -31,7 +35,7 @@ impl fmt::Display for Verbose<'_> {
             last_tag = Some(tag);
 
             f.write_str("\n\t")?;
-            super::write_spec(f, cmd_spec)?;
+            super::write_spec(f, cmd_spec, cmd_alias, true, "\n\t")?;
         }
 
         Ok(())

--- a/src/sudoers/entry/verbose.rs
+++ b/src/sudoers/entry/verbose.rs
@@ -6,14 +6,15 @@ use crate::sudoers::{
 };
 
 use super::Entry;
-use super::EMPTY_RUNAS;
 
 pub struct Verbose<'a>(pub Entry<'a>);
 
 impl fmt::Display for Verbose<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self(Entry { run_as, cmd_specs }) = self;
-        let run_as = run_as.unwrap_or(&EMPTY_RUNAS);
+
+        let root_runas = super::root_runas();
+        let run_as = run_as.unwrap_or(&root_runas);
 
         let mut last_tag = None;
         for (tag, cmd_spec) in cmd_specs {

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -222,19 +222,19 @@ fn group_cmd_specs_per_runas<'a>(
         groups: Vec::new(),
     };
 
-    let mut runas = None;
+    let mut last_runas = None;
     let mut collected_specs = vec![];
 
-    for (new_runas, (tag, spec)) in cmnd_specs {
-        if let Some(new_runas) = new_runas {
+    for (runas, (tag, spec)) in cmnd_specs {
+        if runas.map(|r| r as *const _) != last_runas.map(|r| r as *const _) {
             if !collected_specs.is_empty() {
                 entries.push(Entry::new(
-                    runas.take().unwrap_or(&EMPTY_RUNAS),
+                    last_runas.take().unwrap_or(&EMPTY_RUNAS),
                     mem::take(&mut collected_specs),
                 ));
             }
 
-            runas = Some(new_runas);
+            last_runas = runas;
         }
 
         let (negate, meta) = match spec {
@@ -257,7 +257,10 @@ fn group_cmd_specs_per_runas<'a>(
     }
 
     if !collected_specs.is_empty() {
-        entries.push(Entry::new(runas.unwrap_or(&EMPTY_RUNAS), collected_specs));
+        entries.push(Entry::new(
+            last_runas.unwrap_or(&EMPTY_RUNAS),
+            collected_specs,
+        ));
     }
 }
 

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -182,7 +182,7 @@ impl Sudoers {
 
         let mut entries = vec![];
         for cmd_specs in user_specs {
-            group_cmd_specs_per_runas(cmd_specs, &mut entries, &self.aliases.cmnd);
+            group_cmd_specs_per_runas(cmd_specs, &mut entries, &self.aliases.cmnd.1);
         }
 
         entries
@@ -214,7 +214,7 @@ impl Sudoers {
 fn group_cmd_specs_per_runas<'a>(
     cmnd_specs: impl Iterator<Item = (Option<&'a RunAs>, (Tag, &'a Spec<Command>))>,
     entries: &mut Vec<Entry<'a>>,
-    cmnd_aliases: &'a VecOrd<Def<Command>>,
+    cmnd_aliases: &'a [Def<Command>],
 ) {
     let mut last_runas = None;
     let mut collected_specs = vec![];

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -217,21 +217,13 @@ fn group_cmd_specs_per_runas<'a>(
     entries: &mut Vec<Entry<'a>>,
     cmnd_aliases: &HashMap<&String, &'a Vec<Spec<Command>>>,
 ) {
-    static EMPTY_RUNAS: RunAs = RunAs {
-        users: Vec::new(),
-        groups: Vec::new(),
-    };
-
     let mut last_runas = None;
     let mut collected_specs = vec![];
 
     for (runas, (tag, spec)) in cmnd_specs {
         if runas.map(|r| r as *const _) != last_runas.map(|r| r as *const _) {
             if !collected_specs.is_empty() {
-                entries.push(Entry::new(
-                    last_runas.take().unwrap_or(&EMPTY_RUNAS),
-                    mem::take(&mut collected_specs),
-                ));
+                entries.push(Entry::new(last_runas, mem::take(&mut collected_specs)));
             }
 
             last_runas = runas;
@@ -257,10 +249,7 @@ fn group_cmd_specs_per_runas<'a>(
     }
 
     if !collected_specs.is_empty() {
-        entries.push(Entry::new(
-            last_runas.unwrap_or(&EMPTY_RUNAS),
-            collected_specs,
-        ));
+        entries.push(Entry::new(last_runas, collected_specs));
     }
 }
 

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -225,7 +225,7 @@ fn group_cmd_specs_per_runas<'a>(
             last_runas = runas;
         }
 
-        collected_specs.push((tag, spec.as_ref()));
+        collected_specs.push((tag, spec));
     }
 
     if !collected_specs.is_empty() {

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -273,10 +273,18 @@ pub(super) struct AliasTable {
 }
 
 /// A vector with a list defining the order in which it needs to be processed
-type VecOrd<T> = (Vec<usize>, Vec<T>);
+struct VecOrd<T>(Vec<usize>, Vec<T>);
 
-fn elems<T>(vec: &VecOrd<T>) -> impl Iterator<Item = &T> {
-    vec.0.iter().map(|&i| &vec.1[i])
+impl<T> Default for VecOrd<T> {
+    fn default() -> Self {
+        VecOrd(Vec::default(), Vec::default())
+    }
+}
+
+impl<T> VecOrd<T> {
+    fn iter(&self) -> impl Iterator<Item = &T> {
+        self.0.iter().map(|&i| &self.1[i])
+    }
 }
 
 /// Check if the user `am_user` is allowed to run `cmdline` on machine `on_host` as the requested
@@ -481,7 +489,7 @@ where
     let all = Qualified::Allow(Meta::All);
 
     let mut set = HashMap::new();
-    for Def(id, list) in elems(table) {
+    for Def(id, list) in table.iter() {
         if find_item(list, &pred, &set).is_some() {
             set.insert(id.clone(), true);
         } else if find_item(once(&all).chain(list), &pred, &set).is_none() {

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
@@ -8,7 +8,7 @@ macro_rules! assert_snapshot {
             filters => vec![
                 (BIN_LS, "<BIN_LS>"),
                 (&format!("Sudoers entry: {ETC_SUDOERS}"), "Sudoers entry:"),
-                ("Matching Defaults entries for root on container:
+                ("Matching Defaults entries for ferruccio on container:
     !fqdn, !lecture, !mailerpath
 ", "")
             ],
@@ -24,8 +24,11 @@ macro_rules! assert_snapshot {
 // sudoers entries
 
 fn sudo_ll_of(sudoers: &str) -> Result<String> {
-    let env = Env(sudoers).hostname(HOSTNAME).build()?;
+    let user = "ferruccio";
+    let sudoers = ["ALL ALL = NOPASSWD: /tmp", sudoers].join("\n");
+    let env = Env(sudoers).hostname(HOSTNAME).user(user).build()?;
     Command::new("sudo")
+        .as_user(user)
         .args(["-l", "-l"])
         .output(&env)?
         .stdout()

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/command_alias.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/command_alias.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/command_arguments.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/command_arguments.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/complex_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/complex_runas.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: !ferris, root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_across_runas_groups.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_any.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_any.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_multiple_commands.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_multiple_commands.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_multiple_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_multiple_runas_groups.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_nopasswd.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_not_in_first_position.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_not_in_first_position.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_override.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_override_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_override_across_runas_groups.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_path.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/cwd_path.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/empty_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/empty_runas.snap
@@ -2,9 +2,15 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
 
 Sudoers entry:
     RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
+
+Sudoers entry:
+    RunAsUsers: ferruccio
     Commands:
 	ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/group_runas.snap
@@ -2,10 +2,16 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
 
 Sudoers entry:
     RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
+
+Sudoers entry:
+    RunAsUsers: ferruccio
     RunAsGroups: crabs
     Commands:
 	ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/implicit_runas_group.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/implicit_runas_group.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_commands.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_commands.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_group_runas.snap
@@ -2,10 +2,16 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
 
 Sudoers entry:
     RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
+
+Sudoers entry:
+    RunAsUsers: ferruccio
     RunAsGroups: crabs, root
     Commands:
 	ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_lines.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_lines.snap
@@ -2,15 +2,16 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root
     Commands:
 	/usr/bin/true
 	/usr/bin/false
-
-Sudoers entry:
-    RunAsUsers: root
-    Commands:
-	<BIN_LS>

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_runas_groups.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_users_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/multiple_users_runas.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: ferris, root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/negated_command_alias.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/negated_command_alias.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/no_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/no_runas.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_across_runas_groups.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_on_same_command.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_on_same_command.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_override.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_override_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/nopasswd_passwd_override_across_runas_groups.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/not_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/not_group_runas.snap
@@ -2,10 +2,16 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
 
 Sudoers entry:
     RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
+
+Sudoers entry:
+    RunAsUsers: ferruccio
     RunAsGroups: !crabs
     Commands:
 	ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/not_user_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/not_user_runas.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: !ferris

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd_across_runas_groups.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd_nopasswd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/passwd_nopasswd_override.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_group_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_group_id_runas.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: %#0

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_group_runas.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: %root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_id_runas.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: #0

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_non_unix_group_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_non_unix_group_id_runas.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: %:#0

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_non_unix_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_non_unix_group_runas.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: %:root

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/long_format/snapshots/user_runas.snap
@@ -2,7 +2,13 @@
 source: sudo-compliance-tests/src/sudo/flag_list/long_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+
+Sudoers entry:
+    RunAsUsers: root
+    Options: !authenticate
+    Commands:
+	/tmp
 
 Sudoers entry:
     RunAsUsers: ferris

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
@@ -324,3 +324,10 @@ fn multiple_lines() -> Result<()> {
     assert_snapshot!(stdout);
     Ok(())
 }
+
+#[test]
+fn empty_runas_with_colon() -> Result<()> {
+    let stdout = sudo_list_of(&format!(" ALL  ALL  = (:) {BIN_TRUE} "))?;
+    assert_snapshot!(stdout);
+    Ok(())
+}

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
@@ -233,7 +233,6 @@ fn cwd_across_runas_groups() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "gh974"]
 #[test]
 fn cwd_override_across_runas_groups() -> Result<()> {
     let stdout = sudo_list_of(&format!(
@@ -300,7 +299,6 @@ fn passwd_across_runas_groups() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "gh974"]
 #[test]
 fn nopasswd_passwd_override_across_runas_groups() -> Result<()> {
     let stdout = sudo_list_of(&format!(

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
@@ -7,7 +7,7 @@ macro_rules! assert_snapshot {
         insta::with_settings!({
             filters => vec![
                 (BIN_LS, "<BIN_LS>"),
-                ("Matching Defaults entries for root on container:
+                ("Matching Defaults entries for ferruccio on container:
     !fqdn, !lecture, !mailerpath
 ", "")],
             prepend_module_to_snapshot => false,
@@ -22,8 +22,14 @@ macro_rules! assert_snapshot {
 // sudoers entries
 
 fn sudo_list_of(sudoers: &str) -> Result<String> {
-    let env = Env(sudoers).hostname(HOSTNAME).build()?;
-    Command::new("sudo").arg("-l").output(&env)?.stdout()
+    let user = "ferruccio";
+    let sudoers = ["ALL ALL = NOPASSWD: /tmp", sudoers].join("\n");
+    let env = Env(sudoers).hostname(HOSTNAME).user(user).build()?;
+    Command::new("sudo")
+        .as_user(user)
+        .arg("-l")
+        .output(&env)?
+        .stdout()
 }
 
 #[test]

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/command_alias.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/command_alias.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) <BIN_LS>, /usr/bin/true, /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/command_arguments.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/command_arguments.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) /usr/bin/true a b c, /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/complex_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/complex_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (!ferris, root : crabs, !root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_across_runas_groups.snap
@@ -2,6 +2,7 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) CWD=* /usr/bin/true
     (ferris) CWD=* /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_any.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_any.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) CWD=* /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_multiple_commands.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_multiple_commands.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) CWD=* /usr/bin/true, /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_multiple_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_multiple_runas_groups.snap
@@ -2,6 +2,7 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) CWD=* /usr/bin/true
     (ferris) CWD=* /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_nopasswd.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) CWD=* NOPASSWD: /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_not_in_first_position.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_not_in_first_position.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) /usr/bin/true, CWD=* /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_override.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) CWD=* /usr/bin/true, CWD=/home /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_override_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_override_across_runas_groups.snap
@@ -2,6 +2,7 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) CWD=* /usr/bin/true
     (ferris) CWD=* /usr/bin/false, CWD=/home <BIN_LS>

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_path.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/cwd_path.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) CWD=/home /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/empty_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/empty_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
-    (root) ALL
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
+    (ferruccio) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/empty_runas_with_colon.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/empty_runas_with_colon.snap
@@ -1,0 +1,6 @@
+---
+source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
+expression: stdout
+---
+User root may run the following commands on container:
+    (root) /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/empty_runas_with_colon.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/empty_runas_with_colon.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
-    (root) /usr/bin/true
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
+    (ferruccio) /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/group_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
-    (root : crabs) ALL
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
+    (ferruccio : crabs) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/implicit_runas_group.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/implicit_runas_group.snap
@@ -2,6 +2,7 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) /usr/bin/true
     (ferris) /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_commands.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_commands.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) /usr/bin/true, /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_group_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
-    (root : crabs, root) ALL
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
+    (ferruccio : crabs, root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_lines.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_lines.snap
@@ -2,6 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) /usr/bin/true, /usr/bin/false
-    (root) <BIN_LS>

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_runas_groups.snap
@@ -2,6 +2,7 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) /usr/bin/true
     (ferris) /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_users_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/multiple_users_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (ferris, root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/negated_command_alias.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/negated_command_alias.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) <BIN_LS>, !/usr/bin/true, /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/no_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/no_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) NOPASSWD: /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_across_runas_groups.snap
@@ -2,6 +2,7 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) NOPASSWD: /usr/bin/true
     (ferris) NOPASSWD: /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_on_same_command.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_on_same_command.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) PASSWD: /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_override.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) NOPASSWD: /usr/bin/true, PASSWD: /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_override_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/nopasswd_passwd_override_across_runas_groups.snap
@@ -2,6 +2,7 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) NOPASSWD: /usr/bin/true
     (ferris) NOPASSWD: /usr/bin/false, PASSWD: <BIN_LS>

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/not_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/not_group_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
-    (root : !crabs) ALL
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
+    (ferruccio : !crabs) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/not_user_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/not_user_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (!ferris) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) PASSWD: /usr/bin/true

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd_across_runas_groups.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd_across_runas_groups.snap
@@ -2,6 +2,7 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) PASSWD: /usr/bin/true
     (ferris) PASSWD: /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd_nopasswd_override.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/passwd_nopasswd_override.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (root) PASSWD: /usr/bin/true, NOPASSWD: /usr/bin/false

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_group_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_group_id_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (%#0) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_group_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (%root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_id_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (#0) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_non_unix_group_id_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_non_unix_group_id_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (%:#0) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_non_unix_group_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_non_unix_group_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (%:root) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_runas.snap
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/short_format/snapshots/user_runas.snap
@@ -2,5 +2,6 @@
 source: sudo-compliance-tests/src/sudo/flag_list/short_format/mod.rs
 expression: stdout
 ---
-User root may run the following commands on container:
+User ferruccio may run the following commands on container:
+    (root) NOPASSWD: /tmp
     (ferris) ALL

--- a/test-framework/sudo-compliance-tests/src/sudo/nopasswd.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/nopasswd.rs
@@ -74,7 +74,6 @@ fn nopasswd_tag_for_command() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh530"]
 fn run_sudo_l_flag_without_pwd_if_one_nopasswd_is_set() -> Result<()> {
     let env = Env(format!(
         "ALL ALL=(ALL:ALL) NOPASSWD: {BIN_TRUE}, PASSWD: {BIN_LS}"
@@ -90,17 +89,10 @@ fn run_sudo_l_flag_without_pwd_if_one_nopasswd_is_set() -> Result<()> {
     assert!(output.status().success());
 
     let actual = output.stdout()?;
-    if sudo_test::is_original_sudo() {
-        assert_contains!(
-            actual,
-            format!("User {USERNAME} may run the following commands")
-        );
-    } else {
-        assert_contains!(
-            actual,
-            format!("I'm sorry {USERNAME}. I'm afraid I can't do that")
-        );
-    }
+    assert_contains!(
+        actual,
+        format!("User {USERNAME} may run the following commands")
+    );
 
     Ok(())
 }


### PR DESCRIPTION
There  was some needed attention the `--list` command. 
* `()` and `(:)` were not handled correctly
* Un-ignore some tests that were broken by #975 
* Recursive aliases are not unfolded properly