### PR TITLE
Improve visudo errors

### DIFF
--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -257,8 +257,14 @@ fn edit_sudoers_file(
 
         writeln!(stderr, "The provided sudoers file format is not recognized or contains syntax errors. Please review:\n")?;
 
-        for crate::sudoers::Error { message, .. } in errors {
-            writeln!(stderr, "syntax error: {message}")?;
+        for crate::sudoers::Error {
+            message,
+            source,
+            location,
+        } in errors
+        {
+            let path = source.as_deref().unwrap_or(sudoers_path);
+            diagnostic::diagnostic!("syntax error: {message}", path @ location);
         }
 
         writeln!(stderr)?;


### PR DESCRIPTION
This now shows errors in the same format as sudo, which includes the location of the error as well as the line where the error happened.

Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/980