### PR TITLE
Replace accept_if function with next_if, eat_char and eat_not_char methods

### DIFF
--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -540,7 +540,7 @@ impl Parse for Sudo {
                 // the failed "try_nonterminal::<Identifier>" will have consumed the '#'
                 // the most ignominious part of sudoers: having to parse bits of comments
                 parse_include(stream).or_else(|_| {
-                    while stream.eat_not_char('\n') {}
+                    stream.skip_to_newline();
                     make(Sudo::LineComment)
                 })
             };

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -213,7 +213,7 @@ impl Sudo {
 /// ```
 impl Parse for Identifier {
     fn parse(stream: &mut CharStream) -> Parsed<Self> {
-        if accept_if(|c| c == '#', stream).is_some() {
+        if stream.eat_char('#') {
             let Digits(guid) = expect_nonterminal(stream)?;
             make(Identifier::ID(guid))
         } else {
@@ -289,15 +289,15 @@ impl Parse for Meta<Identifier> {
 /// ```
 impl Parse for UserSpecifier {
     fn parse(stream: &mut CharStream) -> Parsed<Self> {
-        let userspec = if accept_if(|c| c == '%', stream).is_some() {
-            let ctor = if accept_if(|c| c == ':', stream).is_some() {
+        let userspec = if stream.eat_char('%') {
+            let ctor = if stream.eat_char(':') {
                 UserSpecifier::NonunixGroup
             } else {
                 UserSpecifier::Group
             };
             // in this case we must fail 'hard', since input has been consumed
             ctor(expect_nonterminal(stream)?)
-        } else if accept_if(|c| c == '+', stream).is_some() {
+        } else if stream.eat_char('+') {
             // TODO Netgroups
             unrecoverable!(stream, "netgroups are not supported yet");
         } else {
@@ -517,7 +517,7 @@ impl Parse for Sudo {
     // but accept:
     //   "user, User_Alias machine = command"; this does the same
     fn parse(stream: &mut CharStream) -> Parsed<Sudo> {
-        if accept_if(|c| c == '@', stream).is_some() {
+        if stream.eat_char('@') {
             return parse_include(stream);
         }
 
@@ -540,7 +540,7 @@ impl Parse for Sudo {
                 // the failed "try_nonterminal::<Identifier>" will have consumed the '#'
                 // the most ignominious part of sudoers: having to parse bits of comments
                 parse_include(stream).or_else(|_| {
-                    while accept_if(|c| c != '\n', stream).is_some() {}
+                    while stream.eat_not_char('\n') {}
                     make(Sudo::LineComment)
                 })
             };
@@ -569,7 +569,7 @@ impl Parse for Sudo {
 /// Parse the include/include dir part that comes after the '#' or '@' prefix symbol
 fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
     fn get_path(stream: &mut CharStream, key_pos: (usize, usize)) -> Parsed<(String, Span)> {
-        let path = if accept_if(|c| c == '"', stream).is_some() {
+        let path = if stream.eat_char('"') {
             let QuotedInclude(path) = expect_nonterminal(stream)?;
             expect_syntax('"', stream)?;
             path
@@ -700,8 +700,8 @@ impl Parse for defaults::SettingsModifier {
         let id_pos = stream.get_pos();
 
         // Parse multiple entries enclosed in quotes (for list-like Defaults-settings)
-        let parse_vars = |stream: &mut _| -> Parsed<Vec<String>> {
-            if accept_if(|c| c == '"', stream).is_some() {
+        let parse_vars = |stream: &mut CharStream| -> Parsed<Vec<String>> {
+            if stream.eat_char('"') {
                 let mut result = Vec::new();
                 while let Some(EnvVar(name)) = try_nonterminal(stream)? {
                     result.push(name);
@@ -738,8 +738,8 @@ impl Parse for defaults::SettingsModifier {
             };
 
         // Parse a text parameter
-        let text_item = |stream: &mut _| {
-            if accept_if(|c| c == '"', stream).is_some() {
+        let text_item = |stream: &mut CharStream| {
+            if stream.eat_char('"') {
                 let QuotedText(text) = expect_nonterminal(stream)?;
                 expect_syntax('"', stream)?;
                 make(text)

--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -139,7 +139,7 @@ impl Parse for Comment {
         if !stream.eat_char('#') {
             return Err(Status::Reject);
         }
-        while stream.eat_not_char('\n') {}
+        stream.skip_to_newline();
         make(Comment {})
     }
 }
@@ -324,7 +324,7 @@ where
                 let error = |stream: &mut CharStream| unrecoverable!(stream, "{msg}");
                 result.push(error(stream));
             }
-            while stream.eat_not_char('\n') {}
+            stream.skip_to_newline();
         }
     }
 

--- a/src/sudoers/char_stream.rs
+++ b/src/sudoers/char_stream.rs
@@ -32,8 +32,8 @@ impl CharStream<'_> {
         self.next_if(|c| c == expect_char).is_some()
     }
 
-    pub fn eat_not_char(&mut self, expect_not_char: char) -> bool {
-        self.next_if(|c| c != expect_not_char).is_some()
+    pub fn skip_to_newline(&mut self) {
+        while self.next_if(|c| c != '\n').is_some() {}
     }
 
     pub fn peek(&mut self) -> Option<char> {

--- a/src/sudoers/char_stream.rs
+++ b/src/sudoers/char_stream.rs
@@ -15,8 +15,9 @@ impl<'a> CharStream<'a> {
 }
 
 impl CharStream<'_> {
-    pub fn advance(&mut self) {
-        match self.iter.next() {
+    pub fn next_if(&mut self, f: impl FnOnce(char) -> bool) -> Option<char> {
+        let item = self.iter.next_if(|&c| f(c));
+        match item {
             Some('\n') => {
                 self.line += 1;
                 self.col = 1;
@@ -24,6 +25,15 @@ impl CharStream<'_> {
             Some(_) => self.col += 1,
             _ => {}
         }
+        item
+    }
+
+    pub fn eat_char(&mut self, expect_char: char) -> bool {
+        self.next_if(|c| c == expect_char).is_some()
+    }
+
+    pub fn eat_not_char(&mut self, expect_not_char: char) -> bool {
+        self.next_if(|c| c != expect_not_char).is_some()
     }
 
     pub fn peek(&mut self) -> Option<char> {
@@ -43,12 +53,12 @@ mod test {
     fn test_iter() {
         let mut stream = CharStream::new("12\n3\n".chars());
         assert_eq!(stream.peek(), Some('1'));
-        stream.advance();
+        assert!(stream.eat_char('1'));
         assert_eq!(stream.peek(), Some('2'));
-        stream.advance();
-        stream.advance();
+        assert!(stream.eat_char('2'));
+        assert!(stream.eat_char('\n'));
         assert_eq!(stream.peek(), Some('3'));
-        stream.advance();
+        assert!(stream.eat_char('3'));
         assert_eq!(stream.get_pos(), (2, 2));
     }
 }


### PR DESCRIPTION
This makes the call sites slightly clearer and takes advantage of Peekable::next_if instead of manually reimplementing it.