### PR TITLE
Refactor Context + Make search path dependent on sudoers file

### DIFF
--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -1,34 +1,13 @@
 use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2};
+use crate::sudo::{SudoListOptions, SudoRunOptions, SudoValidateOptions};
+use crate::sudoers::Sudoers;
 use crate::system::{Group, Hostname, Process, User};
 
-use super::resolve::CurrentUser;
 use super::{
     command::CommandAndArguments,
-    resolve::{resolve_launch_and_shell, resolve_target_user_and_group},
-    Error, SudoPath, SudoString,
+    resolve::{resolve_shell, resolve_target_user_and_group, CurrentUser},
+    Error, SudoPath,
 };
-
-#[derive(Clone, Copy)]
-pub enum ContextAction {
-    List,
-    Run,
-    Validate,
-}
-
-// this is a bit of a hack to keep the existing `Context` API working
-#[derive(Clone)]
-pub struct OptionsForContext {
-    pub chdir: Option<SudoPath>,
-    pub group: Option<SudoString>,
-    pub login: bool,
-    pub non_interactive: bool,
-    pub positional_args: Vec<String>,
-    pub reset_timestamp: bool,
-    pub shell: bool,
-    pub stdin: bool,
-    pub user: Option<SudoString>,
-    pub action: ContextAction,
-}
 
 #[derive(Debug)]
 pub struct Context {
@@ -50,7 +29,7 @@ pub struct Context {
     pub password_feedback: bool,
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(u32)]
 pub enum LaunchType {
     #[default]
@@ -60,7 +39,59 @@ pub enum LaunchType {
 }
 
 impl Context {
-    pub fn build_from_options(sudo_options: OptionsForContext) -> Result<Context, Error> {
+    pub fn from_run_opts(
+        sudo_options: SudoRunOptions,
+        policy: &mut Sudoers,
+    ) -> Result<Context, Error> {
+        let hostname = Hostname::resolve();
+        let current_user = CurrentUser::resolve()?;
+
+        let (target_user, target_group) =
+            resolve_target_user_and_group(&sudo_options.user, &sudo_options.group, &current_user)?;
+
+        let launch = if sudo_options.login {
+            LaunchType::Login
+        } else if sudo_options.shell {
+            LaunchType::Shell
+        } else {
+            LaunchType::Direct
+        };
+
+        let shell = resolve_shell(launch, &current_user, &target_user);
+
+        let override_path = policy.search_path(&hostname, &current_user, &target_user);
+
+        let command = {
+            let system_path;
+
+            let path = if let Some(path) = override_path {
+                path
+            } else {
+                system_path = std::env::var("PATH").unwrap_or_default();
+                system_path.as_ref()
+            };
+
+            CommandAndArguments::build_from_args(shell, sudo_options.positional_args, path)
+        };
+
+        Ok(Context {
+            hostname,
+            command,
+            current_user,
+            target_user,
+            target_group,
+            use_session_records: !sudo_options.reset_timestamp,
+            launch,
+            chdir: sudo_options.chdir,
+            stdin: sudo_options.stdin,
+            non_interactive: sudo_options.non_interactive,
+            process: Process::new(),
+            use_pty: true,
+            password_feedback: false,
+        })
+    }
+
+    pub fn from_validate_opts(sudo_options: SudoValidateOptions) -> Result<Context, Error> {
         let hostname = Hostname::resolve();
         let current_user = CurrentUser::resolve()?;
         let (target_user, target_group) =
@@ -74,7 +105,7 @@ impl Context {
             target_group,
             use_session_records: !sudo_options.reset_timestamp,
             launch: Default::default(),
-            chdir: sudo_options.chdir,
+            chdir: None,
             stdin: sudo_options.stdin,
             non_interactive: sudo_options.non_interactive,
             process: Process::new(),
@@ -83,38 +114,46 @@ impl Context {
         })
     }
 
-    pub fn supply_command(
-        self,
-        sudo_options: OptionsForContext,
-        secure_path: Option<&str>,
+    pub fn from_list_opts(
+        sudo_options: SudoListOptions,
+        policy: &mut Sudoers,
     ) -> Result<Context, Error> {
-        let (launch, shell) =
-            resolve_launch_and_shell(&sudo_options, &self.current_user, &self.target_user);
+        let hostname = Hostname::resolve();
+        let current_user = CurrentUser::resolve()?;
+        let (target_user, target_group) =
+            resolve_target_user_and_group(&sudo_options.user, &sudo_options.group, &current_user)?;
 
-        let command = match sudo_options.action {
-            ContextAction::Run | ContextAction::List
-                if !sudo_options.positional_args.is_empty() =>
-            {
-                let system_path;
+        let override_path = policy.search_path(&hostname, &current_user, &target_user);
 
-                let path = if let Some(path) = secure_path {
-                    path
-                } else {
-                    system_path = std::env::var("PATH").unwrap_or_default();
-                    system_path.as_ref()
-                };
+        let command = if sudo_options.positional_args.is_empty() {
+            Default::default()
+        } else {
+            let system_path;
 
-                CommandAndArguments::build_from_args(shell, sudo_options.positional_args, path)
-            }
+            let path = if let Some(path) = override_path {
+                path
+            } else {
+                system_path = std::env::var("PATH").unwrap_or_default();
+                system_path.as_ref()
+            };
 
-            // FIXME `Default` is being used as `Option::None`
-            _ => Default::default(),
+            CommandAndArguments::build_from_args(None, sudo_options.positional_args, path)
         };
 
-        Ok(Self {
-            launch,
+        Ok(Context {
+            hostname,
             command,
-            ..self
+            current_user,
+            target_user,
+            target_group,
+            use_session_records: !sudo_options.reset_timestamp,
+            launch: Default::default(),
+            chdir: None,
+            stdin: sudo_options.stdin,
+            non_interactive: sudo_options.non_interactive,
+            process: Process::new(),
+            use_pty: true,
+            password_feedback: false,
         })
     }
 }
@@ -125,23 +164,18 @@ mod tests {
         sudo::SudoAction,
         system::{interface::UserId, Hostname},
     };
-    use std::collections::HashMap;
 
     use super::Context;
 
     #[test]
-    fn test_build_context() {
+    fn test_build_run_context() {
         let options = SudoAction::try_parse_from(["sudo", "echo", "hello"])
             .unwrap()
             .try_into_run()
             .ok()
             .unwrap();
-        let path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-        let (ctx_opts, _pipe_opts) = options.into();
-        let context = Context::build_from_options(ctx_opts, Some(path)).unwrap();
 
-        let mut target_environment = HashMap::new();
-        target_environment.insert("SUDO_USER".to_string(), context.current_user.name.clone());
+        let context = Context::from_run_opts(options, &mut Default::default()).unwrap();
 
         if cfg!(target_os = "linux") {
             // this assumes /bin is a symlink on /usr/bin, like it is on modern Debian/Ubuntu

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -92,13 +92,9 @@ impl Context {
             resolve_launch_and_shell(&sudo_options, &self.current_user, &self.target_user);
 
         let command = match sudo_options.action {
-            ContextAction::Validate | ContextAction::List
-                if sudo_options.positional_args.is_empty() =>
+            ContextAction::Run | ContextAction::List
+                if !sudo_options.positional_args.is_empty() =>
             {
-                // FIXME `Default` is being used as `Option::None`
-                Default::default()
-            }
-            _ => {
                 let system_path;
 
                 let path = if let Some(path) = secure_path {
@@ -110,6 +106,9 @@ impl Context {
 
                 CommandAndArguments::build_from_args(shell, sudo_options.positional_args, path)
             }
+
+            // FIXME `Default` is being used as `Option::None`
+            _ => Default::default(),
         };
 
         Ok(Self {

--- a/src/common/resolve.rs
+++ b/src/common/resolve.rs
@@ -11,10 +11,7 @@ use std::{
 };
 
 use super::SudoString;
-use super::{
-    context::{LaunchType, OptionsForContext},
-    Error,
-};
+use super::{context::LaunchType, Error};
 
 #[derive(PartialEq, Debug)]
 enum NameOrId<'a, T: FromStr> {
@@ -97,21 +94,21 @@ impl ops::Deref for AuthUser {
 
 type Shell = Option<PathBuf>;
 
-pub(super) fn resolve_launch_and_shell(
-    sudo_options: &OptionsForContext,
+pub(super) fn resolve_shell(
+    launch_type: LaunchType,
     current_user: &User,
     target_user: &User,
-) -> (LaunchType, Shell) {
-    if sudo_options.login {
-        (LaunchType::Login, Some(target_user.shell.clone()))
-    } else if sudo_options.shell {
-        let shell = env::var("SHELL")
-            .map(|s| s.into())
-            .unwrap_or_else(|_| current_user.shell.clone());
+) -> Shell {
+    match launch_type {
+        LaunchType::Login => Some(target_user.shell.clone()),
 
-        (LaunchType::Shell, Some(shell))
-    } else {
-        (LaunchType::Direct, None)
+        LaunchType::Shell => Some(
+            env::var("SHELL")
+                .map(|s| s.into())
+                .unwrap_or_else(|_| current_user.shell.clone()),
+        ),
+
+        LaunchType::Direct => None,
     }
 }
 

--- a/src/exec/interface.rs
+++ b/src/exec/interface.rs
@@ -15,7 +15,6 @@ pub trait RunOptions {
     fn chdir(&self) -> Option<&SudoPath>;
     fn is_login(&self) -> bool;
     fn user(&self) -> &User;
-    fn requesting_user(&self) -> &User;
     fn group(&self) -> &Group;
     fn pid(&self) -> ProcessId;
 
@@ -49,10 +48,6 @@ impl RunOptions for Context {
 
     fn user(&self) -> &User {
         &self.target_user
-    }
-
-    fn requesting_user(&self) -> &User {
-        &self.current_user
     }
 
     fn group(&self) -> &Group {

--- a/src/su/context.rs
+++ b/src/su/context.rs
@@ -36,7 +36,7 @@ pub(crate) struct SuContext {
     options: SuRunOptions,
     pub(crate) environment: Environment,
     user: User,
-    requesting_user: CurrentUser,
+    pub(crate) requesting_user: CurrentUser,
     group: Group,
     pub(crate) process: Process,
 }
@@ -235,10 +235,6 @@ impl RunOptions for SuContext {
 
     fn user(&self) -> &crate::system::User {
         &self.user
-    }
-
-    fn requesting_user(&self) -> &User {
-        &self.requesting_user
     }
 
     fn group(&self) -> &crate::system::Group {

--- a/src/su/mod.rs
+++ b/src/su/mod.rs
@@ -89,7 +89,7 @@ fn run(options: SuRunOptions) -> Result<(), Error> {
 
     // authenticate the target user
     let mut pam: PamContext<CLIConverser> = authenticate(
-        &context.requesting_user().name,
+        &context.requesting_user.name,
         &context.user().name,
         context.is_login(),
     )?;

--- a/src/sudo/cli/mod.rs
+++ b/src/sudo/cli/mod.rs
@@ -733,7 +733,7 @@ fn ensure_is_absent(context: &str, thing: &dyn IsAbsent, name: &str) -> Result<(
     if thing.is_absent() {
         Ok(())
     } else {
-        Err(format!("{context} conflicts with {name}"))
+        Err(format!("{context} cannot be used together with {name}"))
     }
 }
 
@@ -795,7 +795,7 @@ fn reject_all(context: &str, opts: SudoOptions) -> Result<(), String> {
     }
 
     ensure_is_absent(context, &env_var_list, "environment variable")?;
-    ensure_is_absent(context, &positional_args, "positional argument")?;
+    ensure_is_absent(context, &positional_args, "command")?;
 
     Ok(())
 }

--- a/src/sudo/cli/mod.rs
+++ b/src/sudo/cli/mod.rs
@@ -2,7 +2,6 @@
 
 use std::{borrow::Cow, mem};
 
-use crate::common::context::{ContextAction, OptionsForContext};
 use crate::common::{SudoPath, SudoString};
 
 pub mod help;
@@ -798,107 +797,4 @@ fn reject_all(context: &str, opts: SudoOptions) -> Result<(), String> {
     ensure_is_absent(context, &positional_args, "command")?;
 
     Ok(())
-}
-
-impl From<SudoListOptions> for OptionsForContext {
-    fn from(opts: SudoListOptions) -> Self {
-        let SudoListOptions {
-            group,
-            non_interactive,
-            positional_args,
-            reset_timestamp,
-            stdin,
-            user,
-
-            list: _,
-            other_user: _,
-        } = opts;
-
-        Self {
-            action: ContextAction::List,
-
-            group,
-            non_interactive,
-            positional_args,
-            reset_timestamp,
-            stdin,
-            user,
-
-            chdir: None,
-            login: false,
-            shell: false,
-        }
-    }
-}
-
-impl From<SudoValidateOptions> for OptionsForContext {
-    fn from(opts: SudoValidateOptions) -> Self {
-        let SudoValidateOptions {
-            group,
-            non_interactive,
-            reset_timestamp,
-            stdin,
-            user,
-        } = opts;
-
-        Self {
-            action: ContextAction::Validate,
-
-            group,
-            non_interactive,
-            reset_timestamp,
-            stdin,
-            user,
-
-            chdir: None,
-            login: false,
-            positional_args: vec![],
-            shell: false,
-        }
-    }
-}
-
-pub struct OptionsForPipeline {
-    pub preserve_env: PreserveEnv,
-    pub user_requested_env_vars: Vec<(String, String)>,
-}
-
-impl SudoRunOptions {
-    pub fn into(self) -> (OptionsForContext, OptionsForPipeline) {
-        let SudoRunOptions {
-            chdir,
-            group,
-            login,
-            non_interactive,
-            positional_args,
-            reset_timestamp,
-            shell,
-            stdin,
-            user,
-
-            env_var_list,
-            preserve_env,
-        } = self;
-
-        let ctx_opts = OptionsForContext {
-            action: ContextAction::Run,
-
-            chdir,
-            group,
-            login,
-            non_interactive,
-            positional_args,
-            reset_timestamp,
-            shell,
-            stdin,
-            user,
-        };
-
-        let pipe_opts = OptionsForPipeline {
-            preserve_env,
-            user_requested_env_vars: env_var_list,
-        };
-
-        (ctx_opts, pipe_opts)
-    }
 }

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -10,7 +10,7 @@ use crate::system::User;
 use crate::system::{time::Duration, timestamp::SessionRecordFile, Process};
 use cli::help;
 #[cfg(test)]
-pub use cli::SudoAction;
+pub(crate) use cli::SudoAction;
 #[cfg(not(test))]
 use cli::SudoAction;
 use pam::PamAuthenticator;
@@ -18,7 +18,9 @@ use pipeline::Pipeline;
 use std::path::Path;
 
 mod cli;
-pub mod diagnostic;
+pub(crate) use cli::{SudoListOptions, SudoRunOptions, SudoValidateOptions};
+
+pub(crate) mod diagnostic;
 mod env;
 mod pam;
 mod pipeline;

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -73,7 +73,8 @@ impl<Auth: AuthPlugin> Pipeline<Auth> {
             )
         }
 
-        let mut context = Context::build_from_options(ctx_opts, policy.search_path())?;
+        let mut context = Context::build_from_options(ctx_opts.clone())?
+            .supply_command(ctx_opts, policy.search_path())?;
 
         let policy = judge(policy, &context)?;
 
@@ -137,7 +138,9 @@ impl<Auth: AuthPlugin> Pipeline<Auth> {
 
     pub fn run_validate(mut self, cmd_opts: SudoValidateOptions) -> Result<(), Error> {
         let mut policy = read_sudoers()?;
-        let mut context = Context::build_from_options(cmd_opts.into(), policy.search_path())?;
+        let ctx_opts: crate::common::context::OptionsForContext = cmd_opts.into();
+        let mut context = Context::build_from_options(ctx_opts.clone())?
+            .supply_command(ctx_opts, policy.search_path())?;
 
         match policy.validate_authorization() {
             Authorization::Forbidden => {

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -25,9 +25,7 @@ impl<Auth: super::AuthPlugin> Pipeline<Auth> {
 
         let mut sudoers = super::read_sudoers()?;
 
-        let ctx_opts: crate::common::context::OptionsForContext = cmd_opts.into();
-        let mut context = Context::build_from_options(ctx_opts.clone())?
-            .supply_command(ctx_opts, /*sudoers.search_path()*/ None)?; // TODO
+        let mut context = Context::from_list_opts(cmd_opts, &mut sudoers)?;
 
         if original_command.is_some() && !context.command.resolved {
             return Err(Error::CommandNotFound(context.command.command));

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -25,7 +25,9 @@ impl<Auth: super::AuthPlugin> Pipeline<Auth> {
 
         let mut sudoers = super::read_sudoers()?;
 
-        let mut context = Context::build_from_options(cmd_opts.into(), sudoers.search_path())?;
+        let ctx_opts: crate::common::context::OptionsForContext = cmd_opts.into();
+        let mut context = Context::build_from_options(ctx_opts.clone())?
+            .supply_command(ctx_opts, sudoers.search_path())?;
 
         if original_command.is_some() && !context.command.resolved {
             return Err(Error::CommandNotFound(context.command.command));

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -27,7 +27,7 @@ impl<Auth: super::AuthPlugin> Pipeline<Auth> {
 
         let ctx_opts: crate::common::context::OptionsForContext = cmd_opts.into();
         let mut context = Context::build_from_options(ctx_opts.clone())?
-            .supply_command(ctx_opts, sudoers.search_path())?;
+            .supply_command(ctx_opts, /*sudoers.search_path()*/ None)?; // TODO
 
         if original_command.is_some() && !context.command.resolved {
             return Err(Error::CommandNotFound(context.command.command));

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -2,7 +2,7 @@ use super::Sudoers;
 
 use super::Judgement;
 use crate::common::{SudoPath, HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1};
-use crate::system::time::Duration;
+use crate::system::{time::Duration, Hostname, User};
 /// Data types and traits that represent what the "terms and conditions" are after a succesful
 /// permission check.
 ///
@@ -98,7 +98,13 @@ impl Judgement {
 }
 
 impl Sudoers {
-    pub fn search_path(&mut self) -> Option<&str> {
+    pub fn search_path(
+        &mut self,
+        on_host: &Hostname,
+        current_user: &User,
+        target_user: &User,
+    ) -> Option<&str> {
+        self.specify_host_user_runas(on_host, current_user, target_user);
         self.settings.secure_path()
     }
 

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_user.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_user.rs
@@ -54,7 +54,7 @@ fn uppercase_u_flag_fails() -> Result<()> {
         if sudo_test::is_original_sudo() {
             "sudo: the -U option may only be used with the -l option"
         } else {
-            "conflicts with --other-user"
+            "cannot be used together with --other-user"
         }
     );
 


### PR DESCRIPTION
Dependent on #897 

Closes #989
Closes #986

There is some duplication in `context.rs`, but that is essentially the duplication that was already there in the `From<>` impl's that were previously there (whose only job was converting the nicely seperate CLI objects into a intermediate object that was then converted to the "Context" object.

This PR doesn't get rid of the Context object but does make it shorter-lived: it only exists in the pipeline now where we can maybe chip away at it more. Also, it doesn't really fix the issue that Context is a "one size fits all" object that doesn't really get fully used in every circumstance.

It probably is blasphemous to say this but this is one of the areas where I feel having structural inheritance can be a nice thing. :-)