### PR TITLE
Fix recursion-check in alias table

### DIFF
--- a/src/sudoers/entry/verbose.rs
+++ b/src/sudoers/entry/verbose.rs
@@ -35,7 +35,7 @@ impl fmt::Display for Verbose<'_> {
             last_tag = Some(tag);
 
             f.write_str("\n\t")?;
-            super::write_spec(f, cmd_spec, cmd_alias, true, "\n\t")?;
+            super::write_spec(f, cmd_spec, cmd_alias.iter().rev(), true, "\n\t")?;
         }
 
         Ok(())

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -178,7 +178,7 @@ impl Sudoers {
     ) -> impl Iterator<Item = Entry<'a>> {
         let user_specs = self.matching_user_specs(invoking_user, hostname);
 
-        user_specs.flat_map(|cmd_specs| group_cmd_specs_per_runas(cmd_specs, &self.aliases.cmnd.1))
+        user_specs.flat_map(|cmd_specs| group_cmd_specs_per_runas(cmd_specs, &self.aliases.cmnd))
     }
 
     pub(crate) fn solve_editor_path(&self) -> Option<PathBuf> {
@@ -214,7 +214,7 @@ fn peeking_take_while<'a, T>(
 
 fn group_cmd_specs_per_runas<'a>(
     cmnd_specs: impl Iterator<Item = (Option<&'a RunAs>, (Tag, &'a Spec<Command>))>,
-    cmnd_aliases: &'a [Def<Command>],
+    cmnd_aliases: &'a VecOrd<Def<Command>>,
 ) -> impl Iterator<Item = Entry<'a>> {
     // `distribute_tags` will have given every spec a reference to the "runas specification"
     // that applies to it. The output of sudo --list splits the CmndSpec list based on that:
@@ -282,7 +282,7 @@ impl<T> Default for VecOrd<T> {
 }
 
 impl<T> VecOrd<T> {
-    fn iter(&self) -> impl Iterator<Item = &T> {
+    fn iter(&self) -> impl DoubleEndedIterator<Item = &T> + Clone {
         self.0.iter().map(|&i| &self.1[i])
     }
 }

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -707,7 +707,7 @@ fn sanitize_alias_table<T>(table: &Vec<Def<T>>, diagnostics: &mut Vec<Error>) ->
                 let Def(_, members) = &self.table[pos];
                 for elem in members {
                     let Meta::Alias(name) = remqualify(elem) else {
-                        break;
+                        continue;
                     };
                     let Some(dependency) = self.table.iter().position(|Def(id, _)| id == name)
                     else {

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -431,6 +431,16 @@ fn useralias_underscore_regression() {
         .is_alias());
 }
 
+#[test]
+fn regression_check_recursion() {
+    let (_, error) = analyze(
+        Path::new("/etc/fakesudoers"),
+        sudoer!["User_Alias A=user, B", "User_Alias B=A"],
+    );
+
+    assert!(!error.is_empty());
+}
+
 fn test_topo_sort(n: usize) {
     let alias = |s: &str| Qualified::Allow(Meta::<UserSpecifier>::Alias(s.to_string()));
     let stop = || Qualified::Allow(Meta::<UserSpecifier>::All);

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -142,11 +142,11 @@ impl Token for AliasName {
     }
 
     fn accept_1st(c: char) -> bool {
-        c.is_ascii_uppercase() || c.is_ascii_digit()
+        c.is_ascii_uppercase()
     }
 
     fn accept(c: char) -> bool {
-        Self::accept_1st(c) || c == '_'
+        Self::accept_1st(c) || c.is_ascii_digit() || c == '_'
     }
 }
 


### PR DESCRIPTION
`sanitize_alias_table` checked alias definitions for recursion, but didn't do this in all cases (due to `break` being confused with `continue`...). This had no impact at all, except we didn't complain in all cases that we should have--which is probably why it went unnoticed.

However, after #978 was recently merged, `write_spec` could actually enter in a infinite loop since it now unfolds every alias definition. The fix is pretty simple: since VecOrd captures a topologically sorted list of alias definitions, once an alias has been unfolded we only need to consider its "downstream" alias definitions.