### PR TITLE
Make the compliance tests mostly pass on FreeBSD with og sudo too

### DIFF
--- a/test-framework/e2e-tests/src/su/signal_handling/mod.rs
+++ b/test-framework/e2e-tests/src/su/signal_handling/mod.rs
@@ -58,10 +58,7 @@ fn child_terminated_by_signal() -> Result<()> {
     let env = Env("").build()?;
 
     // child process sends SIGTERM to itself
-    let output = Command::new("su")
-        .arg("-c")
-        .arg("kill $$")
-        .output(&env)?;
+    let output = Command::new("su").arg("-c").arg("kill $$").output(&env)?;
 
     assert_eq!(Some(143), output.status().code());
     assert!(output.stderr().is_empty());

--- a/test-framework/sudo-compliance-tests/src/helpers.rs
+++ b/test-framework/sudo-compliance-tests/src/helpers.rs
@@ -53,7 +53,10 @@ impl Drop for Rsyslogd<'_> {
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "Logging not really functional on FreeBSD even with og-sudo")]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "Logging not really functional on FreeBSD even with og-sudo"
+)]
 fn rsyslogd_works() -> Result<()> {
     let env = Env("").build()?;
     let rsyslog = Rsyslogd::start(&env)?;

--- a/test-framework/sudo-compliance-tests/src/su/limits.rs
+++ b/test-framework/sudo-compliance-tests/src/su/limits.rs
@@ -3,7 +3,10 @@ use sudo_test::{Command, Env, User};
 use crate::{Result, PASSWORD, USERNAME};
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't support /etc/security")]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "FreeBSD doesn't support /etc/security"
+)]
 fn etc_security_limits_rules_apply_according_to_the_target_user() -> Result<()> {
     let target_user = "ghost";
     let original = "2048";

--- a/test-framework/sudo-compliance-tests/src/su/syslog.rs
+++ b/test-framework/sudo-compliance-tests/src/su/syslog.rs
@@ -9,7 +9,10 @@ fn wait_until_rsyslogd_starts_up() {
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "Logging not really functional on FreeBSD even with og-sudo")]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "Logging not really functional on FreeBSD even with og-sudo"
+)]
 fn logs_every_session() -> Result<()> {
     let invoking_user = USERNAME;
     let invoking_userid = 1000;
@@ -57,7 +60,10 @@ fn logs_every_session() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "Logging not really functional on FreeBSD even with og-sudo")]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "Logging not really functional on FreeBSD even with og-sudo"
+)]
 fn logs_every_failed_authentication_attempt() -> Result<()> {
     let invoking_user = USERNAME;
     let invoking_userid = 1000;

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/needs_auth.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/needs_auth.rs
@@ -18,7 +18,11 @@ ALL ALL=(ALL:ALL) ALL")
     assert_eq!(Some(1), output.status().code());
 
     let diagnostic = if sudo_test::is_original_sudo() {
-        format!("[sudo] password for {USERNAME}:")
+        if cfg!(not(target_os = "linux")) {
+            "Password:".to_owned()
+        } else {
+            format!("[sudo] password for {USERNAME}:")
+        }
     } else {
         "[sudo: authenticate] Password:".to_string()
     };
@@ -48,7 +52,11 @@ fn other_user_has_nopasswd_tag() -> Result<()> {
     assert_eq!(Some(1), output.status().code());
 
     let diagnostic = if sudo_test::is_original_sudo() {
-        format!("[sudo] password for {USERNAME}:")
+        if cfg!(not(target_os = "linux")) {
+            "Password:".to_owned()
+        } else {
+            format!("[sudo] password for {USERNAME}:")
+        }
     } else {
         "[sudo: authenticate] Password:".to_string()
     };

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list/needs_auth.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list/needs_auth.rs
@@ -5,7 +5,9 @@ use crate::{Result, USERNAME};
 #[test]
 fn when_other_user_is_self() -> Result<()> {
     let env = Env("Defaults !lecture
-ALL ALL=(ALL:ALL) ALL").user(USERNAME).build()?;
+ALL ALL=(ALL:ALL) ALL")
+    .user(USERNAME)
+    .build()?;
 
     let output = Command::new("sudo")
         .args(["-S", "-l", "-U", USERNAME])

--- a/test-framework/sudo-compliance-tests/src/sudo/misc.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/misc.rs
@@ -218,6 +218,10 @@ fn does_not_panic_on_io_errors_cli_error() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "FreeBSD uses a binary database as canonical source of users"
+)]
 fn long_username() -> Result<()> {
     // `useradd` limits usernames to 32 characters
     // directly write to `/etc/passwd` to work around this limitation
@@ -241,6 +245,10 @@ fn long_username() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "FreeBSD uses a binary database as canonical source of users"
+)]
 fn missing_primary_group() -> Result<()> {
     let username = "user";
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD).build()?;

--- a/test-framework/sudo-compliance-tests/src/sudo/nopasswd.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/nopasswd.rs
@@ -132,10 +132,18 @@ fn v_flag_without_pwd_fails_if_nopasswd_is_not_set_for_all_users_entries() -> Re
 
     let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_contains!(
-            stderr,
-            format!("[sudo] password for {USERNAME}: \nsudo: no password was provided\nsudo: a password is required")
-        );
+        if cfg!(not(target_os = "linux")) {
+            assert_contains!(
+                stderr,
+                "Password: \nsudo: no password was provided\nsudo: a password is required"
+                    .to_owned()
+            );
+        } else {
+            assert_contains!(
+                stderr,
+                format!("[sudo] password for {USERNAME}: \nsudo: no password was provided\nsudo: a password is required")
+            );
+        }
     } else {
         assert_contains!(
             stderr,

--- a/test-framework/sudo-compliance-tests/src/sudo/pass_auth/stdin.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pass_auth/stdin.rs
@@ -97,7 +97,11 @@ fn input_longer_than_max_pam_response_size_is_handled_gracefully() -> Result<()>
 
     let stderr = output.stderr();
     if sudo_test::is_original_sudo() {
-        assert_contains!(stderr, "sudo: 2 incorrect password attempts");
+        if cfg!(target_os = "freebsd") {
+            assert_contains!(stderr, "sudo: 1 incorrect password attempt");
+        } else {
+            assert_contains!(stderr, "sudo: 2 incorrect password attempts");
+        }
     } else {
         assert_contains!(stderr, "incorrect authentication attempt");
         assert_not_contains!(stderr, "panic");

--- a/test-framework/sudo-compliance-tests/src/sudo/passwd.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/passwd.rs
@@ -5,7 +5,14 @@ use crate::{Result, SUDOERS_NO_LECTURE, USERNAME};
 macro_rules! assert_snapshot {
     ($($tt:tt)*) => {
         insta::with_settings!({
-            filters => vec![(r"[[:xdigit:]]{12}", "[host]")],
+            filters => if cfg!(target_os = "linux") {
+                vec![(r"[[:xdigit:]]{12}", "[host]")]
+            } else {
+                vec![
+                    (r"[[:xdigit:]]{12}", "[host]"),
+                    ("Password:", "[sudo] password for ferris: "),
+                ]
+            },
             prepend_module_to_snapshot => false,
             snapshot_path => "../snapshots/passwd",
         }, {

--- a/test-framework/sudo-compliance-tests/src/sudo/password_retry.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/password_retry.rs
@@ -44,7 +44,7 @@ fn three_retries_allowed_by_default() -> Result<()> {
     };
     assert_contains!(output.stderr(), diagnostic);
 
-    let password_prompt = if sudo_test::is_original_sudo() {
+    let password_prompt = if sudo_test::is_original_sudo() && cfg!(target_os = "linux") {
         "password for ferris:"
     } else {
         "Password:"
@@ -88,7 +88,7 @@ Defaults passwd_tries=2"
     };
     assert_contains!(stderr, diagnostic);
 
-    let password_prompt = if sudo_test::is_original_sudo() {
+    let password_prompt = if sudo_test::is_original_sudo() && cfg!(target_os = "linux") {
         "password for ferris:"
     } else {
         "Password:"

--- a/test-framework/sudo-compliance-tests/src/sudo/password_retry.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/password_retry.rs
@@ -106,7 +106,10 @@ Defaults passwd_tries=2"
 
 // this is a PAM security feature
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "on FreeBSD retry is immediately allowed")]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "on FreeBSD retry is immediately allowed"
+)]
 fn retry_is_not_allowed_immediately() -> Result<()> {
     let script_path = "/tmp/script.sh";
     let env = Env(format!("{USERNAME} ALL=(ALL:ALL) ALL"))
@@ -143,7 +146,10 @@ fn time_password_retry(script_path: &str, env: Env) -> Result<u64> {
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "/etc/pam.d/common-auth doesn't exist on FreeBSD")]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "/etc/pam.d/common-auth doesn't exist on FreeBSD"
+)]
 fn can_control_retry_delay_using_pam() -> Result<()> {
     const NEW_DELAY_MICROS: u32 = 5_000_000;
 

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd.rs
@@ -1,14 +1,17 @@
 //! Test the Cmnd_Spec component of the user specification: <user> ALL=(ALL:ALL) <cmnd_spec>
 
 use pretty_assertions::assert_eq;
-use sudo_test::{Command, Env, TextFile, BIN_LS, BIN_TRUE};
+use sudo_test::{Command, Env, TextFile, BIN_LS, BIN_TRUE, ETC_SUDOERS};
 
 use crate::{Result, USERNAME};
 
 macro_rules! assert_snapshot {
     ($($tt:tt)*) => {
         insta::with_settings!({
-            filters => vec![(r"[[:xdigit:]]{12}", "[host]")],
+            filters => vec![
+                (r"[[:xdigit:]]{12}", "[host]"),
+                (ETC_SUDOERS, "/etc/sudoers"),
+            ],
             prepend_module_to_snapshot => false,
             snapshot_path => "../../snapshots/sudoers/cmnd",
         }, {

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
@@ -1,11 +1,15 @@
-use sudo_test::{Command, Env, BIN_LS, BIN_TRUE};
+use sudo_test::{Command, Env, BIN_LS, BIN_TRUE, ETC_SUDOERS};
 
 use crate::{Result, USERNAME};
 
 macro_rules! assert_snapshot {
     ($($tt:tt)*) => {
         insta::with_settings!({
-            filters => vec![(r"[[:xdigit:]]{12}", "[host]")],
+            filters => vec![
+                (r"[[:xdigit:]]{12}", "[host]"),
+                (ETC_SUDOERS, "/etc/sudoers"),
+                (BIN_LS, "/usr/bin/ls")
+            ],
             prepend_module_to_snapshot => false,
             snapshot_path => "../../snapshots/sudoers/cmnd_alias",
         }, {

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/env/keep.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/env/keep.rs
@@ -277,7 +277,7 @@ fn can_set_from_commandline() -> Result<()> {
             // ordering can be important (see below)
             "ALL ALL=(ALL:ALL) NOPASSWD: /usr/bin/env, ALL",
             "",
-        ]
+        ],
     ] {
         let env = Env(sudoers).build()?;
 

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/include.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/include.rs
@@ -211,7 +211,11 @@ fn ownership_check() -> Result<()> {
     assert!(!output.status().success());
     assert_eq!(Some(1), output.status().code());
     let diagnostic = if sudo_test::is_original_sudo() {
-        "sudo: /etc/sudoers2 is owned by uid 1000, should be 0"
+        if cfg!(target_os = "freebsd") {
+            "sudo: /etc/sudoers2 is owned by uid 1001, should be 0"
+        } else {
+            "sudo: /etc/sudoers2 is owned by uid 1000, should be 0"
+        }
     } else {
         "/etc/sudoers2 must be owned by root"
     };
@@ -231,7 +235,11 @@ fn ownership_check_not_fatal() -> Result<()> {
 
     assert!(output.status().success());
     let diagnostic = if sudo_test::is_original_sudo() {
-        "sudo: /etc/sudoers2 is owned by uid 1000, should be 0"
+        if cfg!(target_os = "freebsd") {
+            "sudo: /etc/sudoers2 is owned by uid 1001, should be 0"
+        } else {
+            "sudo: /etc/sudoers2 is owned by uid 1000, should be 0"
+        }
     } else {
         "/etc/sudoers2 must be owned by root"
     };

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/includedir.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/includedir.rs
@@ -158,7 +158,11 @@ fn ignores_and_warns_about_file_with_bad_ownership() -> Result<()> {
 
     assert!(output.status().success());
     let diagnostic = if sudo_test::is_original_sudo() {
-        format!("{ETC_DIR}/sudoers.d/a is owned by uid 1000, should be 0")
+        if cfg!(target_os = "freebsd") {
+            format!("{ETC_DIR}/sudoers.d/a is owned by uid 1001, should be 0")
+        } else {
+            format!("{ETC_DIR}/sudoers.d/a is owned by uid 1000, should be 0")
+        }
     } else {
         format!("{ETC_DIR}/sudoers.d/a must be owned by root")
     };
@@ -372,7 +376,11 @@ fn ignores_directory_with_bad_ownership() -> Result<()> {
     assert_eq!(Some(1), output.status().code());
     let diagnostics = if sudo_test::is_original_sudo() {
         [
-            format!("sudo: {ETC_DIR}/sudoers2.d is owned by uid 1000, should be 0"),
+            if cfg!(target_os = "freebsd") {
+                format!("sudo: {ETC_DIR}/sudoers2.d is owned by uid 1001, should be 0")
+            } else {
+                format!("sudo: {ETC_DIR}/sudoers2.d is owned by uid 1000, should be 0")
+            },
             "root is not in the sudoers file".to_owned(),
         ]
     } else {

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/run_as.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/run_as.rs
@@ -288,10 +288,12 @@ fn when_both_user_and_group_are_specified_then_as_that_group_is_allowed() -> Res
 
 #[test]
 fn runas_specifiers_distribute() -> Result<()> {
-    let env = Env(format!("ALL ALL=({USERNAME}:{GROUPNAME}) NOPASSWD: /tmp/foo, ALL"))
-        .user(USERNAME)
-        .group(GROUPNAME)
-        .build()?;
+    let env = Env(format!(
+        "ALL ALL=({USERNAME}:{GROUPNAME}) NOPASSWD: /tmp/foo, ALL"
+    ))
+    .user(USERNAME)
+    .group(GROUPNAME)
+    .build()?;
 
     Command::new("sudo")
         .args(["-g", GROUPNAME, "true"])

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
@@ -5,7 +5,14 @@ use crate::{Result, GROUPNAME, PASSWORD, SUDOERS_NO_LECTURE, USERNAME};
 macro_rules! assert_snapshot {
     ($($tt:tt)*) => {
         insta::with_settings!({
-            filters => vec![(r"[[:xdigit:]]{12}", "[host]")],
+            filters => if cfg!(target_os = "linux") {
+                vec![(r"[[:xdigit:]]{12}", "[host]")]
+            } else {
+                vec![
+                    (r"[[:xdigit:]]{12}", "[host]"),
+                    ("Password:", "[sudo] password for ferris: "),
+                ]
+            },
             prepend_module_to_snapshot => false,
             snapshot_path => "../../snapshots/sudoers/runas_alias",
         }, {

--- a/test-framework/sudo-compliance-tests/src/sudo/syslog.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/syslog.rs
@@ -22,7 +22,10 @@ fn sudo_logs_every_executed_command() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "Logging not really functional on FreeBSD even with og-sudo")]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "Logging not really functional on FreeBSD even with og-sudo"
+)]
 fn sudo_logs_every_failed_authentication_attempt() -> Result<()> {
     let env = Env(SUDOERS_USER_ALL_ALL).user(USERNAME).build()?;
     let rsyslog = Rsyslogd::start(&env)?;

--- a/test-framework/sudo-compliance-tests/src/visudo/what_now_prompt.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo/what_now_prompt.rs
@@ -1,4 +1,4 @@
-use sudo_test::{Command, Env, EnvNoImplicit, TextFile};
+use sudo_test::{is_original_sudo, Command, Env, EnvNoImplicit, TextFile};
 
 use crate::{
     visudo::{CHMOD_EXEC, DEFAULT_EDITOR, ETC_SUDOERS, LOGS_PATH},
@@ -46,7 +46,13 @@ fn on_e_re_edits() -> Result<()> {
 
     let num_times_called = lines.len();
     assert_eq!(2, num_times_called);
-    assert_eq!(lines[0], lines[1]);
+    if is_original_sudo() && cfg!(target_os = "freebsd") {
+        // On FreeBSD we have to name our editor vi, which seems to trigger a special case in sudo.
+        assert_eq!(lines[0], "-- /usr/local/etc/sudoers.tmp");
+        assert_eq!(lines[1], "+1 -- /usr/local/etc/sudoers.tmp");
+    } else {
+        assert_eq!(lines[0], lines[1]);
+    }
 
     Ok(())
 }

--- a/test-framework/sudo-test/src/docker.rs
+++ b/test-framework/sudo-test/src/docker.rs
@@ -62,8 +62,10 @@ impl Container {
         docker_run.args(["run", "--detach"]);
         // Disable network access for the containers. This removes the overhead
         // of setting up a new network namespace and associated firewall rule
-        // adjustments.
-        docker_run.arg("--net=none");
+        // adjustments. On FreeBSD it seems to introduce extra overhead however.
+        if cfg!(not(target_os = "freebsd")) {
+            docker_run.arg("--net=none");
+        }
         if let Some(hostname) = hostname {
             docker_run.args(["--hostname", hostname]);
         }

--- a/test-framework/sudo-test/src/lib.rs
+++ b/test-framework/sudo-test/src/lib.rs
@@ -74,7 +74,9 @@ pub fn Env(sudoers: impl Into<TextFile>) -> EnvBuilder {
     // Change a couple of flags to match the defaults of sudo-rs. In particular some sudo builds
     // have lecture or mailing enabled by default while sudo-rs doesn't implement those at all.
     // And fqdn breaks when --net=none passed to docker and sudo-rs doesn't implement it either.
-    sudoers.contents.insert_str(0, "Defaults !fqdn, !lecture, !mailerpath\n");
+    sudoers
+        .contents
+        .insert_str(0, "Defaults !fqdn, !lecture, !mailerpath\n");
     builder.file(ETC_SUDOERS, sudoers);
     if cfg!(target_os = "freebsd") {
         // Many tests expect the users group to exist, but FreeBSD doesn't actually use it.


### PR DESCRIPTION
The only remaining failure with og sudo is:

```
---- sudo::sudoers::secure_path::if_set_searches_program_in_secure_path stdout ----
unset PATH; cd /usr/bin; /usr/local/bin/sudo true
Error: "program failed with exit code 1. stderr:\nsudo: ignoring \"true\" found in '.'\nUse \"sudo ./true\" if this is the \"true\" you wish to run."
```