### PR TITLE
supply PAM file to make test work as intended

### DIFF
--- a/test-framework/sudo-compliance-tests/src/sudo/limits.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/limits.rs
@@ -2,8 +2,19 @@ use sudo_test::{Command, Env};
 
 use crate::{Result, SUDOERS_ALL_ALL_NOPASSWD, USERNAME};
 
+const SUDO_PAM_CONFIG: &str = "
+session    required   pam_limits.so
+
+@include common-auth
+@include common-account
+@include common-session-noninteractive
+";
+
 #[test]
-#[ignore = "gh644"]
+#[cfg_attr(
+     target_os = "freebsd",
+     ignore = "FreeBSD doesn't support /etc/security"
+ )]
 fn etc_security_limits_rules_apply_according_to_the_target_user() -> Result<()> {
     let target_user = "ghost";
     let original = "2048";
@@ -14,6 +25,7 @@ fn etc_security_limits_rules_apply_according_to_the_target_user() -> Result<()> 
     );
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
         .file("/etc/security/limits.d/50-test.conf", limits)
+        .file("/etc/pam.d/sudo", SUDO_PAM_CONFIG)
         .user(USERNAME)
         .user(target_user)
         .build()?;

--- a/test-framework/sudo-compliance-tests/src/sudo/limits.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/limits.rs
@@ -12,9 +12,9 @@ session    required   pam_limits.so
 
 #[test]
 #[cfg_attr(
-     target_os = "freebsd",
-     ignore = "FreeBSD doesn't support /etc/security"
- )]
+    target_os = "freebsd",
+    ignore = "FreeBSD doesn't support /etc/security"
+)]
 fn etc_security_limits_rules_apply_according_to_the_target_user() -> Result<()> {
     let target_user = "ghost";
     let original = "2048";


### PR DESCRIPTION
Related to #644; this removes one failing test from that issue and focuses that issue on `rlimit_core` (which we don't have on the roadmap currently)