### PR TITLE
make sudo service name for sudo-i configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,11 @@ pretty_assertions = "1.2.1"
 
 [features]
 default = []
+
+# when enabled, use "sudo-i" PAM service name for sudo -i
+pam-login = []
+
+# enable dev-logging (used for development only)
 dev = []
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ sudoers configuration exists at that location. For an explanation of the
 sudoers syntax you can look at the
 [original sudo man page](https://www.sudo.ws/docs/man/sudoers.man/).
 
+### Feature flags
+By default, sudo-rs will use the PAM service name `sudo`. On Debian and Fedora
+systems, it is customary that the name `sudo-i` is used when the `-i / --login`
+command line option is used. To get this behaviour, enable the `pam-login`
+feature when building:
+```
+cargo build --release --features pam-login
+```
+This feature is enabled on our pre-supplied binaries.
+
 [rustup]: https://rustup.rs/
 
 ## Differences from original sudo

--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -94,8 +94,7 @@ pub fn init_pam(
     auth_user: &str,
     requesting_user: &str,
 ) -> PamResult<PamContext<CLIConverser>> {
-    // FIXME make it configurable by the packager
-    let service_name = if is_login_shell && cfg!(target_os = "linux") {
+    let service_name = if is_login_shell && cfg!(feature = "pam-login") {
         "sudo-i"
     } else {
         "sudo"

--- a/test-framework/sudo-test/src/ours.linux.Dockerfile
+++ b/test-framework/sudo-test/src/ours.linux.Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
 RUN cargo search sudo
 WORKDIR /usr/src/sudo
 COPY . .
-RUN --mount=type=cache,target=/usr/src/sudo/target cargo build --locked --features="dev" --bins && mkdir -p build && cp target/debug/sudo build/sudo && cp target/debug/su build/su && cp target/debug/visudo build/visudo
+RUN --mount=type=cache,target=/usr/src/sudo/target cargo build --locked --features="dev,pam-login" --bins && mkdir -p build && cp target/debug/sudo build/sudo && cp target/debug/su build/su && cp target/debug/visudo build/visudo
 # set setuid on install
 RUN install -m 4755 build/sudo /usr/bin/sudo && \
     install -m 4755 build/su /usr/bin/su && \

--- a/util/build-release.sh
+++ b/util/build-release.sh
@@ -14,7 +14,7 @@ DATE=$(grep -m1 '^##' "$PROJECT_DIR"/CHANGELOG.md | grep -o '[0-9]\{4\}-[0-9]\{2
 # Build binaries
 docker build --pull --tag "$BUILDER_IMAGE_TAG" --file "$SCRIPT_DIR/Dockerfile-release" "$SCRIPT_DIR"
 docker run --rm --user "$(id -u):$(id -g)" -v "$PROJECT_DIR:/build" -w "/build" "$BUILDER_IMAGE_TAG" cargo clean
-docker run --rm --user "$(id -u):$(id -g)" -v "$PROJECT_DIR:/build" -w "/build" "$BUILDER_IMAGE_TAG" cargo build --release
+docker run --rm --user "$(id -u):$(id -g)" -v "$PROJECT_DIR:/build" -w "/build" "$BUILDER_IMAGE_TAG" cargo build --release --features pam-login
 
 # Generate man pages
 "$PROJECT_DIR/util/generate-docs.sh"


### PR DESCRIPTION
Closes #903 

The default after this PR is that "sudo" is the default service name; this is the same for Todd Miller's sudo.

For packagers, this would have the following changes:

- for Arch Linux, no patch is necessary anymore
- Fedora and Debian would need to add `--feature pam-login` when building