### PR TITLE
In exec_command(), use yield instead of sleep to wait for parent

### DIFF
--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -205,7 +205,7 @@ fn exec_command(
     // foreground.
     if foreground {
         while !pty_follower.tcgetpgrp().is_ok_and(|pid| pid == command_pid) {
-            std::thread::sleep(std::time::Duration::from_micros(1));
+            std::thread::yield_now();
         }
     }
 


### PR DESCRIPTION
On some systems, a short sleep does not always yield the CPU. An explicit yield prevents us from consuming CPU while we wait for the parent to grant the monitor the controlling terminal. Fixes issue #1013.