### PR TITLE
Add key=value matching for env_keep and env_check

### DIFF
--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -704,10 +704,11 @@ impl Parse for defaults::SettingsModifier {
             if stream.eat_char('"') {
                 let mut result = Vec::new();
                 while let Some(EnvVar(name)) = try_nonterminal(stream)? {
-                    result.push(name);
                     if is_syntax('=', stream)? {
-                        let EnvVar(_) = expect_nonterminal(stream)?;
-                        unrecoverable!(stream, "values in environment variables not yet supported")
+                        let StringParameter(value) = expect_nonterminal(stream)?;
+                        result.push(name + "=" + &value);
+                    } else {
+                        result.push(name);
                     }
                     if result.len() > Identifier::LIMIT {
                         unrecoverable!(stream, "environment variable list too long")

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/env/check.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/env/check.rs
@@ -69,7 +69,6 @@ fn if_value_starts_with_parentheses_variable_is_removed() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh344"]
 fn key_value_matches() -> Result<()> {
     super::key_value_matches(ENV_LIST)
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/env/keep.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/env/keep.rs
@@ -65,7 +65,6 @@ fn if_value_starts_with_parentheses_variable_is_removed() -> Result<()> {
 }
 
 #[test]
-#[ignore = "gh344"]
 fn key_value_matches() -> Result<()> {
     super::key_value_matches(ENV_LIST)
 }


### PR DESCRIPTION
Note: this is a bit "Stringly typed", but the OS environment is that anyway (it also splits on the first occurence of "="), so in this case KISS prevails.

Of course whether or not the `needle` needs to be a tuple in this function definition is a matter of taste, but it saves one from having to distinguish "key1" and "key2" in the `in_table` function.