### PR TITLE
Touchups and fixes for `--prompt` / `SUDO_PROMPT`

### DIFF
--- a/docs/man/sudo.8.md
+++ b/docs/man/sudo.8.md
@@ -72,7 +72,9 @@ even if that process runs in its own pseudo terminal.
 :   Use a custom authentication prompt with optional escape sequences. The
     following percent (‘%’) escape sequences are supported:
 
-         %h  expanded to the local host name
+         %H  expanded to the local host name
+
+         %h  expanded to the local host name without the domain name
 
          %p  expanded to the name of the user whose password is being requested
              (this respects the rootpw, targetpw flags)

--- a/docs/man/sudo.8.md
+++ b/docs/man/sudo.8.md
@@ -86,7 +86,8 @@ even if that process runs in its own pseudo terminal.
 
          %%  two consecutive ‘%’ characters are collapsed into a single ‘%’ character
 
-    The custom prompt will override the default prompt, but not suppress the the prompt provided by PAM. The only exception is if the requested *prompt* is empty (`""`)
+    The custom prompt will override the default prompt or the one specified by the SUDO_PROMPT enviroment variable.
+    No *prompt* will suppress the the prompt provided by PAM, unless the requested *prompt* is empty (`""`)
 
 `-S`, `--stdin`
 :   Read from standard input instead of using the terminal device.

--- a/docs/man/sudo.8.md
+++ b/docs/man/sudo.8.md
@@ -68,6 +68,24 @@ even if that process runs in its own pseudo terminal.
 :   Avoid prompting the user for input of any kind. If any input is required for
     the *command* to run, sudo-rs will display an error message and exit.
 
+`p`, `--prompt`=*prompt*
+:   Use a custom authentication prompt with optional escape sequences. The
+    following percent (‘%’) escape sequences are supported:
+
+         %h  expanded to the local host name
+
+         %p  expanded to the name of the user whose password is being requested
+             (this respects the rootpw, targetpw flags)
+
+         %U  expanded to the login name of the user the command will be run as
+             (defaults to root unless the -u option is also specified)
+
+         %u  expanded to the invoking user's login name
+
+         %%  two consecutive ‘%’ characters are collapsed into a single ‘%’ character
+
+    The custom prompt will override the default prompt, but not suppress the the prompt provided by PAM. The only exception is if the requested *prompt* is empty (`""`)
+
 `-S`, `--stdin`
 :   Read from standard input instead of using the terminal device.
 

--- a/src/pam/mod.rs
+++ b/src/pam/mod.rs
@@ -103,6 +103,7 @@ impl PamContext {
     }
 
     pub fn set_auth_prompt(&mut self, prompt: Option<String>) {
+        // SAFETY: self.data_ptr was created by Box::into_raw
         unsafe {
             (*self.data_ptr).auth_prompt = prompt;
         }

--- a/src/pam/mod.rs
+++ b/src/pam/mod.rs
@@ -69,7 +69,10 @@ impl PamContext {
             converser,
             converser_name: converser_name.to_owned(),
             no_interact,
-            auth_prompt: Some("authenticate".to_owned()),
+            auth_prompt: std::env::var("SUDO_PROMPT")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .or(Some("authenticate".to_owned())),
             panicked: false,
         }));
 

--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -60,7 +60,9 @@ pub(super) fn init_pam(
                     continue;
                 }
                 match chars.next() {
-                    Some('H' | 'h') => final_prompt.push_str(hostname),
+                    Some('H') => final_prompt.push_str(hostname),
+                    Some('h') => final_prompt
+                        .push_str(hostname.split_once('.').map(|x| x.0).unwrap_or(hostname)),
                     Some('p') => final_prompt.push_str(auth_user),
                     Some('U') => final_prompt.push_str(target_user),
                     Some('u') => final_prompt.push_str(requesting_user),

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_prompt.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_prompt.rs
@@ -51,14 +51,14 @@ fn empty_prompt_disables_prompt() -> Result<()> {
 #[test]
 fn show_host_and_users() -> Result<()> {
     let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) ALL"))
-        .hostname("this_host")
+        .hostname("this_host.domain")
         .user(User(USERNAME).password(PASSWORD))
         .build()?;
 
     test_prompt(
         &env,
         "on %H/%h: %u %U",
-        "on this_host/this_host: ferris root",
+        "on this_host.domain/this_host: ferris root",
     )
 }
 


### PR DESCRIPTION
This was missed in the PR #1003

Also, %H and %h can be treated differently quite easily. Also adds `SUDO_PROMPT`.