### PR TITLE
Fix the DEFAULT_PATH value

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,4 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     println!("cargo:rustc-link-lib=pam");
-
-    println!("cargo:rustc-env=DEFAULT_PATH=/usr/bin:/bin:/usr/sbin:/sbin");
 }

--- a/build.rs
+++ b/build.rs
@@ -32,5 +32,5 @@ fn main() {
 
     println!("cargo:rustc-link-lib=pam");
 
-    println!("cargo:rustc-env=DEFAULT_PATH=\"/bin/:/usr/bin/:/usr/local/bin:/sbin/:/usr/sbin\"")
+    println!("cargo:rustc-env=DEFAULT_PATH=/usr/bin:/bin:/usr/sbin:/sbin");
 }

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -259,7 +259,7 @@ impl Sudoers {
                     }
                     let path = resolve_path(
                         path,
-                        &std::env::var("PATH").unwrap_or(env!("DEFAULT_PATH").to_string()),
+                        &std::env::var("PATH").unwrap_or(env!("SUDO_PATH_DEFAULT").to_string()),
                     );
                     if let Some(path) = path {
                         return Some(path);


### PR DESCRIPTION
`cargo:rustc-env` doesn't require quotes, so any quotes end up getting set as part of the env var. Also change the contents of the default path to match `_PATH_STDPATH` in og sudo and glibc.