### PR TITLE
Fix man page titles in pandoc syntax

### DIFF
--- a/docs/man/su.1.md
+++ b/docs/man/su.1.md
@@ -1,6 +1,4 @@
----
-title: SU(1) sudo-rs 0.2.4 | sudo-rs
----
+% SU(1) sudo-rs 0.2.4 | sudo-rs
 
 # NAME
 

--- a/docs/man/sudo.8.md
+++ b/docs/man/sudo.8.md
@@ -1,6 +1,4 @@
----
-title: SUDO(8) sudo-rs 0.2.4 | sudo-rs
----
+% SUDO(8) sudo-rs 0.2.4 | sudo-rs
 
 # NAME
 

--- a/docs/man/sudoers.5.md
+++ b/docs/man/sudoers.5.md
@@ -1,6 +1,4 @@
-<!-- ---
-title: SUDOERS(5) sudo-rs 0.2.4 | sudo-rs
---- -->
+% SUDOERS(5) sudo-rs 0.2.4 | sudo-rs
 
 # NAME
 
@@ -353,7 +351,7 @@ sudo's behavior can be modified by Default_Entry lines, as explained earlier.  A
   If set, sudo will prompt for the root password instead of the password of the invoking user when running a command or editing a file.  This flag is off by default.
 
 * use_pty
-  
+
   If set, and sudo is running in a terminal, the command will be run in a pseudo-terminal (even if no I/O logging is being done).  If the sudo process is not attached to a terminal, use_pty has no effect.
 
   A malicious program run under sudo may be capable of injecting commands into the user's terminal or running a background process that retains access to the user's terminal device even after the main program has finished executing.  By running the command in a separate pseudo-terminal, this attack is no longer possible.  This flag is on by default.

--- a/docs/man/visudo.8.md
+++ b/docs/man/visudo.8.md
@@ -1,6 +1,4 @@
----
-title: VISUDO(8) sudo-rs 0.2.4 | sudo-rs
----
+% VISUDO(8) sudo-rs 0.2.4 | sudo-rs
 
 # NAME
 


### PR DESCRIPTION
Hi, I am the package maintainer for `sudo-rs` for Arch Linux. I noticed that the man pages do not have the correct titles when compiled with Arch's pandoc. I get almost the same results using the pandoc docker image the docs script uses, so I'm not sure it ever worked.

I updated the man page metadata based on [the example in the pandoc docs](https://pandoc.org/MANUAL.html#extension-pandoc_title_block), which appears to work both with the docker pandoc your scripts use as well as Arch's pandoc package.

Thanks for maintaining this software.