### PR TITLE
Prevent accidental lockouts

### DIFF
--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -278,24 +278,7 @@ fn edit_sudoers_file(
                 )
             })?;
 
-        if errors.is_empty() {
-            if sudo_visudo_is_allowed(sudoers, &host_name) == Some(false) {
-                writeln!(
-                    stderr,
-                    "It looks like you have removed your ability to run 'sudo visudo' again.\n"
-                )?;
-                match ask_response(
-                    b"What now? (p)roceed anyway / e(x)it without saving / (e)dit again: ",
-                    b"xep",
-                )? {
-                    b'x' => return Ok(()),
-                    b'p' => {}
-                    _ => continue,
-                }
-            }
-
-            break;
-        } else {
+        let true = errors.is_empty() else {
             writeln!(stderr, "The provided sudoers file format is not recognized or contains syntax errors. Please review:\n")?;
 
             for crate::sudoers::Error {
@@ -314,7 +297,24 @@ fn edit_sudoers_file(
                 b'x' => return Ok(()),
                 _ => continue,
             }
+        };
+
+        if sudo_visudo_is_allowed(sudoers, &host_name) == Some(false) {
+            writeln!(
+                stderr,
+                "It looks like you have removed your ability to run 'sudo visudo' again.\n"
+            )?;
+            match ask_response(
+                b"What now? (p)roceed anyway / e(x)it without saving / (e)dit again: ",
+                b"xep",
+            )? {
+                b'x' => return Ok(()),
+                b'p' => {}
+                _ => continue,
+            }
         }
+
+        break;
     }
 
     let tmp_contents = std::fs::read(tmp_path)?;

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -305,11 +305,11 @@ fn edit_sudoers_file(
                 "It looks like you have removed your ability to run 'sudo visudo' again.\n"
             )?;
             match ask_response(
-                b"What now? (p)roceed anyway / e(x)it without saving / (e)dit again: ",
-                b"xep",
+                b"What now? e(x)it without saving / (e)dit again / lock me out and (S)ave: ",
+                b"xeS",
             )? {
                 b'x' => return Ok(()),
-                b'p' => {}
+                b'S' => {}
                 _ => continue,
             }
         }

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -260,7 +260,7 @@ fn edit_sudoers_file(
         None => editor_path_fallback()?,
     };
 
-    'visudo: loop {
+    loop {
         Command::new(&editor_path)
             .arg("--")
             .arg(tmp_path)
@@ -289,11 +289,11 @@ fn edit_sudoers_file(
                     b"xep",
                 )? {
                     b'x' => return Ok(()),
-                    b'p' => break 'visudo,
-                    _ => continue 'visudo,
+                    b'p' => break,
+                    _ => continue,
                 }
             }
-            break 'visudo;
+            break;
         }
 
         writeln!(stderr, "The provided sudoers file format is not recognized or contains syntax errors. Please review:\n")?;
@@ -312,7 +312,7 @@ fn edit_sudoers_file(
 
         match ask_response(b"What now? e(x)it without saving / (e)dit again: ", b"xe")? {
             b'x' => return Ok(()),
-            _ => continue 'visudo,
+            _ => continue,
         }
     }
 

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -289,30 +289,31 @@ fn edit_sudoers_file(
                     b"xep",
                 )? {
                     b'x' => return Ok(()),
-                    b'p' => break,
+                    b'p' => {}
                     _ => continue,
                 }
             }
+
             break;
-        }
+        } else {
+            writeln!(stderr, "The provided sudoers file format is not recognized or contains syntax errors. Please review:\n")?;
 
-        writeln!(stderr, "The provided sudoers file format is not recognized or contains syntax errors. Please review:\n")?;
+            for crate::sudoers::Error {
+                message,
+                source,
+                location,
+            } in errors
+            {
+                let path = source.as_deref().unwrap_or(sudoers_path);
+                diagnostic::diagnostic!("syntax error: {message}", path @ location);
+            }
 
-        for crate::sudoers::Error {
-            message,
-            source,
-            location,
-        } in errors
-        {
-            let path = source.as_deref().unwrap_or(sudoers_path);
-            diagnostic::diagnostic!("syntax error: {message}", path @ location);
-        }
+            writeln!(stderr)?;
 
-        writeln!(stderr)?;
-
-        match ask_response(b"What now? e(x)it without saving / (e)dit again: ", b"xe")? {
-            b'x' => return Ok(()),
-            _ => continue,
+            match ask_response(b"What now? e(x)it without saving / (e)dit again: ", b"xe")? {
+                b'x' => return Ok(()),
+                _ => continue,
+            }
         }
     }
 

--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -278,7 +278,7 @@ fn edit_sudoers_file(
                 )
             })?;
 
-        let true = errors.is_empty() else {
+        if !errors.is_empty() {
             writeln!(stderr, "The provided sudoers file format is not recognized or contains syntax errors. Please review:\n")?;
 
             for crate::sudoers::Error {
@@ -297,24 +297,24 @@ fn edit_sudoers_file(
                 b'x' => return Ok(()),
                 _ => continue,
             }
-        };
-
-        if sudo_visudo_is_allowed(sudoers, &host_name) == Some(false) {
-            writeln!(
-                stderr,
-                "It looks like you have removed your ability to run 'sudo visudo' again.\n"
-            )?;
-            match ask_response(
-                b"What now? e(x)it without saving / (e)dit again / lock me out and (S)ave: ",
-                b"xeS",
-            )? {
-                b'x' => return Ok(()),
-                b'S' => {}
-                _ => continue,
+        } else {
+            if sudo_visudo_is_allowed(sudoers, &host_name) == Some(false) {
+                writeln!(
+                    stderr,
+                    "It looks like you have removed your ability to run 'sudo visudo' again.\n"
+                )?;
+                match ask_response(
+                    b"What now? e(x)it without saving / (e)dit again / lock me out and (S)ave: ",
+                    b"xeS",
+                )? {
+                    b'x' => return Ok(()),
+                    b'S' => {}
+                    _ => continue,
+                }
             }
-        }
 
-        break;
+            break;
+        }
     }
 
     let tmp_contents = std::fs::read(tmp_path)?;


### PR DESCRIPTION
Closes #1044 

Also fixes a bug in `visudo` where it would not consume the newline that was entered in a prompt.

I've also tried to reformat the "redo until the sudoers file is acceptable" loop to make the control flow a little more clear.

Can be reviewed commit-by-commit.

I expect a6ccf9f to be a controversial commit and I can live without it.