### PR TITLE
Fix potential panic with misconfiguration

### DIFF
--- a/docs/man/sudoers.5.md
+++ b/docs/man/sudoers.5.md
@@ -368,7 +368,7 @@ sudo's behavior can be modified by Default_Entry lines, as explained earlier.  A
 
 * timestamp_timeout
 
-  Number of minutes that can elapse before sudo will ask for a passwd again.  The timeout may include a fractional component if minute granularity is insufficient, for example 2.5.  The default is 15.  Set this to 0 to always prompt for a password.  If set to a value less than 0 the user's timestamp will not expire until the system is rebooted.  This can be used to allow users to create or delete their own timestamps via “sudo -v” and “sudo -k” respectively.
+  Number of minutes that can elapse before sudo will ask for a passwd again.  The timeout may include a fractional component if minute granularity is insufficient, for example 2.5.  The default is 15.  Set this to 0 to always prompt for a password.
 
 ## Strings that can be used in a boolean context:
 

--- a/src/defaults/mod.rs
+++ b/src/defaults/mod.rs
@@ -63,7 +63,7 @@ defaults! {
 /// passwd_timeout and timestamp_timeout.
 fn fractional_minutes(input: &str) -> Option<i64> {
     if let Some((integral, fractional)) = input.split_once('.') {
-        // - 'input' is maximally 18 chacters, making fractional.len() at most 17;
+        // - 'input' is maximally 18 characters, making fractional.len() at most 17;
         //   1e17 < 2**63, so the definition of 'shift' will not overflow.
         // - for the same reason, if both parses in the definition of 'seconds' succeed,
         //   we will have constructed an integer < 1e17.

--- a/src/defaults/mod.rs
+++ b/src/defaults/mod.rs
@@ -63,9 +63,11 @@ defaults! {
 /// passwd_timeout and timestamp_timeout.
 fn fractional_minutes(input: &str) -> Option<i64> {
     if input.contains('.') {
+        //math note: the token length is capped at 18 characters, so the max value parsed is 1e17;
+        //1e17 * 60 still fits in an i64, so the 'as' can never cause truncation
         Some((input.parse::<f64>().ok()? * 60.0).floor() as i64)
     } else {
-        Some(input.parse::<i64>().ok()? * 60)
+        input.parse::<i64>().ok()?.checked_mul(60)
     }
 }
 

--- a/src/defaults/mod.rs
+++ b/src/defaults/mod.rs
@@ -63,10 +63,15 @@ defaults! {
 /// passwd_timeout and timestamp_timeout.
 fn fractional_minutes(input: &str) -> Option<i64> {
     if let Some((integral, fractional)) = input.split_once('.') {
+        // - 'input' is maximally 18 chacters, making fractional.len() at most 17;
+        //   1e17 < 2**63, so the definition of 'shift' will not overflow.
+        // - for the same reason, if both parses in the definition of 'seconds' succeed,
+        //   we will have constructed an integer < 1e17.
+        //-  1e17 * 60 = 6e18 < 9e18 < 2**63, so the final line also will not overflow
         let shift = 10i64.pow(fractional.len().try_into().ok()?);
         let seconds = integral.parse::<i64>().ok()? * shift + fractional.parse::<i64>().ok()?;
 
-        Some(seconds.checked_mul(60)? / shift)
+        Some(seconds * 60 / shift)
     } else {
         input.parse::<i64>().ok()?.checked_mul(60)
     }

--- a/src/sudoers/ast_names.rs
+++ b/src/sudoers/ast_names.rs
@@ -17,7 +17,7 @@ mod names {
     }
 
     impl UserFriendly for tokens::Numeric {
-        const DESCRIPTION: &'static str = "number";
+        const DESCRIPTION: &'static str = "nonnegative number";
     }
 
     impl UserFriendly for Identifier {


### PR DESCRIPTION
Closing #1032 (by adding a more meaningful error message and removing the mention of negative timestamps from the documentation).

Closing #1048 (by using `checked_mul` 😊, and adding a note that the `as` conversion from f64's is fine)

