### PR TITLE
Add missing `//SAFETY` comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,6 @@ opt-level = "s"
 
 [lints.rust]
 unsafe_op_in_unsafe_fn = { level = "deny" }
+
+[lints.clippy]
+undocumented_unsafe_blocks = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 msrv = "1.70"
+check-private-items = true

--- a/src/cutils/mod.rs
+++ b/src/cutils/mod.rs
@@ -96,6 +96,7 @@ pub fn safe_isatty(fildes: BorrowedFd) -> bool {
     }
 }
 
+#[allow(clippy::undocumented_unsafe_blocks)]
 #[cfg(test)]
 mod test {
     use super::{os_string_from_ptr, string_from_ptr};

--- a/src/pam/converse.rs
+++ b/src/pam/converse.rs
@@ -244,6 +244,7 @@ pub(super) unsafe extern "C" fn converse<C: Converser>(
     res.as_int()
 }
 
+#[allow(clippy::undocumented_unsafe_blocks)]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/pam/securemem.rs
+++ b/src/pam/securemem.rs
@@ -94,6 +94,7 @@ fn wipe_memory(memory: &mut [u8]) {
     atomic::compiler_fence(atomic::Ordering::SeqCst);
 }
 
+#[allow(clippy::undocumented_unsafe_blocks)]
 #[cfg(test)]
 mod test {
     use super::PamBuffer;

--- a/src/system/file/tmpdir.rs
+++ b/src/system/file/tmpdir.rs
@@ -6,12 +6,15 @@ use std::path::PathBuf;
 pub(crate) fn create_temporary_dir() -> io::Result<PathBuf> {
     let template = cstr!("/tmp/sudoers-XXXXXX").to_owned();
 
+    // SAFETY: mkdtemp is passed a valid null-terminated C string
     let ptr = unsafe { libc::mkdtemp(template.into_raw()) };
 
     if ptr.is_null() {
         return Err(io::Error::last_os_error());
     }
 
+    // SAFETY: ptr is the same pointer produced by into_raw() above, and it
+    // is still pointing to a zero-terminated C string
     let path = OsString::from_vec(unsafe { CString::from_raw(ptr) }.into_bytes()).into();
 
     Ok(path)

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -904,6 +904,7 @@ pub(crate) const ROOT_GROUP_NAME: &str = "root";
 #[cfg(all(test, not(target_os = "linux")))]
 pub(crate) const ROOT_GROUP_NAME: &str = "wheel";
 
+#[allow(clippy::undocumented_unsafe_blocks)]
 #[cfg(test)]
 mod tests {
     use std::{

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -229,6 +229,7 @@ impl fmt::Display for TermSize {
     }
 }
 
+#[allow(clippy::undocumented_unsafe_blocks)]
 #[cfg(test)]
 mod tests {
     use std::{


### PR DESCRIPTION
The absence of these slipped through while reviewing this.