### PR TITLE
Rewrite `.fold()` into something that is immediately readable

### DIFF
--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -180,14 +180,11 @@ impl Sudoers {
             || (request.target_user == invoking_user
                 && in_group(invoking_user, request.target_group));
 
-        let mut specs = self
+        let mut flags = self
             .matching_user_specs(invoking_user, hostname)
             .flatten()
             .map(|(_, (tag, _))| tag)
-            .fuse();
-
-        let mut flags = specs.next();
-        flags = specs.find(|tag| !tag.needs_passwd()).or(flags);
+            .max_by_key(|tag| !tag.needs_passwd());
 
         if let Some(tag) = flags.as_mut() {
             if skip_passwd {
@@ -208,14 +205,11 @@ impl Sudoers {
         // exception: if user is root, NOPASSWD is implied
         let skip_passwd = invoking_user.is_root();
 
-        let mut specs = self
+        let mut flags = self
             .matching_user_specs(invoking_user, hostname)
             .flatten()
             .map(|(_, (tag, _))| tag)
-            .fuse();
-
-        let mut flags = specs.next();
-        flags = specs.find(|tag| tag.needs_passwd()).or(flags);
+            .max_by_key(|tag| tag.needs_passwd());
 
         if let Some(tag) = flags.as_mut() {
             if skip_passwd {

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -183,10 +183,11 @@ impl Sudoers {
         let mut specs = self
             .matching_user_specs(invoking_user, hostname)
             .flatten()
+            .map(|(_, (tag, _))| tag)
             .fuse();
 
-        let mut flags = specs.next().map(|(_, (tag, _))| tag);
-        for (_, (tag, _)) in specs {
+        let mut flags = specs.next();
+        for tag in specs {
             if !tag.needs_passwd() {
                 flags = Some(tag)
             }
@@ -214,10 +215,11 @@ impl Sudoers {
         let mut specs = self
             .matching_user_specs(invoking_user, hostname)
             .flatten()
+            .map(|(_, (tag, _))| tag)
             .fuse();
 
-        let mut flags = specs.next().map(|(_, (tag, _))| tag);
-        for (_, (tag, _)) in specs {
+        let mut flags = specs.next();
+        for tag in specs {
             if tag.needs_passwd() {
                 flags = Some(tag)
             }

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -187,11 +187,7 @@ impl Sudoers {
             .fuse();
 
         let mut flags = specs.next();
-        for tag in specs {
-            if !tag.needs_passwd() {
-                flags = Some(tag)
-            }
-        }
+        flags = specs.find(|tag| !tag.needs_passwd()).or(flags);
 
         if let Some(tag) = flags.as_mut() {
             if skip_passwd {
@@ -219,11 +215,7 @@ impl Sudoers {
             .fuse();
 
         let mut flags = specs.next();
-        for tag in specs {
-            if tag.needs_passwd() {
-                flags = Some(tag)
-            }
-        }
+        flags = specs.find(|tag| tag.needs_passwd()).or(flags);
 
         if let Some(tag) = flags.as_mut() {
             if skip_passwd {

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -187,11 +187,8 @@ impl Sudoers {
 
         let mut flags = specs.next().map(|(_, (tag, _))| tag);
         for (_, (tag, _)) in specs {
-            flags = if let Some(outcome) = flags {
-                Some(if outcome.needs_passwd() { tag } else { outcome })
-            } else {
-                //unreachable
-                Some(tag)
+            if flags.as_ref().unwrap().needs_passwd() {
+                flags = Some(tag)
             }
         }
 
@@ -221,11 +218,8 @@ impl Sudoers {
 
         let mut flags = specs.next().map(|(_, (tag, _))| tag);
         for (_, (tag, _)) in specs {
-            flags = if let Some(outcome) = flags {
-                Some(if tag.needs_passwd() { tag } else { outcome })
-            } else {
-                //unreachable
-                Some(tag)
+            if tag.needs_passwd() {
+                flags = Some(tag)
             }
         }
 

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -180,16 +180,14 @@ impl Sudoers {
             || (request.target_user == invoking_user
                 && in_group(invoking_user, request.target_group));
 
-        let mut flags = self
-            .matching_user_specs(invoking_user, hostname)
-            .flatten()
-            .fold(None::<Tag>, |outcome, (_, (tag, _))| {
-                if let Some(outcome) = outcome {
-                    Some(if outcome.needs_passwd() { tag } else { outcome })
-                } else {
-                    Some(tag)
-                }
-            });
+        let mut flags = None::<Tag>;
+        for (_, (tag, _)) in self.matching_user_specs(invoking_user, hostname).flatten() {
+            flags = if let Some(outcome) = flags {
+                Some(if outcome.needs_passwd() { tag } else { outcome })
+            } else {
+                Some(tag)
+            }
+        }
 
         if let Some(tag) = flags.as_mut() {
             if skip_passwd {
@@ -210,16 +208,14 @@ impl Sudoers {
         // exception: if user is root, NOPASSWD is implied
         let skip_passwd = invoking_user.is_root();
 
-        let mut flags = self
-            .matching_user_specs(invoking_user, hostname)
-            .flatten()
-            .fold(None::<Tag>, |outcome, (_, (tag, _))| {
-                if let Some(outcome) = outcome {
-                    Some(if tag.needs_passwd() { tag } else { outcome })
-                } else {
-                    Some(tag)
-                }
-            });
+        let mut flags = None::<Tag>;
+        for (_, (tag, _)) in self.matching_user_specs(invoking_user, hostname).flatten() {
+            flags = if let Some(outcome) = flags {
+                Some(if tag.needs_passwd() { tag } else { outcome })
+            } else {
+                Some(tag)
+            }
+        }
 
         if let Some(tag) = flags.as_mut() {
             if skip_passwd {

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -187,7 +187,7 @@ impl Sudoers {
 
         let mut flags = specs.next().map(|(_, (tag, _))| tag);
         for (_, (tag, _)) in specs {
-            if flags.as_ref().unwrap().needs_passwd() {
+            if !tag.needs_passwd() {
                 flags = Some(tag)
             }
         }

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -185,9 +185,7 @@ impl Sudoers {
             .flatten()
             .fold(None::<Tag>, |outcome, (_, (tag, _))| {
                 if let Some(outcome) = outcome {
-                    let new_outcome = if outcome.needs_passwd() { tag } else { outcome };
-
-                    Some(new_outcome)
+                    Some(if outcome.needs_passwd() { tag } else { outcome })
                 } else {
                     Some(tag)
                 }
@@ -217,9 +215,7 @@ impl Sudoers {
             .flatten()
             .fold(None::<Tag>, |outcome, (_, (tag, _))| {
                 if let Some(outcome) = outcome {
-                    let new_outcome = if tag.needs_passwd() { tag } else { outcome };
-
-                    Some(new_outcome)
+                    Some(if tag.needs_passwd() { tag } else { outcome })
                 } else {
                     Some(tag)
                 }


### PR DESCRIPTION
Based on #1036, rewriting the `.fold()`.

Commits are done step-by-step to show that the rewrite behaves equivalently (except for 75554ac, but that is fixed in the final beautiful result).

You can review this commit by commit (this will show you my "I'm not trying to be clever" careful editing of the code), but you can also just look at the final result which will be very easy to review.

Obviously we're going to squash these commits.

A hearty thanks to @cikzh for rubber ducking.