### PR TITLE
Fix username escaping

### DIFF
--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -570,7 +570,7 @@ impl Parse for Sudo {
 fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
     fn get_path(stream: &mut CharStream, key_pos: (usize, usize)) -> Parsed<(String, Span)> {
         let path = if stream.eat_char('"') {
-            let QuotedInclude(path) = expect_nonterminal(stream)?;
+            let QuotedIncludePath(path) = expect_nonterminal(stream)?;
             expect_syntax('"', stream)?;
             path
         } else {
@@ -744,7 +744,7 @@ impl Parse for defaults::SettingsModifier {
         // Parse a text parameter
         let text_item = |stream: &mut CharStream| {
             if stream.eat_char('"') {
-                let QuotedText(text) = expect_nonterminal(stream)?;
+                let QuotedStringParameter(text) = expect_nonterminal(stream)?;
                 expect_syntax('"', stream)?;
                 make(text)
             } else {

--- a/src/sudoers/ast_names.rs
+++ b/src/sudoers/ast_names.rs
@@ -65,6 +65,9 @@ mod names {
     impl UserFriendly for UserSpecifier {
         const DESCRIPTION: &'static str = "user";
     }
+    impl UserFriendly for tokens::Username {
+        const DESCRIPTION: &'static str = "user";
+    }
 
     impl UserFriendly for tokens::Hostname {
         const DESCRIPTION: &'static str = "host name";
@@ -112,6 +115,10 @@ mod names {
 
     impl<T> UserFriendly for Def<T> {
         const DESCRIPTION: &'static str = "alias definition";
+    }
+
+    impl<T: UserFriendly> UserFriendly for tokens::Unquoted<T> {
+        const DESCRIPTION: &'static str = T::DESCRIPTION;
     }
 }
 

--- a/src/sudoers/ast_names.rs
+++ b/src/sudoers/ast_names.rs
@@ -70,16 +70,16 @@ mod names {
         const DESCRIPTION: &'static str = "host name";
     }
 
-    impl UserFriendly for tokens::QuotedText {
+    impl UserFriendly for tokens::QuotedStringParameter {
         const DESCRIPTION: &'static str = "non-empty string";
     }
 
-    impl UserFriendly for tokens::QuotedInclude {
+    impl UserFriendly for tokens::QuotedIncludePath {
         const DESCRIPTION: &'static str = "non-empty string";
     }
 
     impl UserFriendly for tokens::StringParameter {
-        const DESCRIPTION: &'static str = tokens::QuotedText::DESCRIPTION;
+        const DESCRIPTION: &'static str = tokens::QuotedStringParameter::DESCRIPTION;
     }
 
     impl UserFriendly for tokens::IncludePath {

--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -231,6 +231,10 @@ impl<T: Token> Parse for T {
                     Ok(c)
                 } else if pred(ESCAPE) {
                     Ok(ESCAPE)
+                } else if stream.eat_char('\n') {
+                    // we've just consumed some whitespace, we should end
+                    // parsing the token but not abort it
+                    reject()
                 } else {
                     unrecoverable!(stream, "illegal escape sequence")
                 }

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -245,6 +245,11 @@ fn permission_test() {
     // test the less-intuitive "substition-like" alias mechanism
     FAIL!(["User_Alias FOO=!user", "ALL, FOO ALL=ALL"], "user" => root(), "vm"; "/bin/ls");
     pass!(["User_Alias FOO=!user", "!FOO ALL=ALL"], "user" => root(), "vm"; "/bin/ls");
+
+    // quoting
+    pass!(["a\\,b ALL=ALL"], "a,b" => request! { root, root }, "server"; "/bin/foo");
+    pass!(["\"a,b\" ALL=ALL"], "a,b" => request! { root, root }, "server"; "/bin/foo");
+    pass!(["\"a\\b\" ALL=ALL"], "a\\b" => request! { root, root }, "server"; "/bin/foo");
 }
 
 #[test]

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -240,7 +240,7 @@ fn permission_test() {
     pass!(["Runas_Alias TIME=%wheel,!!sudo","user ALL=(:TIME) ALL"], "user" => request! { user, sudo }, "vm"; "/bin/ls");
     pass!(["Runas_Alias TIME=%wheel,!!sudo","user ALL=(TIME) ALL"], "user" => request! { wheel, wheel }, "vm"; "/bin/ls");
 
-    pass!(["Runas_Alias \\"," TIME=%wheel\\",",sudo # hallo","user ALL\\","=(TIME) ALL"], "user" => request! { wheel, wheel }, "vm"; "/bin/ls");
+    pass!(["Runas_Alias \\"," TIME=%wheel \\",",sudo # hallo","user ALL \\","=(TIME) ALL"], "user" => request! { wheel, wheel }, "vm"; "/bin/ls");
 
     // test the less-intuitive "substition-like" alias mechanism
     FAIL!(["User_Alias FOO=!user", "ALL, FOO ALL=ALL"], "user" => root(), "vm"; "/bin/ls");

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -399,3 +399,18 @@ impl Token for ChDir {
         matches!(c, '\\' | '"' | ' ')
     }
 }
+
+/// Some tokens that support escape characters also support being surrounded by quotes to avoid escaping directly.
+pub struct Unquoted<T>(pub String, pub std::marker::PhantomData<T>);
+
+impl<T> Token for Unquoted<T> {
+    const MAX_LEN: usize = 1024;
+
+    fn construct(text: String) -> Result<Self, String> {
+        Ok(Self(text, std::marker::PhantomData))
+    }
+
+    fn accept(c: char) -> bool {
+        c != '"' && !c.is_control()
+    }
+}

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -280,13 +280,14 @@ impl Token for EnvVar {
     }
 }
 
-pub struct QuotedText(pub String);
+/// A token with a very liberal inner tokenizer; compare StringParameter below
+pub struct QuotedStringParameter(pub String);
 
-impl Token for QuotedText {
+impl Token for QuotedStringParameter {
     const MAX_LEN: usize = 1024;
 
     fn construct(s: String) -> Result<Self, String> {
-        Ok(QuotedText(s))
+        Ok(Self(s))
     }
 
     fn accept(c: char) -> bool {
@@ -299,15 +300,17 @@ impl Token for QuotedText {
     }
 }
 
+/// Similar to QuotedStringParameter but treats backslashes differently
+/// Compare IncludePath below.
 // `@include "some/path"`
 //           ^^^^^^^^^^^
-pub struct QuotedInclude(pub String);
+pub struct QuotedIncludePath(pub String);
 
-impl Token for QuotedInclude {
+impl Token for QuotedIncludePath {
     const MAX_LEN: usize = 1024;
 
     fn construct(s: String) -> Result<Self, String> {
-        Ok(QuotedInclude(s))
+        Ok(Self(s))
     }
 
     fn accept(c: char) -> bool {
@@ -343,7 +346,7 @@ impl Token for IncludePath {
 pub struct StringParameter(pub String);
 
 impl Token for StringParameter {
-    const MAX_LEN: usize = QuotedText::MAX_LEN;
+    const MAX_LEN: usize = QuotedStringParameter::MAX_LEN;
 
     fn construct(s: String) -> Result<Self, String> {
         Ok(StringParameter(s))

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -403,11 +403,19 @@ impl Token for ChDir {
 /// Some tokens that support escape characters also support being surrounded by quotes to avoid escaping directly.
 pub struct Unquoted<T>(pub String, pub std::marker::PhantomData<T>);
 
-impl<T> Token for Unquoted<T> {
+impl<T: Token> Token for Unquoted<T> {
     const MAX_LEN: usize = 1024;
 
     fn construct(text: String) -> Result<Self, String> {
-        Ok(Self(text, std::marker::PhantomData))
+        let mut quoted = String::new();
+        for ch in text.chars() {
+            if T::escaped(ch) {
+                quoted.push('\\');
+            }
+            quoted.push(ch);
+        }
+
+        Ok(Self(quoted, std::marker::PhantomData))
     }
 
     fn accept(c: char) -> bool {

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -23,6 +23,11 @@ impl Token for Username {
     fn accept_1st(c: char) -> bool {
         c != '_' && Self::accept(c)
     }
+
+    const ALLOW_ESCAPE: bool = true;
+    fn escaped(c: char) -> bool {
+        matches!(c, '\\' | '"' | ',' | ':' | '=' | '!' | '(' | ')')
+    }
 }
 
 impl Many for Username {}


### PR DESCRIPTION
Closing #17  and #836

Note, even though #17 would suggest we also allow escaping in hostnames, I decided to not support that at this time:

- It's an added complicated to the code (and would probably lead into some DRY'ing because the same trick employed in `UserSpecifier` neads to be repeated)

- Our hostname matching is pretty rudimentary anyway (since we don't do `fqdn`)

- I'm sure it's a failure of my imagination but why would you need to escape characters in a hostname