### PR TITLE
su, sudo: Check the user didn't change during PAM transaction

### DIFF
--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -32,6 +32,7 @@ pub enum Error {
     MaxAuthAttempts(usize),
     PathValidation(PathBuf),
     StringValidation(String),
+    InvalidUser(String, String),
 }
 
 impl fmt::Display for Error {
@@ -102,6 +103,12 @@ impl fmt::Display for Error {
             }
             Error::PathValidation(path) => {
                 write!(f, "invalid path: {path:?}")
+            }
+            Error::InvalidUser(username, other_user) => {
+                write!(
+                    f,
+                    "Sorry, user {username} is not allowed to authenticate as {other_user}.",
+                )
             }
         }
     }

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -32,7 +32,6 @@ pub enum Error {
     MaxAuthAttempts(usize),
     PathValidation(PathBuf),
     StringValidation(String),
-    InvalidUser(String, String),
 }
 
 impl fmt::Display for Error {
@@ -103,12 +102,6 @@ impl fmt::Display for Error {
             }
             Error::PathValidation(path) => {
                 write!(f, "invalid path: {path:?}")
-            }
-            Error::InvalidUser(username, other_user) => {
-                write!(
-                    f,
-                    "Sorry, user {username} is not allowed to authenticate as {other_user}.",
-                )
             }
         }
     }

--- a/src/pam/error.rs
+++ b/src/pam/error.rs
@@ -175,6 +175,7 @@ pub enum PamError {
     IoError(std::io::Error),
     EnvListFailure,
     InteractionRequired,
+    InvalidUser(String, String),
 }
 
 impl From<std::io::Error> for PamError {
@@ -221,6 +222,12 @@ impl fmt::Display for PamError {
                 )
             }
             PamError::InteractionRequired => write!(f, "Interaction is required"),
+            PamError::InvalidUser(username, other_user) => {
+                write!(
+                    f,
+                    "Sorry, user {username} is not allowed to authenticate as {other_user}.",
+                )
+            }
         }
     }
 }

--- a/src/su/mod.rs
+++ b/src/su/mod.rs
@@ -40,8 +40,6 @@ fn authenticate(requesting_user: &str, user: &str, login: bool) -> Result<PamCon
     pam.mark_silent(true);
     pam.mark_allow_null_auth_token(false);
 
-    pam.set_user(user)?;
-
     let mut max_tries = 3;
     let mut current_try = 0;
 

--- a/src/su/mod.rs
+++ b/src/su/mod.rs
@@ -45,20 +45,9 @@ fn authenticate(requesting_user: &str, user: &str, login: bool) -> Result<PamCon
 
     loop {
         current_try += 1;
-        match pam.authenticate() {
+        match pam.authenticate(user) {
             // there was no error, so authentication succeeded
-            Ok(_) => {
-                // Check that no PAM module changed the user.
-                let pam_user = match pam.get_user() {
-                    Ok(u) => u,
-                    Err(e) => return Err(e.into()),
-                };
-
-                if pam_user != user {
-                    return Err(Error::InvalidUser(pam_user, user.to_string()));
-                }
-                break;
-            }
+            Ok(_) => break,
 
             // maxtries was reached, pam does not allow any more tries
             Err(PamError::Pam(PamErrorType::MaxTries)) => {

--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -96,25 +96,9 @@ pub(super) fn attempt_authenticate(
     let mut current_try = 0;
     loop {
         current_try += 1;
-        match pam.authenticate() {
+        match pam.authenticate(auth_user) {
             // there was no error, so authentication succeeded
-            Ok(_) => {
-                // Check that no PAM module changed the user.
-                match pam.get_user() {
-                    Ok(pam_user) => {
-                        if pam_user != auth_user {
-                            return Err(Error::InvalidUser(
-                                pam_user,
-                                auth_user.to_string())
-                            );
-                        }
-                    },
-                    Err(e) => {
-                        return Err(e.into());
-                    }
-                }
-                break;
-            }
+            Ok(_) => break,
 
             // maxtries was reached, pam does not allow any more tries
             Err(PamError::Pam(PamErrorType::MaxTries)) => {

--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -44,12 +44,11 @@ pub(super) fn init_pam(
         bell,
         non_interactive,
         password_feedback,
-        None,
+        Some(auth_user),
     )?;
     pam.mark_silent(matches!(launch, LaunchType::Direct));
     pam.mark_allow_null_auth_token(false);
     pam.set_requesting_user(requesting_user)?;
-    pam.set_user(auth_user)?;
 
     match auth_prompt.as_deref() {
         None => {}

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -184,7 +184,12 @@ fn auth_and_update_record_file(
         hostname: &context.hostname,
     })?;
     if auth_status.must_authenticate {
-        attempt_authenticate(&mut pam_context, context.non_interactive, allowed_attempts)?;
+        attempt_authenticate(
+            &mut pam_context,
+            &auth_user.name,
+            context.non_interactive,
+            allowed_attempts,
+        )?;
         if let (Some(record_file), Some(scope)) = (&mut auth_status.record_file, scope) {
             match record_file.create(scope, context.current_user.uid) {
                 Ok(_) => (),


### PR DESCRIPTION
PAM modules can change the user during their execution, in such case,
sudo would still use the user that has been provided giving potentially
access to another user with the credentials of another one.

So prevent this to happen, by ensuring that the final PAM user is
matching the one which started the transaction

Similar to:
 - https://github.com/util-linux/util-linux/pull/3206
 - https://github.com/sudo-project/sudo/pull/412