### PR TITLE
Implement support for NOEXEC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ name = "visudo"
 path = "bin/visudo.rs"
 
 [dependencies]
-libc = "0.2.149"
+libc = "0.2.152"
 glob = "0.3.0"
 log = { version = "0.4.11", features = ["std"] }
 

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -31,6 +31,7 @@ pub struct Context {
     pub process: Process,
     // policy
     pub use_pty: bool,
+    pub noexec: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -93,6 +94,7 @@ impl Context {
             non_interactive: sudo_options.non_interactive,
             process: Process::new(),
             use_pty: true,
+            noexec: false,
         })
     }
 
@@ -117,6 +119,7 @@ impl Context {
             non_interactive: sudo_options.non_interactive,
             process: Process::new(),
             use_pty: true,
+            noexec: false,
         })
     }
 
@@ -161,6 +164,7 @@ impl Context {
             non_interactive: sudo_options.non_interactive,
             process: Process::new(),
             use_pty: true,
+            noexec: false,
         })
     }
 
@@ -179,6 +183,7 @@ impl Context {
             group: &self.target_group,
 
             use_pty: self.use_pty,
+            noexec: self.noexec,
         })
     }
 }

--- a/src/defaults/mod.rs
+++ b/src/defaults/mod.rs
@@ -36,6 +36,7 @@ defaults! {
     env_editor                = true
     rootpw                    = false
     targetpw                  = false
+    noexec                    = false
 
     passwd_tries              = 3 [0..=1000]
 

--- a/src/exec/no_pty.rs
+++ b/src/exec/no_pty.rs
@@ -26,7 +26,11 @@ use crate::{
     },
 };
 
-pub(super) fn exec_no_pty(sudo_pid: ProcessId, mut command: Command) -> io::Result<ExitReason> {
+pub(super) fn exec_no_pty(
+    sudo_pid: ProcessId,
+    mut file_closer: FileCloser,
+    mut command: Command,
+) -> io::Result<ExitReason> {
     // FIXME (ogsudo): Initialize the policy plugin's session here.
 
     // Block all the signals until we are done setting up the signal handlers so we don't miss
@@ -38,8 +42,6 @@ pub(super) fn exec_no_pty(sudo_pid: ProcessId, mut command: Command) -> io::Resu
             None
         }
     };
-
-    let mut file_closer = FileCloser::new();
 
     // FIXME (ogsudo): Some extra config happens here if selinux is available.
 

--- a/src/exec/noexec.rs
+++ b/src/exec/noexec.rs
@@ -180,7 +180,7 @@ pub(crate) fn add_noexec_filter(command: &mut Command, file_closer: &mut FileClo
         let mut control: SingleRightAnciliaryData = unsafe { zeroed() };
         // SAFETY: The buf field is valid when zero-initialized.
         msg.msg_controllen = unsafe { control.buf.len() };
-        msg.msg_control = &mut control as *mut _ as *mut _;
+        msg.msg_control = &mut control as *mut _ as *mut libc::c_void;
 
         // SAFETY: A valid socket fd and a valid initialized msghdr are passed in.
         if unsafe { recvmsg(rx_fd.as_raw_fd(), &mut msg, 0) } == -1 {

--- a/src/exec/noexec.rs
+++ b/src/exec/noexec.rs
@@ -1,0 +1,290 @@
+// On Linux we can use a seccomp() filter to disable exec.
+
+use std::alloc::{handle_alloc_error, GlobalAlloc, Layout};
+use std::ffi::c_void;
+use std::mem::{offset_of, zeroed};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::net::UnixStream;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+use std::ptr::{self, addr_of};
+use std::{cmp, io, thread};
+
+use libc::{
+    c_int, c_uint, c_ulong, close, cmsghdr, ioctl, iovec, msghdr, prctl, recvmsg, seccomp_data,
+    seccomp_notif, seccomp_notif_resp, seccomp_notif_sizes, sendmsg, sock_filter, sock_fprog,
+    syscall, SYS_execve, SYS_execveat, SYS_seccomp, __errno_location, BPF_ABS, BPF_JEQ, BPF_JMP,
+    BPF_JUMP, BPF_K, BPF_LD, BPF_RET, BPF_STMT, CMSG_DATA, CMSG_FIRSTHDR, CMSG_LEN, CMSG_SPACE,
+    EACCES, ENOENT, MSG_TRUNC, PR_SET_NO_NEW_PRIVS, SCM_RIGHTS, SECCOMP_FILTER_FLAG_NEW_LISTENER,
+    SECCOMP_GET_NOTIF_SIZES, SECCOMP_RET_ALLOW, SECCOMP_SET_MODE_FILTER,
+    SECCOMP_USER_NOTIF_FLAG_CONTINUE, SOL_SOCKET,
+};
+
+use crate::system::FileCloser;
+
+const SECCOMP_RET_USER_NOTIF: c_uint = 0x7fc00000;
+const SECCOMP_IOCTL_NOTIF_RECV: c_ulong = 0xc0502100;
+const SECCOMP_IOCTL_NOTIF_SEND: c_ulong = 0xc0182101;
+
+unsafe fn seccomp<T>(operation: c_uint, flags: c_uint, args: *mut T) -> c_int {
+    unsafe { syscall(SYS_seccomp, operation, flags, args) as c_int }
+}
+
+struct NotifyAllocs {
+    req: *mut seccomp_notif,
+    req_size: usize,
+    resp: *mut seccomp_notif_resp,
+}
+
+unsafe impl Send for NotifyAllocs {}
+unsafe impl Sync for NotifyAllocs {}
+
+fn alloc_dynamic<T>(runtime_size: u16) -> (*mut T, usize) {
+    const {
+        assert!(size_of::<T>() > 0);
+    }
+
+    let layout = Layout::from_size_align(
+        cmp::max(runtime_size.into(), size_of::<T>()),
+        align_of::<seccomp_notif>(),
+    )
+    .unwrap();
+
+    // SAFETY: We assert that T is bigger than 0 bytes and as such the computed layout is also
+    // bigger.
+    let ptr = unsafe { std::alloc::System.alloc_zeroed(layout).cast::<T>() };
+    if ptr.is_null() {
+        handle_alloc_error(layout);
+    }
+
+    (ptr, layout.size())
+}
+
+fn alloc_notify_allocs() -> NotifyAllocs {
+    let mut sizes = seccomp_notif_sizes {
+        seccomp_notif: 0,
+        seccomp_notif_resp: 0,
+        seccomp_data: 0,
+    };
+    // SAFETY: A valid seccomp_notif_sizes pointer is passed in
+    if unsafe { seccomp(SECCOMP_GET_NOTIF_SIZES, 0, &mut sizes) } == -1 {
+        panic!(
+            "failed to get sizes for seccomp unotify data structures: {}",
+            io::Error::last_os_error(),
+        );
+    }
+
+    let (req, req_size) = alloc_dynamic::<seccomp_notif>(sizes.seccomp_notif);
+    let (resp, _) = alloc_dynamic::<seccomp_notif_resp>(sizes.seccomp_notif_resp);
+
+    NotifyAllocs {
+        req,
+        req_size,
+        resp,
+    }
+}
+
+unsafe fn handle_notifications(notify_fd: OwnedFd) -> ! {
+    let NotifyAllocs {
+        req,
+        req_size,
+        resp,
+    } = alloc_notify_allocs();
+
+    unsafe {
+        loop {
+            // SECCOMP_IOCTL_NOTIF_RECV expects the target struct to be zeroed
+            // SAFETY: req is at least req_size bytes big
+            std::ptr::write_bytes(req.cast::<u8>(), 0, req_size);
+
+            // SAFETY: A valid pointer to a seccomp_notify is passed in
+            if ioctl(notify_fd.as_raw_fd(), SECCOMP_IOCTL_NOTIF_RECV, req) == -1 {
+                // SAFETY: Trivial
+                if *__errno_location() == ENOENT {
+                    continue; // Syscall was interrupted
+                }
+                // SAFETY: Not actually unsafe
+                libc::abort();
+            }
+
+            // Allow the first execve call as this is sudo itself starting the target executable.
+            // SAFETY: resp is a valid pointer to a seccomp_notify_resp
+            (*resp).id = (*req).id;
+            (*resp).val = 0;
+            (*resp).error = 0;
+            (*resp).flags = SECCOMP_USER_NOTIF_FLAG_CONTINUE as _;
+
+            if ioctl(notify_fd.as_raw_fd(), SECCOMP_IOCTL_NOTIF_SEND, resp) == -1 {
+                // SAFETY: Trivial
+                if *__errno_location() == ENOENT {
+                    continue; // Syscall was interrupted
+                }
+                // SAFETY: Not actually unsafe
+                libc::abort();
+            }
+            break;
+        }
+
+        loop {
+            // SECCOMP_IOCTL_NOTIF_RECV expects the target struct to be zeroed
+            // SAFETY: req is at least req_size bytes big
+            std::ptr::write_bytes(req.cast::<u8>(), 0, req_size);
+
+            // SAFETY: A valid pointer to a seccomp_notify is passed in
+            if ioctl(notify_fd.as_raw_fd(), SECCOMP_IOCTL_NOTIF_RECV, req) == -1 {
+                // SAFETY: Trivial
+                if *__errno_location() == ENOENT {
+                    continue; // Syscall was interrupted
+                }
+                // SAFETY: Not actually unsafe
+                libc::abort();
+            }
+
+            // Set the error code for all syscalls we are notified about to EACCESS.
+            // SAFETY: resp is a valid pointer to a seccomp_notify_resp
+            (*resp).id = (*req).id;
+            (*resp).val = 0;
+            (*resp).error = -EACCES;
+            (*resp).flags = 0;
+
+            if ioctl(notify_fd.as_raw_fd(), SECCOMP_IOCTL_NOTIF_SEND, resp) == -1 {
+                // SAFETY: Trivial
+                if *__errno_location() == ENOENT {
+                    continue; // Syscall was interrupted
+                }
+                // SAFETY: Not actually unsafe
+                libc::abort();
+            }
+        }
+    }
+}
+
+#[repr(C)]
+union SingleRightAnciliaryData {
+    buf: [u8; unsafe { CMSG_SPACE(size_of::<c_int>() as u32) as usize }],
+    _align: cmsghdr,
+}
+
+pub fn add_noexec_filter(command: &mut Command, file_closer: &mut FileCloser) {
+    let (tx_fd, rx_fd) = UnixStream::pair().unwrap();
+
+    // FIXME spawn thread receiving notify_fd from rx_fd and calling handle_notifications
+    thread::spawn(move || {
+        let mut data = [0u8; 1];
+        let mut iov = iovec {
+            iov_base: &mut data as *mut [u8; 1] as *mut c_void,
+            iov_len: 1,
+        };
+
+        let mut msg: msghdr = unsafe { zeroed() };
+        msg.msg_name = ptr::null_mut();
+        msg.msg_namelen = 0;
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+
+        let mut control: SingleRightAnciliaryData = unsafe { zeroed() };
+        msg.msg_control = &mut control as *mut _ as *mut _;
+        // FIXME stacked borrows violation?
+        msg.msg_controllen = unsafe { control.buf.len() };
+
+        if unsafe { recvmsg(rx_fd.as_raw_fd(), &mut msg, 0) } == -1 {
+            panic!("failed to recvmsg: {}", io::Error::last_os_error());
+        }
+
+        if msg.msg_flags & MSG_TRUNC == MSG_TRUNC {
+            unreachable!();
+        }
+
+        let cmsgp = unsafe { CMSG_FIRSTHDR(&mut msg) };
+        unsafe {
+            if cmsgp.is_null()
+                || (*cmsgp).cmsg_len != CMSG_LEN(size_of::<c_int>() as u32) as usize
+                || (*cmsgp).cmsg_level != SOL_SOCKET
+                || (*cmsgp).cmsg_type != SCM_RIGHTS
+            {
+                unreachable!();
+            }
+        }
+
+        let notify_fd = unsafe { CMSG_DATA(cmsgp).cast::<c_int>().read() };
+
+        unsafe {
+            handle_notifications(OwnedFd::from_raw_fd(notify_fd));
+        }
+    });
+
+    file_closer.except(&tx_fd);
+
+    unsafe {
+        command.pre_exec(move || {
+            // SAFETY: libc unnecessarily marks these functions as unsafe
+            let exec_filter: [sock_filter; 5] = [
+                // Load syscall number into the accumulator
+                BPF_STMT((BPF_LD | BPF_ABS) as _, offset_of!(seccomp_data, nr) as _),
+                // Jump to user notify for execve/execveat
+                BPF_JUMP((BPF_JMP | BPF_JEQ | BPF_K) as _, SYS_execve as _, 2, 0),
+                BPF_JUMP((BPF_JMP | BPF_JEQ | BPF_K) as _, SYS_execveat as _, 1, 0),
+                // Allow non-matching syscalls
+                BPF_STMT((BPF_RET | BPF_K) as _, SECCOMP_RET_ALLOW),
+                // Notify sudo about execve/execveat syscall
+                BPF_STMT((BPF_RET | BPF_K) as _, SECCOMP_RET_USER_NOTIF as _),
+            ];
+
+            let exec_fprog = sock_fprog {
+                len: 5,
+                filter: addr_of!(exec_filter) as *mut sock_filter,
+            };
+
+            // SAFETY: Trivially safe as it doesn't touch any memory.
+            // SECCOMP_SET_MODE_FILTER will fail unless the process has
+            // CAP_SYS_ADMIN or the no_new_privs bit is set.
+            if prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) == -1 {
+                return Err(io::Error::last_os_error());
+            }
+
+            // While the man page warns againt using seccomp_unotify as security
+            // mechanism, the TOCTOU problem that is described there isn't
+            // relevant here. We only SECCOMP_USER_NOTIF_FLAG_CONTINUE the first
+            // execve which is done by ourself and thus trusted.
+            // SAFETY: Passes a valid sock_fprog as argument.
+            let notify_fd = seccomp(
+                SECCOMP_SET_MODE_FILTER,
+                SECCOMP_FILTER_FLAG_NEW_LISTENER as _,
+                addr_of!(exec_fprog).cast_mut(),
+            );
+            if notify_fd < 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            let mut data = [0u8; 1];
+            let mut iov = iovec {
+                iov_base: &mut data as *mut [u8; 1] as *mut c_void,
+                iov_len: 1,
+            };
+
+            let mut msg: msghdr = zeroed();
+            msg.msg_name = ptr::null_mut();
+            msg.msg_namelen = 0;
+            msg.msg_iov = &mut iov;
+            msg.msg_iovlen = 1;
+
+            let mut control: SingleRightAnciliaryData = zeroed();
+            msg.msg_control = &mut control as *mut _ as *mut _;
+            // FIXME stacked borrows violation?
+            msg.msg_controllen = control.buf.len();
+            let cmsgp = CMSG_FIRSTHDR(&mut msg);
+            (*cmsgp).cmsg_level = SOL_SOCKET;
+            (*cmsgp).cmsg_type = SCM_RIGHTS;
+            (*cmsgp).cmsg_len = CMSG_LEN(size_of::<c_int>() as u32) as usize;
+            ptr::write(CMSG_DATA(cmsgp).cast::<c_int>(), notify_fd);
+
+            if sendmsg(tx_fd.as_raw_fd(), &msg, 0) == -1 {
+                return Err(io::Error::last_os_error());
+            }
+
+            close(notify_fd);
+
+            Ok(())
+        });
+    }
+}

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -29,6 +29,7 @@ use super::{CommandStatus, SIGCONT_BG};
 
 pub(in crate::exec) fn exec_pty(
     sudo_pid: ProcessId,
+    mut file_closer: FileCloser,
     mut command: Command,
     user_tty: UserTerm,
 ) -> io::Result<ExitReason> {
@@ -57,8 +58,6 @@ pub(in crate::exec) fn exec_pty(
 
     // Fetch the parent process group so we can signals to it.
     let parent_pgrp = getpgrp();
-
-    let mut file_closer = FileCloser::new();
 
     // Set all the IO streams for the command to the follower side of the pty.
     let mut clone_follower = || -> io::Result<PtyFollower> {

--- a/src/su/context.rs
+++ b/src/su/context.rs
@@ -218,6 +218,7 @@ impl SuContext {
             group: &self.group,
 
             use_pty: true,
+            noexec: false,
         }
     }
 }

--- a/src/sudo/env/environment.rs
+++ b/src/sudo/env/environment.rs
@@ -282,6 +282,7 @@ mod tests {
                         use_pty: true,
                         #[cfg(feature = "apparmor")]
                         apparmor_profile: None,
+                        noexec: false,
                     }
                 ),
                 expected,

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -132,6 +132,7 @@ fn create_test_context(sudo_options: SudoRunOptions) -> Context {
         process: Process::new(),
         use_session_records: false,
         use_pty: true,
+        noexec: false,
         bell: false,
     }
 }
@@ -171,6 +172,7 @@ fn test_environment_variable_filtering() {
                 trust_environment: false,
                 #[cfg(feature = "apparmor")]
                 apparmor_profile: None,
+                noexec: false,
             },
         )
         .unwrap();

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -237,6 +237,7 @@ fn apply_policy_to_context(
     // in case the user could set these from the commandline, something more fancy
     // could be needed, but here we copy these -- perhaps we should split up the Context type
     context.use_pty = controls.use_pty;
+    context.noexec = controls.noexec;
 
     Ok(())
 }

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -100,7 +100,7 @@ pub enum EnvironmentControl {
 #[derive(Copy, Clone, Default, PartialEq)]
 #[cfg_attr(test, derive(Debug, Eq))]
 #[repr(u32)]
-pub enum Noexec {
+pub enum ExecControl {
     #[default]
     Implicit = HARDENED_ENUM_VALUE_0,
     // PASSWD:
@@ -117,7 +117,7 @@ pub struct Tag {
     pub(super) cwd: Option<ChDir>,
     pub(super) env: EnvironmentControl,
     pub(super) apparmor_profile: Option<String>,
-    pub(super) noexec: Noexec,
+    pub(super) noexec: ExecControl,
 }
 
 impl Tag {
@@ -407,8 +407,8 @@ impl Parse for MetaOrTag {
             // a parse error elsewhere. 'NOINTERCEPT' is the default behaviour.
             "FOLLOW" | "NOFOLLOW" | "NOINTERCEPT" => switch(|_| {})?,
 
-            "EXEC" => switch(|tag| tag.noexec = Noexec::Exec)?,
-            "NOEXEC" => switch(|tag| tag.noexec = Noexec::Noexec)?,
+            "EXEC" => switch(|tag| tag.noexec = ExecControl::Exec)?,
+            "NOEXEC" => switch(|tag| tag.noexec = ExecControl::Noexec)?,
 
             "SETENV" => switch(|tag| tag.env = EnvironmentControl::Setenv)?,
             "NOSETENV" => switch(|tag| tag.env = EnvironmentControl::Nosetenv)?,

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -97,6 +97,18 @@ pub enum EnvironmentControl {
     Nosetenv = HARDENED_ENUM_VALUE_2,
 }
 
+#[derive(Copy, Clone, Default, PartialEq)]
+#[cfg_attr(test, derive(Debug, Eq))]
+#[repr(u32)]
+pub enum Noexec {
+    #[default]
+    Implicit = HARDENED_ENUM_VALUE_0,
+    // PASSWD:
+    Exec = HARDENED_ENUM_VALUE_1,
+    // NOPASSWD:
+    Noexec = HARDENED_ENUM_VALUE_2,
+}
+
 /// Commands in /etc/sudoers can have attributes attached to them, such as NOPASSWD, NOEXEC, ...
 #[derive(Default, Clone, PartialEq)]
 #[cfg_attr(test, derive(Debug, Eq))]
@@ -105,7 +117,7 @@ pub struct Tag {
     pub(super) cwd: Option<ChDir>,
     pub(super) env: EnvironmentControl,
     pub(super) apparmor_profile: Option<String>,
-    pub(super) noexec: bool,
+    pub(super) noexec: Noexec,
 }
 
 impl Tag {
@@ -395,8 +407,8 @@ impl Parse for MetaOrTag {
             // a parse error elsewhere. 'NOINTERCEPT' is the default behaviour.
             "FOLLOW" | "NOFOLLOW" | "NOINTERCEPT" => switch(|_| {})?,
 
-            "EXEC" => switch(|tag| tag.noexec = false)?,
-            "NOEXEC" => switch(|tag| tag.noexec = true)?,
+            "EXEC" => switch(|tag| tag.noexec = Noexec::Exec)?,
+            "NOEXEC" => switch(|tag| tag.noexec = Noexec::Noexec)?,
 
             "SETENV" => switch(|tag| tag.env = EnvironmentControl::Setenv)?,
             "NOSETENV" => switch(|tag| tag.env = EnvironmentControl::Nosetenv)?,

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -54,6 +54,7 @@ impl super::Settings {
 pub struct Restrictions<'a> {
     pub use_pty: bool,
     pub trust_environment: bool,
+    pub noexec: bool,
     pub env_keep: &'a HashSet<String>,
     pub env_check: &'a HashSet<String>,
     pub chdir: DirChange<'a>,
@@ -90,6 +91,7 @@ impl Judgement {
                         super::EnvironmentControl::Setenv => true,
                         super::EnvironmentControl::Nosetenv => false,
                     },
+                    noexec: tag.noexec,
                     env_keep: self.settings.env_keep(),
                     env_check: self.settings.env_check(),
                     chdir: match tag.cwd.as_ref() {

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -4,7 +4,7 @@ use super::Judgement;
 use crate::common::{
     SudoPath, HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2,
 };
-use crate::sudoers::ast::Tag;
+use crate::sudoers::ast::{Noexec, Tag};
 use crate::system::{time::Duration, Hostname, User};
 /// Data types and traits that represent what the "terms and conditions" are after a succesful
 /// permission check.
@@ -91,7 +91,11 @@ impl Judgement {
                         super::EnvironmentControl::Setenv => true,
                         super::EnvironmentControl::Nosetenv => false,
                     },
-                    noexec: tag.noexec,
+                    noexec: match tag.noexec {
+                        Noexec::Implicit => self.settings.noexec(),
+                        Noexec::Exec => false,
+                        Noexec::Noexec => true,
+                    },
                     env_keep: self.settings.env_keep(),
                     env_check: self.settings.env_check(),
                     chdir: match tag.cwd.as_ref() {

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -4,7 +4,7 @@ use super::Judgement;
 use crate::common::{
     SudoPath, HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2,
 };
-use crate::sudoers::ast::{Noexec, Tag};
+use crate::sudoers::ast::{ExecControl, Tag};
 use crate::system::{time::Duration, Hostname, User};
 /// Data types and traits that represent what the "terms and conditions" are after a succesful
 /// permission check.
@@ -92,9 +92,9 @@ impl Judgement {
                         super::EnvironmentControl::Nosetenv => false,
                     },
                     noexec: match tag.noexec {
-                        Noexec::Implicit => self.settings.noexec(),
-                        Noexec::Exec => false,
-                        Noexec::Noexec => true,
+                        ExecControl::Implicit => self.settings.noexec(),
+                        ExecControl::Exec => false,
+                        ExecControl::Noexec => true,
                     },
                     env_keep: self.settings.env_keep(),
                     env_check: self.settings.env_check(),

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers.rs
@@ -12,6 +12,7 @@ mod host_alias;
 mod host_list;
 mod include;
 mod includedir;
+mod noexec;
 mod run_as;
 mod runas_alias;
 mod secure_path;

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/noexec.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/noexec.rs
@@ -1,0 +1,136 @@
+//! Test the NOEXEC tag and the noexec option
+
+use sudo_test::{Command, Env, BIN_TRUE};
+
+use crate::{Result, USERNAME};
+
+#[test]
+fn sanity_check() -> Result<()> {
+    let env = Env("Defaults noexec\nALL ALL=(ALL:ALL) NOPASSWD: ALL")
+        .user(USERNAME)
+        .build();
+
+    Command::new("sudo")
+        .arg("/usr/bin/true")
+        .as_user(USERNAME)
+        .output(&env)
+        .assert_success();
+
+    Ok(())
+}
+
+#[test]
+fn exec_denied() -> Result<()> {
+    let env = Env("Defaults noexec\nALL ALL=(ALL:ALL) NOPASSWD: ALL")
+        .user(USERNAME)
+        .build();
+
+    let output = Command::new("sudo")
+        .args(["sh", "-c", BIN_TRUE])
+        .as_user(USERNAME)
+        .output(&env);
+
+    assert!(
+        !output.status().success(),
+        "stdout:\n{}\n\nstderr:\n{}",
+        output.stdout_unchecked(),
+        output.stderr(),
+    );
+
+    assert!(output.stderr().contains("Permission denied"));
+
+    Ok(())
+}
+
+#[test]
+fn exec_denied_second_time() -> Result<()> {
+    let env = Env("Defaults noexec\nALL ALL=(ALL:ALL) NOPASSWD: ALL")
+        .user(USERNAME)
+        .build();
+
+    let output = Command::new("sudo")
+        .args(["sh", "-c"])
+        .arg(format!("{BIN_TRUE} || {BIN_TRUE}"))
+        .as_user(USERNAME)
+        .output(&env);
+
+    assert!(
+        !output.status().success(),
+        "stdout:\n{}\n\nstderr:\n{}",
+        output.stdout_unchecked(),
+        output.stderr(),
+    );
+
+    assert_eq!(
+        output.stderr(),
+        "sh: 1: /usr/bin/true: Permission denied
+sh: 1: /usr/bin/true: Permission denied"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn exec_denied_noexec_tag() -> Result<()> {
+    let env = Env("ALL ALL=(ALL:ALL) NOPASSWD: NOEXEC: ALL")
+        .user(USERNAME)
+        .build();
+
+    let output = Command::new("sudo")
+        .args(["sh", "-c", BIN_TRUE])
+        .as_user(USERNAME)
+        .output(&env);
+
+    assert!(
+        !output.status().success(),
+        "stdout:\n{}\n\nstderr:\n{}",
+        output.stdout_unchecked(),
+        output.stderr(),
+    );
+
+    assert!(
+        output.stderr().contains("Permission denied"),
+        "stderr:\n{}",
+        output.stderr(),
+    );
+
+    Ok(())
+}
+
+#[test]
+fn exec_overrides_noexec_default() -> Result<()> {
+    let env = Env("Defaults noexec\nALL ALL=(ALL:ALL) NOPASSWD: EXEC: ALL")
+        .user(USERNAME)
+        .build();
+
+    Command::new("sudo")
+        .args(["sh", "-c", BIN_TRUE])
+        .as_user(USERNAME)
+        .output(&env)
+        .assert_success();
+
+    Ok(())
+}
+
+#[test]
+fn no_use_pty_works() -> Result<()> {
+    let env = Env("Defaults noexec, !use_pty\nALL ALL=(ALL:ALL) NOPASSWD: ALL")
+        .user(USERNAME)
+        .build();
+
+    let output = Command::new("sudo")
+        .args(["sh", "-c", BIN_TRUE])
+        .as_user(USERNAME)
+        .output(&env);
+
+    assert!(
+        !output.status().success(),
+        "stdout:\n{}\n\nstderr:\n{}",
+        output.stdout_unchecked(),
+        output.stderr(),
+    );
+
+    assert!(output.stderr().contains("Permission denied"));
+
+    Ok(())
+}


### PR DESCRIPTION
This is using seccomp syscall filtering of the execve and execveat syscalls. Unlike the original sudo this does not depend on using LD_PRELOAD. Instead SECCOMP_RET_USER_NOTIF is used combined with a thread which allows the first exec (as done by sudo itself) and denies all further execs. This makes it robust against both statically linked executables and executables compiled for a different libc than sudo-rs itself. Sudo-rs just like original sudo does not protect against malicious programs with NOEXEC. It doesn't prevent mapping memory as executable, nor does it protect against future syscalls that do an exec like the planned io_uring exec opcode [^1]. And it also doesn't protect against honest programs that intentionally or not allow the user to write to /proc/self/mem for the same reasons as that it doesn't protect against malicious programs.

[^1]: https://lwn.net/Articles/1002371/

Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/1071
Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/1072