### PR TITLE
Stop installing libclang in docker containers

### DIFF
--- a/test-framework/sudo-test/src/ours.linux.Dockerfile
+++ b/test-framework/sudo-test/src/ours.linux.Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1-slim-bookworm
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends clang libclang-dev libpam0g-dev procps sshpass rsyslog
+    apt-get install -y --no-install-recommends libpam0g-dev procps sshpass rsyslog
 # cache the crates.io index in the image for faster local testing
 RUN cargo search sudo
 WORKDIR /usr/src/sudo
@@ -14,8 +14,6 @@ RUN install -m 4755 build/sudo /usr/bin/sudo && \
 RUN mkdir -p /etc/sudoers.d
 # Ensure we use the same shell across OSes
 RUN chsh -s /bin/sh
-# remove build dependencies
-RUN apt-get autoremove -y clang libclang-dev
 # set the default working directory to somewhere world writable so sudo / su can create .profraw files there
 WORKDIR /tmp
 # This env var needs to be set when compiled with the dev feature

--- a/util/Dockerfile-release
+++ b/util/Dockerfile-release
@@ -1,2 +1,2 @@
 FROM rust:1.84-slim-bookworm@sha256:69fbd6ab81b514580bc14f35323fecb09feba9e74c5944ece9a70d9a2a369df0
-RUN apt-get update -y && apt-get install -y clang libclang-dev libpam0g-dev
+RUN apt-get update -y && apt-get install -y libpam0g-dev


### PR DESCRIPTION
We don't use rust-bindgen anymore on regular builds, so libclang is not used. Only a single CI job still needs libclang when regenerating the PAM bindings.