### PR TITLE
Some improvements around Authorization, Restrictions and Context

### DIFF
--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -31,7 +31,6 @@ pub struct Context {
     pub process: Process,
     // policy
     pub use_pty: bool,
-    pub password_feedback: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -94,7 +93,6 @@ impl Context {
             non_interactive: sudo_options.non_interactive,
             process: Process::new(),
             use_pty: true,
-            password_feedback: false,
         })
     }
 
@@ -119,7 +117,6 @@ impl Context {
             non_interactive: sudo_options.non_interactive,
             process: Process::new(),
             use_pty: true,
-            password_feedback: false,
         })
     }
 
@@ -164,7 +161,6 @@ impl Context {
             non_interactive: sudo_options.non_interactive,
             process: Process::new(),
             use_pty: true,
-            password_feedback: false,
         })
     }
 

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -132,7 +132,6 @@ fn create_test_context(sudo_options: SudoRunOptions) -> Context {
         process: Process::new(),
         use_session_records: false,
         use_pty: true,
-        password_feedback: false,
         bell: false,
     }
 }

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -73,7 +73,7 @@ pub fn run(mut cmd_opts: SudoRunOptions) -> Result<(), Error> {
         return Err(Error::Authorization(context.current_user.name.to_string()));
     };
 
-    apply_policy_to_context(&mut context, &auth, &controls)?;
+    apply_policy_to_context(&mut context, &controls)?;
     let mut pam_context = auth_and_update_record_file(&mut context, &auth)?;
 
     // build environment
@@ -149,7 +149,7 @@ fn auth_and_update_record_file(
         prior_validity,
         allowed_attempts,
         ref credential,
-        ..
+        pwfeedback,
     }: &Authentication,
 ) -> Result<PamContext, Error> {
     let scope = RecordScope::for_process(&Process::new());
@@ -176,7 +176,7 @@ fn auth_and_update_record_file(
         use_stdin: context.stdin,
         bell: context.bell,
         non_interactive: context.non_interactive,
-        password_feedback: context.password_feedback,
+        password_feedback: pwfeedback,
         auth_prompt: context.prompt.clone(),
         auth_user: &auth_user.name,
         requesting_user: &context.current_user.name,
@@ -205,7 +205,6 @@ fn auth_and_update_record_file(
 
 fn apply_policy_to_context(
     context: &mut Context,
-    auth: &Authentication,
     controls: &Restrictions,
 ) -> Result<(), crate::common::Error> {
     // see if the chdir flag is permitted
@@ -231,7 +230,6 @@ fn apply_policy_to_context(
     // in case the user could set these from the commandline, something more fancy
     // could be needed, but here we copy these -- perhaps we should split up the Context type
     context.use_pty = controls.use_pty;
-    context.password_feedback = auth.pwfeedback;
 
     Ok(())
 }

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -74,7 +74,7 @@ pub fn run(mut cmd_opts: SudoRunOptions) -> Result<(), Error> {
     };
 
     apply_policy_to_context(&mut context, &controls)?;
-    let mut pam_context = auth_and_update_record_file(&mut context, &auth)?;
+    let mut pam_context = auth_and_update_record_file(&context, &auth)?;
 
     // build environment
     let additional_env = pre_exec(&mut pam_context, &context.target_user.name)?;
@@ -128,14 +128,14 @@ pub fn run(mut cmd_opts: SudoRunOptions) -> Result<(), Error> {
 pub fn run_validate(cmd_opts: SudoValidateOptions) -> Result<(), Error> {
     let policy = read_sudoers()?;
 
-    let mut context = Context::from_validate_opts(cmd_opts)?;
+    let context = Context::from_validate_opts(cmd_opts)?;
 
     match policy.check_validate_permission(&*context.current_user, &context.hostname) {
         Authorization::Forbidden => {
             return Err(Error::Authorization(context.current_user.name.to_string()));
         }
         Authorization::Allowed(auth, ()) => {
-            auth_and_update_record_file(&mut context, &auth)?;
+            auth_and_update_record_file(&context, &auth)?;
         }
     }
 
@@ -143,7 +143,7 @@ pub fn run_validate(cmd_opts: SudoValidateOptions) -> Result<(), Error> {
 }
 
 fn auth_and_update_record_file(
-    context: &mut Context,
+    context: &Context,
     &Authentication {
         must_authenticate,
         prior_validity,

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -74,7 +74,7 @@ pub fn run(mut cmd_opts: SudoRunOptions) -> Result<(), Error> {
     };
 
     apply_policy_to_context(&mut context, &controls)?;
-    let mut pam_context = auth_and_update_record_file(&context, &auth)?;
+    let mut pam_context = auth_and_update_record_file(&context, auth)?;
 
     // build environment
     let additional_env = pre_exec(&mut pam_context, &context.target_user.name)?;
@@ -135,7 +135,7 @@ pub fn run_validate(cmd_opts: SudoValidateOptions) -> Result<(), Error> {
             return Err(Error::Authorization(context.current_user.name.to_string()));
         }
         Authorization::Allowed(auth, ()) => {
-            auth_and_update_record_file(&context, &auth)?;
+            auth_and_update_record_file(&context, auth)?;
         }
     }
 
@@ -144,13 +144,13 @@ pub fn run_validate(cmd_opts: SudoValidateOptions) -> Result<(), Error> {
 
 fn auth_and_update_record_file(
     context: &Context,
-    &Authentication {
+    Authentication {
         must_authenticate,
         prior_validity,
         allowed_attempts,
         ref credential,
         pwfeedback,
-    }: &Authentication,
+    }: Authentication,
 ) -> Result<PamContext, Error> {
     let scope = RecordScope::for_process(&Process::new());
     let mut auth_status = determine_auth_status(

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -24,13 +24,13 @@ pub(in crate::sudo) fn run_list(cmd_opts: SudoListOptions) -> Result<(), Error> 
 
     let mut sudoers = super::read_sudoers()?;
 
-    let mut context = Context::from_list_opts(cmd_opts, &mut sudoers)?;
+    let context = Context::from_list_opts(cmd_opts, &mut sudoers)?;
 
     if original_command.is_some() && !context.command.resolved {
         return Err(Error::CommandNotFound(context.command.command));
     }
 
-    if auth_invoking_user(&mut context, &sudoers, &original_command, &other_user)?.is_break() {
+    if auth_invoking_user(&context, &sudoers, &original_command, &other_user)?.is_break() {
         return Ok(());
     }
 
@@ -64,7 +64,7 @@ pub(in crate::sudo) fn run_list(cmd_opts: SudoListOptions) -> Result<(), Error> 
 }
 
 fn auth_invoking_user(
-    context: &mut Context,
+    context: &Context,
     sudoers: &Sudoers,
     original_command: &Option<String>,
     other_user: &Option<User>,

--- a/src/sudo/pipeline/list.rs
+++ b/src/sudo/pipeline/list.rs
@@ -75,7 +75,7 @@ fn auth_invoking_user(
     };
     match sudoers.check_list_permission(&*context.current_user, &context.hostname, list_request) {
         Authorization::Allowed(auth, ()) => {
-            auth_and_update_record_file(context, &auth)?;
+            auth_and_update_record_file(context, auth)?;
             Ok(ControlFlow::Continue(()))
         }
 

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -29,9 +29,6 @@ pub struct Authentication {
     pub allowed_attempts: u16,
     pub prior_validity: Duration,
     pub pwfeedback: bool,
-    #[cfg(feature = "apparmor")]
-    #[expect(dead_code)] // TODO: this attribute should be removed
-    pub apparmor_profile: Option<String>,
 }
 
 impl super::Settings {
@@ -48,8 +45,6 @@ impl super::Settings {
             } else {
                 AuthenticatingUser::InvokingUser
             },
-            #[cfg(feature = "apparmor")]
-            apparmor_profile: tag.apparmor_profile.clone(),
         }
     }
 }
@@ -63,6 +58,9 @@ pub struct Restrictions<'a> {
     pub env_check: &'a HashSet<String>,
     pub chdir: DirChange<'a>,
     pub path: Option<&'a str>,
+    #[cfg(feature = "apparmor")]
+    #[expect(dead_code)] // TODO: this attribute should be removed
+    pub apparmor_profile: Option<String>,
 }
 
 #[must_use]
@@ -101,6 +99,8 @@ impl Judgement {
                         Some(super::ChDir::Path(path)) => DirChange::Strict(Some(path)),
                     },
                     path: self.settings.secure_path(),
+                    #[cfg(feature = "apparmor")]
+                    apparmor_profile: tag.apparmor_profile.clone(),
                 },
             )
         } else {


### PR DESCRIPTION
* Move apparmor_profile to the correct type
* Read pwfeedback directly from `Authorization` in `auth_and_update_record_file`
* Consume `Authorization` in `auth_and_update_record_file`
* Make it clearer where `Context` could be modified.

Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/1090
Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/1092