### PR TITLE
add apparmor compliance test

### DIFF
--- a/test-framework/sudo-compliance-tests/src/sudo/apparmor.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/apparmor.rs
@@ -3,7 +3,7 @@ use sudo_test::{Command, Env};
 use crate::Result;
 
 #[test]
-fn switches_the_apparmor_profile() -> Result<()> {
+fn can_switch_the_apparmor_profile() -> Result<()> {
     let env = Env("root ALL=(ALL:ALL) APPARMOR_PROFILE=docker-default ALL")
         .apparmor("unconfined")
         .build();
@@ -29,6 +29,44 @@ fn cannot_switch_to_nonexisting_profile() -> Result<()> {
 
     output.assert_exit_code(1);
     assert_contains!(output.stderr(), "unable to change AppArmor profile");
+
+    Ok(())
+}
+
+#[test]
+fn can_set_default_apparmor_profile() -> Result<()> {
+    let env = Env("root ALL=(ALL:ALL) ALL
+Defaults apparmor_profile=docker-default
+")
+    .apparmor("unconfined")
+    .build();
+
+    let output = Command::new("sudo")
+        .args(["-s", "cat", "/proc/$$/attr/current"])
+        .output(&env);
+    dbg!(&output);
+
+    output.assert_success();
+    assert_eq!(output.stdout(), "docker-default (enforce)");
+
+    Ok(())
+}
+
+#[test]
+fn tags_override_the_default_apparmor_profile() -> Result<()> {
+    let env = Env("root ALL=(ALL:ALL) APPARMOR_PROFILE=unconfined ALL
+Defaults apparmor_profile=docker-default
+")
+    .apparmor("unconfined")
+    .build();
+
+    let output = Command::new("sudo")
+        .args(["-s", "cat", "/proc/$$/attr/current"])
+        .output(&env);
+    dbg!(&output);
+
+    output.assert_success();
+    assert_eq!(output.stdout(), "unconfined");
 
     Ok(())
 }

--- a/test-framework/sudo-test/src/lib.rs
+++ b/test-framework/sudo-test/src/lib.rs
@@ -1203,4 +1203,24 @@ mod tests {
 
         assert!(found);
     }
+
+    #[cfg(feature = "apparmor")]
+    #[test]
+    fn setting_apparmor_works() -> Result<()> {
+        for profile in ["unconfined", "docker-default (enforce)"] {
+            let env = EnvBuilder::default()
+                .apparmor(profile.strip_suffix(" (enforce)").unwrap_or(profile))
+                .build();
+
+            let output = Command::new("bash")
+                .args(["-c", "cat /proc/$$/attr/current"])
+                .output(&env);
+            dbg!(&output);
+
+            output.assert_success();
+            assert_eq!(output.stdout(), profile);
+        }
+
+        Ok(())
+    }
 }

--- a/test-framework/sudo-test/src/lib.rs
+++ b/test-framework/sudo-test/src/lib.rs
@@ -160,6 +160,7 @@ pub struct EnvBuilder {
     hostname: Option<String>,
     users: HashMap<Username, User>,
     user_passwords: HashMap<String, String>,
+    #[cfg(feature = "apparmor")]
     apparmor_profile: Option<String>,
 }
 
@@ -259,6 +260,7 @@ impl EnvBuilder {
     /// # Panics
     ///
     /// - if the apparmor profile has already been set
+    #[cfg(feature = "apparmor")]
     pub fn apparmor(&mut self, profile: impl ToString) -> &mut Self {
         assert_eq!(self.apparmor_profile, None);
         self.apparmor_profile = Some(profile.to_string());


### PR DESCRIPTION
Compliance test was already there, but not for the `Defaults apparmor_profile` option.