### PR TITLE
Fix spurious sigwinch_works_* failures with podman

### DIFF
--- a/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/change-size.sh
+++ b/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/change-size.sh
@@ -1,4 +1,6 @@
-# Wait for `print-sizes.sh` to write to `/tmp/tty_path`
-sleep 0.5
+# Wait for `print-sizes.sh` to write to `/tmp/tty_path` and report the old tty size.
+until [ -f /tmp/barrier1 ]; do sleep 0.1; done
 # Resize the terminal
 stty -F$(cat /tmp/tty_path) rows 42 cols 69
+# Notify `print-sizes.sh` that the tty size has changed.
+touch /tmp/barrier2

--- a/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/print-sizes.sh
+++ b/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/print-sizes.sh
@@ -2,5 +2,6 @@
 tty > /tmp/tty_path
 # Print the current terminal size
 stty size
-# Print the terminal size, wait for `change-size.sh` to run and then print the terminal size again.
-sudo sh -c "stty size; sleep 1; stty size"
+# Print the terminal size, notify `change-size.sh` that it can change the tty size, wait for it to
+# finish and then print the terminal size again.
+sudo sh -c "stty size; touch /tmp/barrier1; until [ -f /tmp/barrier2 ]; do sleep 0.1; done; stty size"


### PR DESCRIPTION
Podman is significantly slower than docker at running the test suite, causing change-size.sh to sometimes try to change the tty size before print-sizes.sh has written /tmp/tty_path.