### PR TITLE
Fix race between parent and monitor in `use_pty`

### DIFF
--- a/src/exec/event.rs
+++ b/src/exec/event.rs
@@ -91,6 +91,11 @@ impl EventHandle {
             }
         }
     }
+
+    /// Is this event handle ready to be processed?
+    pub(super) fn is_active(&self) -> bool {
+        self.should_poll
+    }
 }
 
 /// The kind of event that will be monitored for a file descriptor.

--- a/src/exec/use_pty/backchannel.rs
+++ b/src/exec/use_pty/backchannel.rs
@@ -199,18 +199,18 @@ impl AsFd for ParentBackchannel {
 /// Different messages exchanged between the monitor and the parent process using a [`ParentBackchannel`].
 #[derive(PartialEq, Eq)]
 pub(super) enum MonitorMessage {
-    ExecCommand,
+    Edge,
     Signal(c_int),
 }
 
 impl MonitorMessage {
     const LEN: usize = PREFIX_LEN + MONITOR_DATA_LEN;
-    const EXEC_CMD: Prefix = 0;
+    const EDGE_CMD: Prefix = 0;
     const SIGNAL: Prefix = 1;
 
     fn from_parts(prefix: Prefix, data: MonitorData) -> Self {
         match prefix {
-            Self::EXEC_CMD => Self::ExecCommand,
+            Self::EDGE_CMD => Self::Edge,
             Self::SIGNAL => Self::Signal(data),
             _ => unreachable!(),
         }
@@ -218,12 +218,12 @@ impl MonitorMessage {
 
     fn to_parts(&self) -> (Prefix, MonitorData) {
         let prefix = match self {
-            MonitorMessage::ExecCommand => Self::EXEC_CMD,
+            MonitorMessage::Edge => Self::EDGE_CMD,
             MonitorMessage::Signal(_) => Self::SIGNAL,
         };
 
         let data = match self {
-            MonitorMessage::ExecCommand => 0,
+            MonitorMessage::Edge => 0,
             MonitorMessage::Signal(data) => *data,
         };
 
@@ -234,7 +234,7 @@ impl MonitorMessage {
 impl std::fmt::Debug for MonitorMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ExecCommand => "ExecCommand".fmt(f),
+            Self::Edge => "Edge".fmt(f),
             &Self::Signal(signal) => write!(f, "Signal({})", signal_fmt(signal)),
         }
     }

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -75,8 +75,8 @@ pub(super) fn exec_monitor(
         err
     })?;
     // Given that `UnixStream` delivers messages in order it shouldn't be possible to
-    // receive an event different to `ExecCommand` at the beginning.
-    debug_assert_eq!(event, MonitorMessage::ExecCommand);
+    // receive an event different to `Edge` at the beginning.
+    debug_assert_eq!(event, MonitorMessage::Edge);
 
     // FIXME (ogsudo): Some extra config happens here if selinux is available.
 
@@ -192,7 +192,7 @@ pub(super) fn exec_monitor(
         dev_warn!("cannot receive red light from parent: {err}");
         err
     })?;
-    debug_assert_eq!(event, MonitorMessage::ExecCommand);
+    debug_assert_eq!(event, MonitorMessage::Edge);
 
     // FIXME (ogsudo): The tty is restored here if selinux is available.
 
@@ -279,8 +279,8 @@ impl<'a> MonitorClosure<'a> {
             }
             Ok(event) => {
                 match event {
-                    // We shouldn't receive this event more than once.
-                    MonitorMessage::ExecCommand => unreachable!(),
+                    // We shouldn't receive this event at this point in the protocol
+                    MonitorMessage::Edge => unreachable!(),
                     // Forward signal to the command.
                     MonitorMessage::Signal(signal) => {
                         if let Some(command_pid) = self.command_pid {

--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -168,6 +168,7 @@ pub(super) fn exec_monitor(
     // Disable nonblocking assetions as we will not poll the backchannel anymore.
     closure.backchannel.set_nonblocking_assertions(false);
 
+    std::thread::sleep(std::time::Duration::from_millis(50));
     match reason {
         StopReason::Break(err) => match err.try_into() {
             Ok(msg) => {

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -207,12 +207,10 @@ pub(in crate::exec) fn exec_pty(
     drop(backchannels.monitor);
 
     // Send green light to the monitor after closing the follower.
-    retry_while_interrupted(|| backchannels.parent.send(&MonitorMessage::ExecCommand)).map_err(
-        |err| {
-            dev_error!("cannot send green light to monitor: {err}");
-            err
-        },
-    )?;
+    retry_while_interrupted(|| backchannels.parent.send(&MonitorMessage::Edge)).map_err(|err| {
+        dev_error!("cannot send green light to monitor: {err}");
+        err
+    })?;
 
     let mut closure = ParentClosure::new(
         monitor_pid,
@@ -354,7 +352,7 @@ impl ParentClosure {
             StopReason::Exit(ParentExit::Command(exit_reason)) => Ok(exit_reason),
         };
         // Send red light to the monitor after processing all events
-        retry_while_interrupted(|| self.backchannel.send(&MonitorMessage::ExecCommand)).map_err(
+        retry_while_interrupted(|| self.backchannel.send(&MonitorMessage::Edge)).map_err(
             |err| {
                 dev_error!("cannot send red light to monitor: {err}");
                 err

--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -235,6 +235,7 @@ pub(in crate::exec) fn exec_pty(
     // FIXME (ogsudo): Retry if `/dev/tty` is revoked.
 
     // Flush the terminal
+    closure.tty_pipe.right().set_nonblocking()?;
     closure.tty_pipe.flush_left().ok();
 
     // Restore the terminal settings

--- a/src/exec/use_pty/pipe/ring_buffer.rs
+++ b/src/exec/use_pty/pipe/ring_buffer.rs
@@ -10,7 +10,7 @@ pub(super) struct RingBuffer {
 
 impl RingBuffer {
     /// The size of the internal storage of the ring buffer.
-    const LEN: usize = 8 * 1024;
+    pub(super) const LEN: usize = 8 * 1024;
 
     /// Create a new, empty buffer.
     pub(super) fn new() -> Self {

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -97,6 +97,22 @@ impl PtyLeader {
 
         Ok(())
     }
+
+    pub(crate) fn set_nonblocking(&self) -> io::Result<()> {
+        let fd = self.file.as_fd();
+        // SAFETY: these two calls to fcntl are memory safe (and the file descriptor is valid as well)
+        unsafe {
+            let flags = cerr(libc::fcntl(fd.as_raw_fd(), libc::F_GETFL))?;
+
+            // Set the O_NONBLOCK flag
+            cerr(libc::fcntl(
+                fd.as_raw_fd(),
+                libc::F_SETFL,
+                flags | libc::O_NONBLOCK,
+            ))?;
+        }
+        Ok(())
+    }
 }
 
 impl io::Read for PtyLeader {


### PR DESCRIPTION
The problem with #1129 was two-fold:

1) When the monitor shuts down, it takes the pseudoterminal it controls with it. So we end up in a condition where the parent is racing with the monitor to read remaining data before the monitor crosses the finish line.

This could be demonstrated by adding a sleep in the monitor, but a better fix is simply to use the existing backchannel to synchronise parent and monitor. I re-used the old `ExecCommand` message for this, as that was already used to handle a similar race at the start.

So basically the backchannel protocol is: parent sends an `Edge` to signal the monitor it can go (this was already the case), do the usual thing while the monitor and child are doing their dance, and then again when the monitor has communicated that it is ended, let it wait for another `Edge` from the parent.

2) Secondly, the monitor is sending the "the child process has terminated" signal to the parent via backchannel communication, but the child is communicating itself the data over a pipe. It so happens that its final data is still in flight but overtaken by the backchannel. 

The fix: in the `flush_left` function, also read the *right* side to completion.