### PR TITLE
Further relax username requirements

### DIFF
--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -365,6 +365,16 @@ fn invalid_username() {
 }
 
 #[test]
+fn inclusive_username() {
+    let UserSpecifier::User(Identifier::Name(sirin)) = parse_eval::<ast::UserSpecifier>("şirin")
+    else {
+        panic!();
+    };
+
+    assert_eq!(sirin, "şirin");
+}
+
+#[test]
 fn directive_test() {
     let y = parse_eval::<Spec<UserSpecifier>>;
     match parse_eval::<ast::Sudo>("User_Alias HENK = user1, user2") {

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -8,7 +8,8 @@ use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_
 #[cfg_attr(test, derive(Clone, PartialEq, Eq))]
 pub struct Username(pub SudoString);
 
-/// A username consists of alphanumeric characters as well as "." and "-", but does not start with an underscore.
+/// A username consists of alphanumeric characters as well as ".", "-", "_".
+/// Furthermore, it may contain embedded "@" characters (but not start with them) and end in a "$".
 // See: https://systemd.io/USER_NAMES/
 impl Token for Username {
     fn construct(text: String) -> Result<Self, String> {
@@ -27,7 +28,7 @@ impl Token for Username {
     }
 
     fn accept_1st(c: char) -> bool {
-        c != '_' && c != '@' && Self::accept(c)
+        c != '@' && Self::accept(c)
     }
 
     const ALLOW_ESCAPE: bool = true;

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -24,7 +24,7 @@ impl Token for Username {
     }
 
     fn accept(c: char) -> bool {
-        c.is_ascii_alphanumeric() || ".-_@$".contains(c)
+        c.is_alphanumeric() || ".-_@$".contains(c)
     }
 
     fn accept_1st(c: char) -> bool {


### PR DESCRIPTION
Closes #1119

Besides allowing username to start with `_`, also allows arbitrary alphanumeric characters.