### PR TITLE
Add `sudoedit` to the parser

### DIFF
--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -395,7 +395,8 @@ impl Parse for MetaOrTag {
                 "INTERCEPT is not supported by sudo-rs"
             ),
             // this is less fatal
-            "LOG_INPUT" | "NOLOG_INPUT" | "LOG_OUTPUT" | "NOLOG_OUTPUT" | "MAIL" | "NOMAIL" => {
+            "LOG_INPUT" | "NOLOG_INPUT" | "LOG_OUTPUT" | "NOLOG_OUTPUT" | "MAIL" | "NOMAIL"
+            | "FOLLOW" => {
                 eprintln_ignore_io_error!(
                     "warning: {} tags are ignored by sudo-rs",
                     keyword.as_str()
@@ -403,9 +404,8 @@ impl Parse for MetaOrTag {
                 switch(|_| {})?
             }
 
-            // 'FOLLOW' and 'NOFOLLOW' are only usable in a sudoedit context, which will result in
-            // a parse error elsewhere. 'NOINTERCEPT' is the default behaviour.
-            "FOLLOW" | "NOFOLLOW" | "NOINTERCEPT" => switch(|_| {})?,
+            // 'NOFOLLOW' and 'NOINTERCEPT' are the default behaviour.
+            "NOFOLLOW" | "NOINTERCEPT" => switch(|_| {})?,
 
             "EXEC" => switch(|tag| tag.noexec = ExecControl::Exec)?,
             "NOEXEC" => switch(|tag| tag.noexec = ExecControl::Noexec)?,

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -471,31 +471,6 @@ impl Parse for CommandSpec {
             }
         }
 
-        let start_pos = stream.get_pos();
-        if let Some(Username(keyword)) = try_nonterminal(stream)? {
-            if keyword == "sudoedit" {
-                // note: special behaviour of forward slashes in wildcards, tread carefully
-                unrecoverable!(pos = start_pos, stream, "sudoedit is not yet supported");
-            } else if keyword == "list" {
-                return make(CommandSpec(
-                    tags,
-                    Allow(Meta::Only((glob::Pattern::new("list").unwrap(), None))),
-                ));
-            } else if keyword.starts_with("sha") {
-                unrecoverable!(
-                    pos = start_pos,
-                    stream,
-                    "digest specifications are not supported"
-                )
-            } else {
-                unrecoverable!(
-                    pos = start_pos,
-                    stream,
-                    "expected command but found {keyword}"
-                )
-            };
-        }
-
         let cmd: Spec<Command> = expect_nonterminal(stream)?;
 
         make(CommandSpec(tags, cmd))

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -375,6 +375,17 @@ fn inclusive_username() {
 }
 
 #[test]
+fn sudoedit_recognized() {
+    let CommandSpec(_, Qualified::Allow(Meta::Only((cmd, args)))) =
+        parse_eval::<ast::CommandSpec>("sudoedit /etc/tmux.conf")
+    else {
+        panic!();
+    };
+    assert_eq!(cmd.as_str(), "sudoedit");
+    assert_eq!(args.unwrap().as_ref(), &["/etc/tmux.conf"][..]);
+}
+
+#[test]
 fn directive_test() {
     let y = parse_eval::<Spec<UserSpecifier>>;
     match parse_eval::<ast::Sudo>("User_Alias HENK = user1, user2") {

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -262,6 +262,10 @@ fn permission_test() {
     // apparmor
     #[cfg(feature = "apparmor")]
     pass!(["ALL ALL=(ALL:ALL) APPARMOR_PROFILE=unconfined ALL"], "user" => root(), "server"; "/bin/bar" => [apparmor_profile: Some("unconfined".to_string())]);
+
+    // list
+    pass!(["ALL ALL=(ALL:ALL) /bin/ls, list"], "user" => root(), "server"; "list");
+    FAIL!(["ALL ALL=(ALL:ALL) ALL, !list"], "user" => root(), "server"; "list");
 }
 
 #[test]
@@ -383,6 +387,12 @@ fn sudoedit_recognized() {
     };
     assert_eq!(cmd.as_str(), "sudoedit");
     assert_eq!(args.unwrap().as_ref(), &["/etc/tmux.conf"][..]);
+}
+
+#[test]
+#[should_panic = "list does not take arguments"]
+fn list_does_not_take_args() {
+    parse_eval::<ast::CommandSpec>("list /etc/tmux.conf");
 }
 
 #[test]


### PR DESCRIPTION
Also does some other changes like producing an error for `FOLLOW` and push the pseudocommand recognizer into the tokenizer where it fits better.

Part of #1121 