### PR TITLE
Fix Typo in Comments for Terminal Restoration and Test Confirmation

### DIFF
--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -573,7 +573,7 @@ impl ParentClosure {
         Ok(())
     }
 
-    /// Restore the terminal when sudo resumes after receving `SIGCONT`.
+    /// Restore the terminal when sudo resumes after receiving `SIGCONT`.
     fn resume_terminal(&mut self) -> io::Result<()> {
         self.check_foreground()?;
 

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -286,7 +286,7 @@ mod tests {
 
         drop(tx);
 
-        // Read one byte from the children to comfirm that it did not panic.
+        // Read one byte from the children to confirm that it did not panic.
         let mut buf = [0];
         rx.read_exact(&mut buf).unwrap();
         assert_eq!(buf[0], 42);


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in comments within the codebase:
- In `src/exec/use_pty/parent.rs`, the comment describing terminal restoration after receiving `SIGCONT` is updated for clarity.
- In `src/system/term/mod.rs`, the comment explaining the test logic for reading a byte from children is clarified.

No functional code changes are introduced; only comment text is improved for better readability and accuracy.