### PR TITLE
Fix Typo in Documentation and Improve Alias Mechanism Test Description

### DIFF
--- a/docs/man/sudo.8.man
+++ b/docs/man/sudo.8.man
@@ -107,7 +107,7 @@ The following percent (`%') escape sequences are supported:
 .EE
 .PP
 The custom prompt will override the default prompt or the one specified
-by the SUDO_PROMPT enviroment variable.
+by the SUDO_PROMPT environment variable.
 No \f[I]prompt\f[R] will suppress the the prompt provided by PAM, unless
 the requested \f[I]prompt\f[R] is empty (\f[CR]\[dq]\[dq]\f[R])
 .RE

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -246,7 +246,7 @@ fn permission_test() {
 
     pass!(["Runas_Alias \\"," TIME=%wheel \\",",sudo # hallo","user ALL \\","=(TIME) ALL"], "user" => request! { wheel, wheel }, "vm"; "/bin/ls");
 
-    // test the less-intuitive "substition-like" alias mechanism
+    // test the less-intuitive "substitution-like" alias mechanism
     FAIL!(["User_Alias FOO=!user", "ALL, FOO ALL=ALL"], "user" => root(), "vm"; "/bin/ls");
     pass!(["User_Alias FOO=!user", "!FOO ALL=ALL"], "user" => root(), "vm"; "/bin/ls");
 


### PR DESCRIPTION


Description:  
This pull request addresses two minor issues:
1. Fixes a typo in the documentation by correcting "enviroment" to "environment" in the sudo.8 man page.
2. Improves the clarity of a comment in the test code by rephrasing the description of the "substitution-like" alias mechanism in src/sudoers/test/mod.rs.

These changes enhance the accuracy and readability of both the documentation and the test code. No functional code changes are introduced.