### PR TITLE
Fix Typos in Documentation Comments

### DIFF
--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -6,7 +6,7 @@ use crate::common::{
 };
 use crate::sudoers::ast::{ExecControl, Tag};
 use crate::system::{time::Duration, Hostname, User};
-/// Data types and traits that represent what the "terms and conditions" are after a succesful
+/// Data types and traits that represent what the "terms and conditions" are after a successful
 /// permission check.
 ///
 /// The trait definitions can be part of some global crate in the future, if we support more

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -145,7 +145,7 @@ impl<T: Many> Many for Meta<T> {
     const LIMIT: usize = T::LIMIT;
 }
 
-/// An identifier that consits of only uppercase characters.
+/// An identifier that consists of only uppercase characters.
 pub struct AliasName(pub String);
 
 impl Token for AliasName {


### PR DESCRIPTION


Description:  
This pull request corrects minor spelling errors in documentation comments within the codebase. Specifically, it fixes the words "successful" and "consists" in the files `src/sudoers/policy.rs` and `src/sudoers/tokens.rs`, respectively. No functional code changes were made; only documentation comments were updated for clarity and correctness.