### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/src/sudoers/entry.rs
+++ b/src/sudoers/entry.rs
@@ -263,7 +263,7 @@ fn write_spec<'a>(
                     // 1) this recursion will terminate, since "alias_list" has become smaller
                     //    by the "alias_list.find()" above
                     // 2) to get the correct macro expansion, alias_list has to be (reverse-)topologically
-                    //    sorted so that "later" definitions do not refer back to "earlier" definitons.
+                    //    sorted so that "later" definitions do not refer back to "earlier" definitions.
                     write_spec(f, spec, alias_list.clone(), sign, separator)?;
                     is_first_iteration = false;
                 }

--- a/src/system/interface.rs
+++ b/src/system/interface.rs
@@ -107,7 +107,7 @@ impl FromStr for UserId {
     }
 }
 
-/// This trait/module is here to not make this crate independent (at the present time) in the idiosyncracies of user representation details
+/// This trait/module is here to not make this crate independent (at the present time) in the idiosyncrasies of user representation details
 /// (which we may decide over time), as well as to make explicit what functionality a user-representation must have; this
 /// interface is not set in stone and "easy" to change.
 pub trait UnixUser {


### PR DESCRIPTION


Description:
This pull request corrects minor spelling mistakes in code comments and documentation to improve clarity and maintain code quality. 