### PR TITLE
Fix typos in comments

### DIFF
--- a/src/exec/noexec.rs
+++ b/src/exec/noexec.rs
@@ -307,7 +307,7 @@ pub(crate) fn add_noexec_filter(command: &mut Command) -> SpawnNoexecHandler {
                 return Err(io::Error::last_os_error());
             }
 
-            // While the man page warns againt using seccomp_unotify as security
+            // While the man page warns against using seccomp_unotify as security
             // mechanism, the TOCTOU problem that is described there isn't
             // relevant here. We only SECCOMP_USER_NOTIF_FLAG_CONTINUE the first
             // execve which is done by ourself and thus trusted.

--- a/src/system/timestamp.rs
+++ b/src/system/timestamp.rs
@@ -216,7 +216,7 @@ impl SessionRecordFile {
     }
 
     /// Disable all records that match the given scope. If an auth user id is
-    /// given then only records with the given scope that are targetting that
+    /// given then only records with the given scope that are targeting that
     /// specific user will be disabled.
     pub fn disable(&mut self, scope: RecordScope, auth_user: Option<UserId>) -> io::Result<()> {
         let lock = FileLock::exclusive(&self.file, false)?;


### PR DESCRIPTION


**Description:**

This pull request contains minor typographical fixes in comments.

- In `src/exec/noexec.rs`, "againt" has been corrected to "against".
- In `src/system/timestamp.rs`, "targetting" has been corrected to "targeting".

These changes improve code readability and do not affect functionality.