### PR TITLE
Fix the permission flags that visudo sets on the temporary file

### DIFF
--- a/src/visudo/mod.rs
+++ b/src/visudo/mod.rs
@@ -226,7 +226,7 @@ fn run(file_arg: Option<&str>, perms: bool, owner: bool) -> io::Result<()> {
         .truncate(true)
         .open(&tmp_path)?;
 
-    tmp_file.set_permissions(Permissions::from_mode(0o700))?;
+    tmp_file.set_permissions(Permissions::from_mode(0o600))?;
 
     let result = edit_sudoers_file(
         existed,

--- a/test-framework/sudo-compliance-tests/src/visudo.rs
+++ b/test-framework/sudo-compliance-tests/src/visudo.rs
@@ -160,7 +160,14 @@ ls -l /tmp/sudoers-*/sudoers > {LOGS_PATH}"#
 
     let ls_output = Command::new("cat").arg(LOGS_PATH).output(&env).stdout();
 
-    assert_ls_output(&ls_output, "-rwx------", "root", ROOT_GROUP);
+    if sudo_test::is_original_sudo() {
+        //TODO: this is incorrect, will be fixed in a future sudo; the
+        //point of the test anyway is that the file is not accessible
+        //by any other than the owner.
+        assert_ls_output(&ls_output, "-rwx------", "root", ROOT_GROUP);
+    } else {
+        assert_ls_output(&ls_output, "-rw-------", "root", ROOT_GROUP);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Discovered by Bjorn