### PR TITLE
Add path resolution for sudoedit

### DIFF
--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{env, io};
 
 use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2};
 use crate::exec::{RunOptions, Umask};
@@ -36,7 +36,7 @@ pub struct Context {
     pub umask: Umask,
     // sudoedit
     #[cfg_attr(not(feature = "sudoedit"), allow(unused))]
-    pub files_to_edit: Vec<Option<std::path::PathBuf>>,
+    pub files_to_edit: Vec<Option<SudoPath>>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -77,7 +77,7 @@ impl Context {
             let path = if let Some(path) = override_path {
                 path
             } else {
-                system_path = std::env::var("PATH").unwrap_or_default();
+                system_path = env::var("PATH").unwrap_or_default();
                 system_path.as_ref()
             };
 
@@ -122,7 +122,7 @@ impl Context {
 
         let files_to_edit = resolved_args
             .clone()
-            .map(|path| path.ok().map(|path| path.into()))
+            .map(|path| path.ok().map(SudoPath::from_cli_string))
             .collect();
 
         // if a path resolved to something that isn't in UTF-8, it means it isn't in the sudoers file
@@ -211,7 +211,7 @@ impl Context {
             let path = if let Some(path) = override_path {
                 path
             } else {
-                system_path = std::env::var("PATH").unwrap_or_default();
+                system_path = env::var("PATH").unwrap_or_default();
                 system_path.as_ref()
             };
 

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -115,7 +115,7 @@ impl Context {
 
         // resolve file arguments; if something can't be resolved, don't add it to the "edit" list
         let resolved_args = sudo_options.positional_args.iter().map(|arg| {
-            std::fs::canonicalize(arg)
+            crate::common::resolve::canonicalize_newfile(arg)
                 .map_err(|_| arg)
                 .and_then(|path| path.into_os_string().into_string().map_err(|_| arg))
         });

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -136,6 +136,7 @@ fn create_test_context(sudo_options: SudoRunOptions) -> Context {
         noexec: false,
         bell: false,
         umask: Umask::Preserve,
+        files_to_edit: vec![],
     }
 }
 

--- a/src/sudo/pipeline/edit.rs
+++ b/src/sudo/pipeline/edit.rs
@@ -21,13 +21,19 @@ pub fn run_edit(edit_opts: SudoEditOptions) -> Result<(), Error> {
 
     let pid = context.process.pid;
 
+    for (path, arg) in context.files_to_edit.iter().zip(&context.command.arguments) {
+        if path.is_none() {
+            eprintln_ignore_io_error!("invalid path: {arg}")
+        }
+    }
+
     // run command and return corresponding exit code
     let command_exit_reason = {
         super::log_command_execution(&context);
 
         eprintln_ignore_io_error!(
             "this would launch sudoedit as requested, to edit the files: {:?}",
-            context.command.arguments.as_slice()
+            context.files_to_edit.as_slice()
         );
 
         Ok::<_, std::io::Error>(ExitReason::Code(42))


### PR DESCRIPTION
I'm out of ideas for naming the functions `canonicalize` and `canonicalize_newfile`. I'd like to wait with resolving #1191 until a first version of Sudoedit is completely merged.