### PR TITLE
Sudoedit entrypoint

### DIFF
--- a/src/sudo/cli/help.rs
+++ b/src/sudo/cli/help.rs
@@ -1,9 +1,9 @@
 pub const USAGE_MSG: &str = "\
 usage: sudo -h | -K | -k | -V
-usage: sudo -v [-BknS] [-g group] [-u user]
-usage: sudo -l [-BknS] [-g group] [-U user] [-u user] [command [arg ...]]
-usage: sudo [-BknS] [-D directory] [-g group] [-u user] [-i | -s] [command [arg ...]]
-usage: sudo -e [-BknS] [-D directory] [-g group] [-u user] file ...";
+usage: sudo [-BknS] [-p prompt] [-D directory] [-g group] [-u user] [-i | -s] [command [arg ...]]
+usage: sudo -v [-BknS] [-p prompt] [-g group] [-u user]
+usage: sudo -l [-BknS] [-p prompt] [-g group] [-U user] [-u user] [command [arg ...]]
+usage: sudo -e [-BknS] [-p prompt] [-D directory] [-g group] [-u user] file ...";
 
 const DESCRIPTOR: &str = "sudo - run commands as another user";
 
@@ -17,6 +17,7 @@ const HELP_MSG: &str = "Options:
   -k, --reset-timestamp         invalidate timestamp file
   -l, --list                    list user's privileges or check a specific command; use twice for longer format
   -n, --non-interactive         non-interactive mode, no prompts are used
+  -p, --prompt=prompt           use the specified password prompt
   -S, --stdin                   read password from standard input
   -s, --shell                   run shell as the target user; a command may also be specified
   -U, --other-user=user         in list mode, display privileges for user

--- a/src/sudo/cli/help_edit.rs
+++ b/src/sudo/cli/help_edit.rs
@@ -1,0 +1,23 @@
+pub const USAGE_MSG: &str = "\
+usage: sudoedit -h | -V
+usage: sudoedit [-BknS] [-p prompt] [-g group] [-u user] file ...";
+
+const DESCRIPTOR: &str = "sudo - edit files as another user";
+
+const HELP_MSG: &str = "Options:
+Options:
+  -B, --bell                    ring bell when prompting
+  -g, --group=group             run command as the specified group name or ID
+  -h, --help                    display help message and exit
+  -k, --reset-timestamp         invalidate timestamp file
+  -n, --non-interactive         non-interactive mode, no prompts are used
+  -p, --prompt=prompt           use the specified password prompt
+  -S, --stdin                   read password from standard input
+  -u, --user=user               run command (or edit file) as specified user
+                                name or ID
+  -V, --version                 display version information and exit
+  --                            stop processing command line arguments";
+
+pub fn long_help_message() -> String {
+    format!("{DESCRIPTOR}\n{USAGE_MSG}\n{HELP_MSG}")
+}

--- a/src/sudo/cli/mod.rs
+++ b/src/sudo/cli/mod.rs
@@ -5,6 +5,8 @@ use std::{borrow::Cow, mem};
 use crate::common::{SudoPath, SudoString};
 
 pub mod help;
+#[cfg_attr(not(feature = "sudoedit"), allow(unused))]
+pub mod help_edit;
 
 #[cfg(test)]
 mod tests;
@@ -518,12 +520,11 @@ impl SudoArg {
     ];
 
     /// argument assignments and shorthand options preprocessing
-    fn normalize_arguments<I>(iter: I) -> Result<Vec<Self>, String>
+    /// the iterator should only iterate over the actual arguments
+    fn normalize_arguments<I>(mut arg_iter: I) -> Result<Vec<Self>, String>
     where
-        I: IntoIterator<Item = String>,
+        I: Iterator<Item = String>,
     {
-        // the first argument is the sudo command - so we can skip it
-        let mut arg_iter = iter.into_iter().skip(1);
         let mut processed = vec![];
 
         while let Some(arg) = arg_iter.next() {
@@ -628,8 +629,20 @@ impl SudoOptions {
         I: IntoIterator<Item = T>,
         T: Into<String> + Clone,
     {
-        let mut options = Self::default();
-        let arg_iter = SudoArg::normalize_arguments(iter.into_iter().map(Into::into))?
+        let mut arg_iter = iter.into_iter().map(Into::into);
+
+        use std::os::unix::ffi::OsStrExt;
+
+        let invoked_as_sudoedit = std::path::Path::new(&arg_iter.next().unwrap_or_default())
+            .file_name()
+            .is_some_and(|name| name.as_bytes().starts_with(b"sudoedit"));
+
+        let mut options = Self {
+            edit: invoked_as_sudoedit,
+            ..Self::default()
+        };
+
+        let arg_iter = SudoArg::normalize_arguments(arg_iter)?
             .into_iter()
             .peekable();
 
@@ -644,7 +657,7 @@ impl SudoOptions {
                             "warning: preserving the entire environment is not supported, `{flag}` is ignored"
                         )
                     }
-                    "-e" | "--edit" => {
+                    "-e" | "--edit" if !invoked_as_sudoedit => {
                         options.edit = true;
                     }
                     "-H" | "--set-home" => {

--- a/src/sudo/cli/mod.rs
+++ b/src/sudo/cli/mod.rs
@@ -23,6 +23,13 @@ pub enum SudoAction {
     Version(SudoVersionOptions),
 }
 
+pub(super) fn is_sudoedit(command_path: Option<String>) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+    std::path::Path::new(&command_path.unwrap_or_default())
+        .file_name()
+        .is_some_and(|name| name.as_bytes().starts_with(b"sudoedit"))
+}
+
 impl SudoAction {
     /// try to parse and environment variable assignment
     /// parse command line arguments from the environment and handle errors
@@ -631,11 +638,7 @@ impl SudoOptions {
     {
         let mut arg_iter = iter.into_iter().map(Into::into);
 
-        use std::os::unix::ffi::OsStrExt;
-
-        let invoked_as_sudoedit = std::path::Path::new(&arg_iter.next().unwrap_or_default())
-            .file_name()
-            .is_some_and(|name| name.as_bytes().starts_with(b"sudoedit"));
+        let invoked_as_sudoedit = is_sudoedit(arg_iter.next());
 
         let mut options = Self {
             edit: invoked_as_sudoedit,

--- a/src/sudo/cli/mod.rs
+++ b/src/sudo/cli/mod.rs
@@ -116,8 +116,6 @@ impl TryFrom<SudoOptions> for SudoHelpOptions {
         let help = mem::take(&mut opts.help);
         debug_assert!(help);
 
-        reject_all("--help", opts)?;
-
         Ok(Self {})
     }
 }
@@ -132,8 +130,6 @@ impl TryFrom<SudoOptions> for SudoVersionOptions {
         // see `SudoOptions::validate`
         let version = mem::take(&mut opts.version);
         debug_assert!(version);
-
-        reject_all("--version", opts)?;
 
         Ok(Self {})
     }

--- a/src/sudo/cli/tests.rs
+++ b/src/sudo/cli/tests.rs
@@ -316,7 +316,13 @@ fn edit() {
     let cmd = SudoAction::try_parse_from(["sudo", "--edit", "filepath"]).unwrap();
     assert!(cmd.is_edit());
 
+    let cmd = SudoAction::try_parse_from(["sudoedit", "filepath"]).unwrap();
+    assert!(cmd.is_edit());
+
     let res = SudoAction::try_parse_from(["sudo", "--edit"]);
+    assert!(res.is_err());
+
+    let res = SudoAction::try_parse_from(["sudoedit", "--edit", "filepath"]);
     assert!(res.is_err());
 }
 

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -68,7 +68,7 @@ fn sudo_process() -> Result<(), Error> {
 
     let usage_msg: &str;
     let long_help: fn() -> String;
-    if std::env::args().next().as_deref() == Some("sudoedit") {
+    if cli::is_sudoedit(std::env::args().next()) {
         usage_msg = cli::help_edit::USAGE_MSG;
         long_help = cli::help_edit::long_help_message;
     } else {

--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -7,7 +7,6 @@ use crate::system::interface::UserId;
 use crate::system::timestamp::RecordScope;
 use crate::system::User;
 use crate::system::{time::Duration, timestamp::SessionRecordFile, Process};
-use cli::help;
 #[cfg(test)]
 pub(crate) use cli::SudoAction;
 #[cfg(not(test))]
@@ -67,11 +66,21 @@ fn sudo_process() -> Result<(), Error> {
 
     self_check()?;
 
+    let usage_msg: &str;
+    let long_help: fn() -> String;
+    if std::env::args().next().as_deref() == Some("sudoedit") {
+        usage_msg = cli::help_edit::USAGE_MSG;
+        long_help = cli::help_edit::long_help_message;
+    } else {
+        usage_msg = cli::help::USAGE_MSG;
+        long_help = cli::help::long_help_message;
+    }
+
     // parse cli options
     match SudoAction::from_env() {
         Ok(action) => match action {
             SudoAction::Help(_) => {
-                eprintln_ignore_io_error!("{}", help::long_help_message());
+                eprintln_ignore_io_error!("{}", long_help());
                 std::process::exit(0);
             }
             SudoAction::Version(_) => {
@@ -98,7 +107,7 @@ fn sudo_process() -> Result<(), Error> {
             SudoAction::Run(options) => {
                 // special case for when no command is given
                 if options.positional_args.is_empty() && !options.shell && !options.login {
-                    eprintln_ignore_io_error!("{}", help::USAGE_MSG);
+                    eprintln_ignore_io_error!("{}", usage_msg);
                     std::process::exit(1);
                 } else {
                     #[cfg(feature = "dev")]
@@ -117,7 +126,7 @@ fn sudo_process() -> Result<(), Error> {
             }
         },
         Err(e) => {
-            eprintln_ignore_io_error!("{e}\n{}", help::USAGE_MSG);
+            eprintln_ignore_io_error!("{e}\n{}", usage_msg);
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
This adds code to recognize when `sudo-rs` is run as `sudoedit` and then switches behaviour accordingly.

Because people might package it as sudoedit-rs i've used a `.starts_with()` check instead of strict equality. I would still say it's not the recommended name. But definitely we're not going to bake in support for an abomination such as `sudo-rsedit`. :-)