### PR TITLE
Add support for `editor`

### DIFF
--- a/src/defaults/mod.rs
+++ b/src/defaults/mod.rs
@@ -34,7 +34,6 @@ defaults! {
     use_pty                   = true
     visiblepw                 = false  #ignored
     pwfeedback                = false
-    env_editor                = true
     rootpw                    = false
     targetpw                  = false
     noexec                    = false
@@ -54,6 +53,9 @@ defaults! {
 
     passwd_timeout            = (5*60) (!= 0) {fractional_minutes}
     timestamp_timeout         = (15*60) (!= 0) {fractional_minutes}
+
+    editor                    = "/usr/bin/editor"
+    env_editor                = true
 
     env_keep                  = ["COLORS", "DISPLAY", "HOSTNAME", "KRB5CCNAME", "LS_COLORS", "PATH",
                                  "PS1", "PS2", "XAUTHORITY", "XAUTHORIZATION", "XDG_CURRENT_DESKTOP"]

--- a/src/sudo/pipeline/edit.rs
+++ b/src/sudo/pipeline/edit.rs
@@ -33,9 +33,16 @@ pub fn run_edit(edit_opts: SudoEditOptions) -> Result<(), Error> {
     let command_exit_reason = {
         super::log_command_execution(&context);
 
+        let editor = policy.preferred_editor();
+
         eprintln_ignore_io_error!(
-            "this would launch sudoedit as requested, to edit the files: {:?}",
-            context.files_to_edit.as_slice()
+            "this would launch sudoedit as requested, to edit the files: {:?} using editor {}",
+            context
+                .files_to_edit
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>(),
+            editor.display(),
         );
 
         Ok::<_, std::io::Error>(ExitReason::Code(42))

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -297,10 +297,26 @@ impl Sudoers {
         target_user: &User,
     ) -> PathBuf {
         self.specify_host_user_runas(on_host, am_user, Some(target_user));
+
+        let env_editor = self.settings.env_editor();
+        self.select_editor(env_editor)
+    }
+
+    #[cfg_attr(not(feature = "sudoedit"), allow(unused))]
+    pub(crate) fn sudoedit_editor_path<User: UnixUser + PartialEq<User>>(
+        &self,
+        on_host: &system::Hostname,
+        am_user: &User,
+        target_user: &User,
+    ) -> PathBuf {
+        self.select_editor(true)
+    }
+
+    fn select_editor(&self, trusted_env: bool) -> PathBuf {
         let blessed_editors = self.settings.editor().expect("editor is always defined");
 
         let is_whitelisted = |path: &Path| -> bool {
-            self.settings.env_editor() || blessed_editors.split(':').any(|x| Path::new(x) == path)
+            trusted_env || blessed_editors.split(':').any(|x| Path::new(x) == path)
         };
 
         // find editor in environment, if possible

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -142,6 +142,11 @@ impl Judgement {
             Authorization::Forbidden
         }
     }
+
+    #[cfg_attr(not(feature = "sudoedit"), allow(unused))]
+    pub(crate) fn preferred_editor(&self) -> std::path::PathBuf {
+        super::select_editor(&self.settings, true)
+    }
 }
 
 impl Sudoers {


### PR DESCRIPTION
This
- acts as an (optional) whitelist and fallback for `visudo`
- acts as a fallback list for `sudoedit`