### PR TITLE
FreeBSD fixes

### DIFF
--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -106,7 +106,8 @@ pub fn run_command(
 
     let spawn_noexec_handler = if options.noexec {
         #[cfg(not(target_os = "linux"))]
-        return Err(io::Error::other(
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
             "NOEXEC is currently only supported on Linux",
         ));
 

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -792,9 +792,10 @@ impl Process {
         }
 
         let ki_start = ki_proc[0].ki_start;
+        #[allow(clippy::useless_conversion)]
         Ok(ProcessCreateTime::new(
-            ki_start.tv_sec,
-            ki_start.tv_usec * 1000,
+            i64::from(ki_start.tv_sec),
+            i64::from(ki_start.tv_usec) * 1000,
         ))
     }
 }


### PR DESCRIPTION
- compilation on 32-bit target gave the usual compilation error
- the MSRV for FreeBSD was secretly 1.74. not a big issue (FreeBSD is very up to date)

There are still two clippy lints about missing SAFETY docs for the sysctl's, I've created #1201 to track that.