### PR TITLE
Fix a bunch of nightly warnings

### DIFF
--- a/src/common/bin_serde.rs
+++ b/src/common/bin_serde.rs
@@ -87,7 +87,7 @@ impl<R: DeSerialize, W: DeSerialize> BinPipe<R, W> {
 }
 
 impl<R: DeSerialize, W: DeSerialize> AsFd for BinPipe<R, W> {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.sock.as_fd()
     }
 }

--- a/src/exec/use_pty/backchannel.rs
+++ b/src/exec/use_pty/backchannel.rs
@@ -191,7 +191,7 @@ impl ParentBackchannel {
 }
 
 impl AsFd for ParentBackchannel {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.socket.as_fd()
     }
 }
@@ -310,7 +310,7 @@ impl MonitorBackchannel {
 }
 
 impl AsFd for MonitorBackchannel {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.socket.as_fd()
     }
 }

--- a/src/pam/converse.rs
+++ b/src/pam/converse.rs
@@ -107,7 +107,7 @@ pub struct CLIConverser {
 use rpassword::Terminal;
 
 impl CLIConverser {
-    fn open(&self) -> std::io::Result<Terminal> {
+    fn open(&self) -> std::io::Result<Terminal<'_>> {
         if self.use_stdin {
             Terminal::open_stdie()
         } else {

--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -316,7 +316,7 @@ impl Terminal<'_> {
         }
     }
 
-    fn source_timeout(&self, timeout: Option<Duration>) -> TimeoutRead {
+    fn source_timeout(&self, timeout: Option<Duration>) -> TimeoutRead<'_> {
         match self {
             Terminal::StdIE(stdin, _) => TimeoutRead::new(stdin.as_fd(), timeout),
             Terminal::Tty(file) => TimeoutRead::new(file.as_fd(), timeout),

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -616,11 +616,11 @@ fn match_group_alias(group: &impl UnixGroup) -> impl Fn(&UserSpecifier) -> bool 
 
 fn match_token<T: basic_parser::Token + std::ops::Deref<Target = String>>(
     text: &str,
-) -> (impl Fn(&T) -> bool + '_) {
+) -> impl Fn(&T) -> bool + '_ {
     move |token| token.as_str() == text
 }
 
-fn match_command<'a>((cmd, args): (&'a Path, &'a [String])) -> (impl Fn(&Command) -> bool + 'a) {
+fn match_command<'a>((cmd, args): (&'a Path, &'a [String])) -> impl Fn(&Command) -> bool + 'a {
     let opts = glob::MatchOptions {
         require_literal_separator: true,
         ..glob::MatchOptions::new()

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -222,7 +222,7 @@ mod test {
             flags: Some(Tag::default()),
             ..Default::default()
         };
-        fn chdir(judge: &mut Judgement) -> DirChange {
+        fn chdir(judge: &mut Judgement) -> DirChange<'_> {
             let Authorization::Allowed(_, ctl) = judge.authorization() else {
                 panic!()
             };

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -87,7 +87,7 @@ pub enum AuthenticatingUser {
 }
 
 impl Judgement {
-    pub fn authorization(&self) -> Authorization<Restrictions> {
+    pub fn authorization(&self) -> Authorization<Restrictions<'_>> {
         // NOTE: we should add conditional compilation to the DSL; this avoids getting
         // an unused warning message
         #[cfg(not(feature = "apparmor"))]

--- a/src/system/signal/stream.rs
+++ b/src/system/signal/stream.rs
@@ -106,7 +106,7 @@ pub(crate) fn register_handlers<const N: usize>(
 }
 
 impl AsFd for SignalStream {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.rx.as_fd()
     }
 }

--- a/src/system/term/user_term.rs
+++ b/src/system/term/user_term.rs
@@ -293,7 +293,7 @@ impl UserTerm {
 }
 
 impl AsFd for UserTerm {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.tty.as_fd()
     }
 }


### PR DESCRIPTION
* warn(unused_parens): unnecessary parentheses around type
* warn(mismatched_lifetime_syntaxes): hiding a lifetime that's elided elsewhere is confusing