### PR TITLE
Fix uid_t and gid_t being used the wrong way around in sudo_call

### DIFF
--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -20,8 +20,8 @@ fn sudo_call<T>(
     target_group: &Group,
     operation: impl FnOnce() -> T,
 ) -> io::Result<T> {
-    const KEEP_UID: libc::gid_t = -1i32 as libc::gid_t;
-    const KEEP_GID: libc::uid_t = -1i32 as libc::uid_t;
+    const KEEP_UID: libc::uid_t = -1i32 as libc::uid_t;
+    const KEEP_GID: libc::gid_t = -1i32 as libc::gid_t;
 
     let cur_groups = {
         // SAFETY: calling with size 0 does not modify through the pointer, and is


### PR DESCRIPTION
This is a harmless issue as both type aliases are generally identical. And if they aren't we just get an error on the setres*id call.

Fixes https://github.com/trifectatechfoundation/sudo-rs/pull/1204#discussion_r2222185035