### PR TITLE
Sudoedit compliance tests (batch 2)

### DIFF
--- a/src/sudo/pipeline/edit.rs
+++ b/src/sudo/pipeline/edit.rs
@@ -43,7 +43,7 @@ pub fn run_edit(edit_opts: SudoEditOptions) -> Result<(), Error> {
 
     if opened_files.len() != context.files_to_edit.len() {
         eprintln_ignore_io_error!("please address the problems and try again");
-        return Ok(());
+        return Err(Error::Silent);
     }
 
     // run command and return corresponding exit code

--- a/src/sudo/pipeline/edit.rs
+++ b/src/sudo/pipeline/edit.rs
@@ -35,7 +35,8 @@ pub fn run_edit(edit_opts: SudoEditOptions) -> Result<(), Error> {
                 &context.target_group,
             ) {
                 Ok(file) => opened_files.push((path, file)),
-                Err(error) if error.raw_os_error() == Some(40) => {
+                // ErrorKind::FilesystemLoop was only stabilized in 1.83
+                Err(error) if error.raw_os_error() == Some(libc::ELOOP) => {
                     user_error!("{arg}: editing symbolic links is not permitted")
                 }
                 Err(error) => user_error!("error opening {arg}: {error}"),

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -248,7 +248,7 @@ fn traversed_secure_open(path: impl AsRef<Path>, forbidden_user: &User) -> io::R
         {
             Err(io::Error::new(
                 ErrorKind::PermissionDenied,
-                "cannot open a file in a path writeable by the user",
+                "cannot open a file in a path writable by the user",
             ))
         } else {
             Ok(())
@@ -291,13 +291,13 @@ mod test {
         assert!(std::fs::File::open("/etc/hosts").is_ok());
         assert!(secure_open_sudoers("/etc/hosts", false).is_ok());
 
-        // /tmp should be readable, but not secure (writeable by group other than root)
+        // /tmp should be readable, but not secure (writable by group other than root)
         assert!(std::fs::File::open("/tmp").is_ok());
         assert!(secure_open_sudoers("/tmp", false).is_err());
 
         #[cfg(target_os = "linux")]
         {
-            // /var/log/wtmp should be readable, but not secure (writeable by group other than root)
+            // /var/log/wtmp should be readable, but not secure (writable by group other than root)
             // It doesn't exist on many non-Linux systems however.
             if std::fs::File::open("/var/log/wtmp").is_ok() {
                 assert!(secure_open_sudoers("/var/log/wtmp", false).is_err());

--- a/test-framework/sudo-compliance-tests/src/sudoedit.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoedit.rs
@@ -6,6 +6,8 @@ use crate::{
     Result, DEFAULT_EDITOR, GROUPNAME, PANIC_EXIT_CODE, SUDOERS_ALL_ALL_NOPASSWD, USERNAME,
 };
 
+mod limits;
+
 const LOGS_PATH: &str = "/tmp/logs.txt";
 const CHMOD_EXEC: &str = "555";
 const EDITOR_DUMMY: &str = "#!/bin/sh

--- a/test-framework/sudo-compliance-tests/src/sudoedit/limits.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoedit/limits.rs
@@ -1,0 +1,41 @@
+use sudo_test::{Command, Directory, Env, TextFile, ROOT_GROUP};
+
+use crate::{DEFAULT_EDITOR, SUDOERS_ALL_ALL_NOPASSWD, USERNAME};
+
+const CHMOD_EXEC: &str = "555";
+const EDITOR_DUMMY: &str = "#!/bin/sh
+echo \"#\" >> \"$1\"";
+
+#[test]
+fn cannot_edit_writable_paths() {
+    let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
+        .user(USERNAME)
+        .directory(Directory("/tmp/bar").chmod("755"))
+        .file(DEFAULT_EDITOR, TextFile(EDITOR_DUMMY).chmod(CHMOD_EXEC))
+        .build();
+
+    for file in ["/tmp/foo.sh", "/tmp/bar/foo.sh", "/var/tmp/foo.sh"] {
+        let output = Command::new("sudoedit")
+            .as_user(USERNAME)
+            .arg(file)
+            .output(&env);
+
+        if sudo_test::is_original_sudo() {
+            if file != "/tmp/bar/foo.sh" {
+                assert_contains!(
+                    output.stderr(),
+                    "editing files in a writable directory is not permitted"
+                );
+            } else {
+                // I don't know why ogsudo gives this error -- probably because opening failed
+                assert_contains!(output.stderr(), "No such file or directory");
+            }
+        } else {
+            assert_contains!(
+                output.stderr(),
+                "cannot open a file in a path writable by the user"
+            );
+        }
+        output.assert_exit_code(1);
+    }
+}

--- a/test-framework/sudo-compliance-tests/src/sudoedit/limits.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoedit/limits.rs
@@ -41,6 +41,25 @@ fn cannot_edit_writable_paths() {
 }
 
 #[test]
+fn can_edit_writable_paths_as_root() {
+    // note: we already have tests that sudoedit "works" so we are skipping
+    // the content check here---the point here is that sudoedit does not stop
+    // the user.
+
+    let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
+        .user(USERNAME)
+        .directory(Directory("/tmp/bar").chmod("755"))
+        .file(DEFAULT_EDITOR, TextFile(EDITOR_DUMMY).chmod(CHMOD_EXEC))
+        .build();
+
+    let file = "/tmp/foo.sh";
+    Command::new("sudoedit")
+        .arg(file)
+        .output(&env)
+        .assert_success();
+}
+
+#[test]
 fn cannot_edit_symlinks() {
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
         .user(USERNAME)

--- a/test-framework/sudo-compliance-tests/src/sudoedit/limits.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoedit/limits.rs
@@ -39,3 +39,22 @@ fn cannot_edit_writable_paths() {
         output.assert_exit_code(1);
     }
 }
+
+#[test]
+fn cannot_edit_symlinks() {
+    let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
+        .user(USERNAME)
+        .file(DEFAULT_EDITOR, TextFile(EDITOR_DUMMY).chmod(CHMOD_EXEC))
+        .build();
+
+    let file = "/usr/bin/sudoedit";
+
+    let output = Command::new("sudoedit")
+        .as_user(USERNAME)
+        .arg(file)
+        .output(&env);
+
+    assert_contains!(output.stderr(), "editing symbolic links is not permitted");
+
+    output.assert_exit_code(1);
+}

--- a/test-framework/sudo-compliance-tests/src/sudoedit/limits.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoedit/limits.rs
@@ -20,6 +20,8 @@ fn cannot_edit_writable_paths() {
             .arg(file)
             .output(&env);
 
+        output.assert_exit_code(1);
+
         if sudo_test::is_original_sudo() {
             if file != "/tmp/bar/foo.sh" {
                 assert_contains!(
@@ -36,14 +38,13 @@ fn cannot_edit_writable_paths() {
                 "cannot open a file in a path writable by the user"
             );
         }
-        output.assert_exit_code(1);
     }
 }
 
 #[test]
 fn can_edit_writable_paths_as_root() {
     // note: we already have tests that sudoedit "works" so we are skipping
-    // the content check here---the point here is that sudoedit does not stop
+    // the content check here: the point here is that sudoedit does not stop
     // the user.
 
     let env = Env(SUDOERS_ALL_ALL_NOPASSWD)
@@ -123,7 +124,7 @@ fn cannot_edit_files_target_user_cannot_access() {
 #[test]
 fn can_edit_files_target_user_or_group_can_access() {
     // note: we already have tests that sudoedit "works" so we are skipping
-    // the content check here---the point here is that sudoedit does not stop
+    // the content check here: the point here is that sudoedit does not stop
     // the user.
 
     let file = "/test.txt";


### PR DESCRIPTION
WIP (builds on #1213 )

- [x] tests for editing files as root (linked to issue #1212)
- [x] testing restrictions on the *target user* when running `sudoedit -u / sudoedit -g`(e.g. `sudoedit -u ferris` won't allow editing a file that `ferris` can't edit)
- [x] not being able to edit files where some part of the path is writable by the current user
- [x] show that `sudoedit /path/to/symlink` in the sudoers policy will not allow the user to do `sudoedit /path/to/symlink`