### PR TITLE
Remove documentation for the ignored flags of `visudo`

### DIFF
--- a/docs/man/visudo.8.man
+++ b/docs/man/visudo.8.man
@@ -21,15 +21,6 @@ specified as \f[I]sudoers\f[R] instead.
 \f[CR]\-h\f[R], \f[CR]\-\-help\f[R]
 Show a help message.
 .TP
-\f[CR]\-I\f[R], \f[CR]\-\-no\-includes\f[R]
-Do not edit included files.
-.TP
-\f[CR]\-q\f[R], \f[CR]\-\-quiet\f[R]
-Less verbose syntax error messages.
-.TP
-\f[CR]\-s\f[R], \f[CR]\-\-strict\f[R]
-Strict syntax checking.
-.TP
 \f[CR]\-V\f[R], \f[CR]\-\-version\f[R]
 Display version information and exit.
 .SH SEE ALSO

--- a/docs/man/visudo.8.md
+++ b/docs/man/visudo.8.md
@@ -26,15 +26,6 @@ title: VISUDO(8) sudo-rs 0.2.8 | sudo-rs
 `-h`, `--help`
 :   Show a help message.
 
-`-I`, `--no-includes`
-:   Do not edit included files.
-
-`-q`, `--quiet`
-:   Less verbose syntax error messages.
-
-`-s`, `--strict`
-:   Strict syntax checking.
-
 `-V`, `--version`
 :   Display version information and exit.
 

--- a/src/visudo/cli.rs
+++ b/src/visudo/cli.rs
@@ -1,9 +1,6 @@
 #[derive(Debug, PartialEq)]
 pub(crate) struct VisudoOptions {
     pub(crate) file: Option<String>,
-    pub(crate) includes: bool,
-    pub(crate) quiet: bool,
-    pub(crate) strict: bool,
     pub(crate) owner: bool,
     pub(crate) perms: bool,
     pub(crate) action: VisudoAction,
@@ -13,9 +10,6 @@ impl Default for VisudoOptions {
     fn default() -> Self {
         Self {
             file: None,
-            includes: true,
-            quiet: false,
-            strict: false,
             owner: false,
             perms: false,
             action: VisudoAction::Run,
@@ -73,28 +67,22 @@ impl VisudoOptions {
             short: 'I',
             long: "no-includes",
             takes_argument: false,
-            set: |options, _| {
-                options.includes = true;
-                Ok(())
-            },
+            set: |_, _| Ok(()),
+            /* ignored for compatibility sake */
         },
         VisudoOption {
             short: 'q',
             long: "quiet",
             takes_argument: false,
-            set: |options, _| {
-                options.quiet = true;
-                Ok(())
-            },
+            set: |_, _| Ok(()),
+            /* ignored for compatibility sake */
         },
         VisudoOption {
             short: 's',
             long: "strict",
             takes_argument: false,
-            set: |options, _| {
-                options.strict = true;
-                Ok(())
-            },
+            set: |_, _| Ok(()),
+            /* ignored for compatibility sake */
         },
         VisudoOption {
             short: 'V',

--- a/src/visudo/help.rs
+++ b/src/visudo/help.rs
@@ -6,9 +6,6 @@ const HELP_MSG: &str = "Options:
   -c, --check              check-only mode
   -f, --file=sudoers       specify sudoers file location
   -h, --help               display help message and exit
-  -I, --no-includes        do not edit include files
-  -q, --quiet              less verbose (quiet) syntax error messages
-  -s, --strict             strict syntax checking
   -V, --version            display version information and exit
 ";
 


### PR DESCRIPTION
I think it can't hurt to still have them not generate  an error. I'm pretty sure `--quiet` and `--strict` don't fit our design philosophy (if sudo gives an error, so should visudo) anyway. The `-I` functionality in original sudo is a bit stale as well anyway: it doesn't edit files included by `@includedir`, and the way it opens file included through `@include` is not the most friendly (it would be better to open them all at the same time).