### PR TITLE
Increase test portability

### DIFF
--- a/src/common/resolve.rs
+++ b/src/common/resolve.rs
@@ -369,8 +369,10 @@ mod test {
     fn canonicalization() {
         assert_eq!(canonicalize("/").unwrap(), Path::new("/"));
         assert!(canonicalize("").is_err());
-        if cfg!(any(target_os = "linux", target_os = "macos")) {
-            // this test REQUIRES /usr/bin/unxz to be a symlink for /usr/bin/xz
+        if cfg!(any(target_os = "linux")) {
+            // this test REQUIRES /usr/bin/unxz to be a symlink for /usr/bin/xz or /usr/bin/busybox
+            assert!(Path::new("/bin").is_symlink());
+            assert!(Path::new("/usr/bin/unxz").is_symlink());
             assert_eq!(
                 canonicalize("/usr/bin/unxz").unwrap(),
                 Path::new("/usr/bin/unxz")
@@ -381,7 +383,8 @@ mod test {
                 Path::new("/usr/bin/unxz")
             );
         } else if cfg!(target_os = "freebsd") {
-            // this test REQUIRES /usr/bin/pkill to be a symlink for /usr/bin/pgrep
+            // this test REQUIRES /usr/bin/pkill to be a symlink
+            assert!(Path::new("/usr/bin/pkill").is_symlink());
             assert_eq!(
                 canonicalize("/usr/bin/pkill").unwrap(),
                 Path::new("/usr/bin/pkill")

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "sudoedit"), allow(dead_code))]
+use std::collections::HashSet;
 use std::ffi::{CStr, CString};
 use std::fs::{DirBuilder, File, Metadata, OpenOptions};
 use std::io::{self, Error, ErrorKind};
@@ -50,10 +51,7 @@ pub(crate) fn sudo_call<T>(
     if cfg!(test)
         && target_user.uid == cur_user_id
         && target_group.gid == cur_group_id
-        && target_groups
-            .iter()
-            .filter(|x| **x != target_group.gid)
-            .eq(cur_groups.iter().filter(|x| **x != cur_group_id))
+        && target_groups.iter().collect::<HashSet<_>>() == cur_groups.iter().collect::<HashSet<_>>()
     {
         // we are not actually switching users, simply run the closure
         // (this would also be safe in production mode, but it is a needless check)


### PR DESCRIPTION
In `sudo_call`, changing privileges should be skipped in test mode (because in testmode, we are not setuid). We wanted to make that sure, however, that in both test mode and non-test mode, `sudo_call` still behaves equivalent and so added a check that doesn't perform a privilege change if it can be determined that the current, target and supplementary groups don't change.

This check however was sensitive to the order of supplemental groups. This PR changes that so the test ignores the order.

Note that on FreeBSD, of course, the order of supplemental groups does have a slight impact (hence the reason why `inject_groups`), so if there's another way to fix this I would be open for that.