### PR TITLE
Remove unhandled exception

### DIFF
--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -587,7 +587,15 @@ fn match_user(user: &impl UnixUser) -> impl Fn(&UserSpecifier) -> bool + '_ {
         UserSpecifier::User(id) => match_identifier(user, id),
         UserSpecifier::Group(Identifier::Name(name)) => user.in_group_by_name(name.as_cstr()),
         UserSpecifier::Group(Identifier::ID(num)) => user.in_group_by_gid(GroupId::new(*num)),
-        _ => todo!(), // nonunix-groups, netgroups, etc.
+        // nonunix-groups, netgroups, etc. are not implemented
+        UserSpecifier::NonunixGroup(group) => {
+            match group {
+                Identifier::Name(name) => auth_warn!("warning: non-unix group {name} was ignored"),
+                Identifier::ID(num) => auth_warn!("warning: non-unix group #{num} was ignored"),
+            }
+
+            false
+        }
     }
 }
 


### PR DESCRIPTION
Since we don't support netgroups/non-unix groups, the right thing to do for now is to say that a non-unix group never matches instead of completely panicking.