### PR TITLE
Forbid unescaped , as part of `EnvVar`

### DIFF
--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -338,7 +338,7 @@ fn default_multi_test() {
     let (mut sudoers, _) = analyze(
         Path::new("/etc/fakesudoers"),
         sudoer![
-        "Defaults !env_editor, use_pty, secure_path=/etc, env_keep = \"FOO BAR\", env_keep -= BAR"
+        "Defaults !env_editor, use_pty, env_keep = \"FOO BAR\", env_keep -= BAR, secure_path=/etc"
     ],
     );
     sudoers.specify_host_user_runas(

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -296,7 +296,7 @@ impl Token for EnvVar {
 
     const ALLOW_ESCAPE: bool = true;
     fn escaped(c: char) -> bool {
-        matches!(c, '\\' | '=' | '#' | '"')
+        matches!(c, '\\' | '=' | '#' | '"' | ',')
     }
 }
 


### PR DESCRIPTION
Closes #1271 