### PR TITLE
docs: add NixOS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ pacman -S sudo-rs
 ```
 This will offer the functionality using the commands `su-rs` and `sudo-rs`.
 
+### NixOS
+
+On NixOS sudo-rs can be installed by adding the following to your configuration:
+
+```nix
+security.sudo-rs.enable = true;
+```
+
+This will replace the usual `sudo` and `sudoedit` commands.
+
 ### Installing our pre-compiled x86-64 binaries
 
 You can also switch to sudo-rs manually by using our pre-compiled tarballs.


### PR DESCRIPTION
I can confirm this works as a happy user for some months :-) 

Note that it appears the NixPkgs derivation doesn't touch `su`, just `sudo` and `sudoedit` ([ref](https://github.com/NixOS/nixpkgs/blob/f9e472b7846c27f1143f245c4c6aaef1710747d0/pkgs/by-name/su/sudo-rs/package.nix#L43)).

Resolves https://github.com/trifectatechfoundation/sudo-rs/issues/1275
