### PR TITLE
Support Defaults noninteractive_auth

### DIFF
--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -34,6 +34,7 @@ pub struct Context {
     pub use_pty: bool,
     pub noexec: bool,
     pub umask: Umask,
+    pub noninteractive_auth: bool,
     // sudoedit
     #[cfg_attr(not(feature = "sudoedit"), allow(unused))]
     pub files_to_edit: Vec<Option<SudoPath>>,
@@ -105,6 +106,7 @@ impl Context {
             use_pty: true,
             noexec: false,
             umask: Umask::Preserve,
+            noninteractive_auth: false,
             files_to_edit: vec![],
         })
     }
@@ -176,6 +178,7 @@ impl Context {
             use_pty: true,
             noexec: false,
             umask: Umask::Preserve,
+            noninteractive_auth: false,
             files_to_edit,
         })
     }
@@ -202,6 +205,7 @@ impl Context {
             use_pty: true,
             noexec: false,
             umask: Umask::Preserve,
+            noninteractive_auth: false,
             files_to_edit: vec![],
         })
     }
@@ -251,6 +255,7 @@ impl Context {
             use_pty: true,
             noexec: false,
             umask: Umask::Preserve,
+            noninteractive_auth: false,
             files_to_edit: vec![],
         })
     }

--- a/src/defaults/mod.rs
+++ b/src/defaults/mod.rs
@@ -43,6 +43,7 @@ defaults! {
     rootpw                    = false
     targetpw                  = false
     noexec                    = false
+    noninteractive_auth       = false
 
     insults                   = false  #ignored
 

--- a/src/sudo/env/environment.rs
+++ b/src/sudo/env/environment.rs
@@ -285,6 +285,7 @@ mod tests {
                         #[cfg(feature = "apparmor")]
                         apparmor_profile: None,
                         noexec: false,
+                        noninteractive_auth: false,
                     }
                 ),
                 expected,

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -138,6 +138,7 @@ fn create_test_context(sudo_options: SudoRunOptions) -> Context {
         noexec: false,
         bell: false,
         umask: Umask::Preserve,
+        noninteractive_auth: false,
         files_to_edit: vec![],
     }
 }
@@ -176,6 +177,7 @@ fn test_environment_variable_filtering() {
                 chdir: crate::sudoers::DirChange::Strict(None),
                 trust_environment: false,
                 umask: crate::exec::Umask::Preserve,
+                noninteractive_auth: false,
                 #[cfg(feature = "apparmor")]
                 apparmor_profile: None,
                 noexec: false,

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -191,6 +191,10 @@ fn auth_and_update_record_file(
         hostname: &context.hostname,
     })?;
     if auth_status.must_authenticate {
+        if context.non_interactive && !context.noninteractive_auth {
+            return Err(Error::InteractionRequired);
+        }
+
         attempt_authenticate(
             &mut pam_context,
             &auth_user.name,
@@ -239,6 +243,7 @@ fn apply_policy_to_context(
     context.use_pty = controls.use_pty;
     context.noexec = controls.noexec;
     context.umask = controls.umask;
+    context.noninteractive_auth = controls.noninteractive_auth;
 
     Ok(())
 }

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -66,6 +66,7 @@ pub struct Restrictions<'a> {
     pub chdir: DirChange<'a>,
     pub path: Option<&'a str>,
     pub umask: Umask,
+    pub noninteractive_auth: bool,
     #[cfg(feature = "apparmor")]
     pub apparmor_profile: Option<String>,
 }
@@ -130,6 +131,7 @@ impl Judgement {
                             Umask::Extend(mask)
                         }
                     },
+                    noninteractive_auth: self.settings.noninteractive_auth(),
                     #[cfg(feature = "apparmor")]
                     apparmor_profile: tag
                         .apparmor_profile


### PR DESCRIPTION
This allows controlling if PAM authentication modules get a chance to run even in non-interactive mode. Previously sudo-rs acted as if it was always on. This commit also changes it to be off by default to match og-sudo.

Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/1278