### PR TITLE
Add spaces to all remaining occurences of 'escaped'

### DIFF
--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -33,7 +33,7 @@ impl Token for Username {
 
     const ALLOW_ESCAPE: bool = true;
     fn escaped(c: char) -> bool {
-        matches!(c, '\\' | '"' | ',' | ':' | '=' | '!' | '(' | ')')
+        matches!(c, '\\' | '"' | ',' | ':' | '=' | '!' | '(' | ')' | ' ')
     }
 }
 


### PR DESCRIPTION
Closes #1282 

Note that adding something to the `escaped` category forbids them from occuring *without* escapes, but spaces were already forbidden in this syntactic category.
