### PR TITLE
Add fix for escaped equal argument in sudoers file

### DIFF
--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -235,6 +235,10 @@ impl<T: Token> Parse for T {
                     // we've just consumed some whitespace, we should end
                     // parsing the token but not abort it
                     reject()
+                } else if let Some(_) = stream.next_if(|c| c == '=') {
+                    // '=' can be used both escaped and un-escaped in
+                    // command arguments
+                    Ok('=')
                 } else {
                     unrecoverable!(stream, "illegal escape sequence")
                 }

--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -235,7 +235,7 @@ impl<T: Token> Parse for T {
                     // we've just consumed some whitespace, we should end
                     // parsing the token but not abort it
                     reject()
-                } else if let Some(_) = stream.next_if(|c| c == '=') {
+                } else if stream.next_if(|c| c == '=').is_some() {
                     // '=' can be used both escaped and un-escaped in
                     // command arguments
                     Ok('=')

--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -235,10 +235,6 @@ impl<T: Token> Parse for T {
                     // we've just consumed some whitespace, we should end
                     // parsing the token but not abort it
                     reject()
-                } else if stream.next_if(|c| c == '=').is_some() {
-                    // '=' can be used both escaped and un-escaped in
-                    // command arguments
-                    Ok('=')
                 } else {
                     unrecoverable!(stream, "illegal escape sequence")
                 }

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -471,6 +471,12 @@ fn gh676_percent_h_escape_unsupported() {
 }
 
 #[test]
+fn gh1295_escaped_equal_argument_ok() {
+    assert!(try_parse_line("Cmd_Alias FOO_CMD = /bin/foo --bar=1").is_some());
+    assert!(try_parse_line(r"Cmd_Alias FOO_CMD = /bin/foo --bar\=1").is_some());
+}
+
+#[test]
 fn hashsign_error() {
     assert!(parse_line("#include foo bar").is_line_comment());
 }

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -259,12 +259,13 @@ impl Token for SimpleCommand {
     }
 
     fn accept(c: char) -> bool {
-        !Self::escaped(c) && !c.is_control()
+        // '=' is allowed both escaped and un-escaped
+        ( !Self::escaped(c) || c == '=' ) && !c.is_control()
     }
 
     const ALLOW_ESCAPE: bool = true;
     fn escaped(c: char) -> bool {
-        matches!(c, '\\' | ',' | ':' | '#' | ' ')
+        matches!(c, '\\' | ',' | ':' | '=' | '#' | ' ')
     }
 }
 

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -260,7 +260,7 @@ impl Token for SimpleCommand {
 
     fn accept(c: char) -> bool {
         // '=' is allowed both escaped and un-escaped
-        ( !Self::escaped(c) || c == '=' ) && !c.is_control()
+        (!Self::escaped(c) || c == '=') && !c.is_control()
     }
 
     const ALLOW_ESCAPE: bool = true;

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -260,7 +260,7 @@ impl Token for SimpleCommand {
 
     fn accept(c: char) -> bool {
         // '=' is allowed both escaped and un-escaped
-        (!Self::escaped(c) || c == '=') && !c.is_control()
+        (!Self::escaped(c) && !c.is_control()) || c == '='
     }
 
     const ALLOW_ESCAPE: bool = true;


### PR DESCRIPTION
This fix will allow a sudoers file to contain an escaped equal sign in command arguments. More specifically, it will make both of these lines valid in a sudoers file:

```
Cmd_Alias FOO_CMD = /bin/foo --bar=1
Cmd_Alias FOO_CMD = /bin/foo --bar\=1
```
Whereas only the un-escaped version is currently allowed.

Closes #1295 