### PR TITLE
Fix a panic when exec fails with use_pty enabled

### DIFF
--- a/src/exec/use_pty/monitor.rs
+++ b/src/exec/use_pty/monitor.rs
@@ -298,9 +298,7 @@ impl<'a> MonitorClosure<'a> {
             Err(err) => registry.set_break(err),
             Ok(error_code) => {
                 // Received error code from the command, forward it to the parent.
-                self.backchannel
-                    .send(&ParentMessage::IoError(error_code))
-                    .ok();
+                registry.set_break(io::Error::from_raw_os_error(error_code));
             }
         }
     }


### PR DESCRIPTION
Previously this would panic as the parent process expected the monitor process to have alreqady broken out of the event loop before sending back an error message. Which then resulted in an edge monitor message, which is only expected to be received outside the event loop, causing a panic. By using set_break we still cause the error to be sent to the parent process, while ensuring that we are no longer inside the event loop of the monitor when doing so.