### PR TITLE
Avoid interleaving logs from different processes

### DIFF
--- a/src/log/simple_logger.rs
+++ b/src/log/simple_logger.rs
@@ -22,7 +22,8 @@ where
     }
 
     fn log(&self, record: &log::Record) {
-        let _ = writeln!(&self.target, "{}{}", self.prefix, record.args());
+        let s = format!("{}{}\n", self.prefix, record.args());
+        let _ = (&self.target).write_all(s.as_bytes());
     }
 
     fn flush(&self) {


### PR DESCRIPTION
Previously there would be multiple write calls. One for the prefix and one or more for the log arguments. Between each write call there can be another process logging part of a log message. By instead buffering the entire log and writing it as a single write we avoid this interleaving.