### PR TITLE
Don't package the audit pdfs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/trifectatechfoundation/sudo-rs"
 homepage = "https://github.com/trifectatechfoundation/sudo-rs"
 publish = true
 categories = ["command-line-interface"]
-exclude = ["proofs", "util"]
+exclude = ["audit", "proofs", "util"]
 
 rust-version = "1.70"
 


### PR DESCRIPTION
This saves about 800KB on the compressed
crates.io upload, reducing it down to about 200KB.