### PR TITLE
Use trusted publishing for publishing to crates.io

### DIFF
--- a/.github/workflows/publish-crates-io.yml
+++ b/.github/workflows/publish-crates-io.yml
@@ -1,0 +1,21 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [released] # only when creating a full release (not pre-release or draft)
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    environment: publish
+    permissions:
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+      id: auth
+    - run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
The publishing is done from a different workflow than the release to ensure that the publishing only happens after we the draft release created by the release workflow is published on github.

This workflow file is based on https://github.com/rust-lang/ar_archive_writer/blob/master/.github/workflows/publish.yml

Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/1332