### PR TITLE
Fix a lint warning introduced on nightly

### DIFF
--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -126,8 +126,7 @@ fn read_unbuffered(
 
     // invariant: the amount of nonzero-bytes in the buffer correspond
     // with the amount of asterisks on the terminal (both tracked in `pw_len`)
-    //TODO: we actually only want to allow clippy::unbuffered_bytes
-    #[allow(clippy::perf)]
+    #[allow(clippy::unbuffered_bytes)]
     for read_byte in source.bytes() {
         let read_byte = read_byte?;
 

--- a/src/system/signal/set.rs
+++ b/src/system/signal/set.rs
@@ -24,7 +24,7 @@ impl SignalAction {
                 // Specify that we want to pass a signal-catching function in `sa_sigaction`.
                 sa_flags |= libc::SA_SIGINFO;
                 (
-                    super::stream::send_siginfo as libc::sighandler_t,
+                    super::stream::send_siginfo as *const () as libc::sighandler_t,
                     SignalSet::full()?,
                 )
             }

--- a/src/system/term/user_term.rs
+++ b/src/system/term/user_term.rs
@@ -85,7 +85,7 @@ fn catching_sigttou(mut function: impl FnMut() -> io::Result<()>) -> io::Result<
     let action = {
         let mut raw: libc::sigaction = make_zeroed_sigaction();
         // Call `on_sigttou` if `SIGTTOU` arrives.
-        raw.sa_sigaction = on_sigttou as sighandler_t;
+        raw.sa_sigaction = on_sigttou as *const () as sighandler_t;
         // Exclude any other signals from the set
         raw.sa_mask = {
             let mut sa_mask = MaybeUninit::<sigset_t>::uninit();


### PR DESCRIPTION
The new function_casts_as_integer lint warns on direct casts from function items to integers as those sometimes indicate a bug in the program. In our case the cast is however correct, so silence the lint by first casting to *const () as suggested by the lint.

Also fix a todo now that we use a newer clippy version.