### PR TITLE
Remove unsupported timestamp_type option from docs

### DIFF
--- a/docs/man/sudoers.5.man
+++ b/docs/man/sudoers.5.man
@@ -30,8 +30,11 @@ start time of the session leader (or parent process) and a timestamp
 (using a monotonic clock if one is available).
 The user may then use sudo without a password for a short period of time
 (15 minutes unless overridden by the timestamp_timeout option).
-\f[CR]sudo\-rs\f[R] uses a separate record for each terminal, which
-means that a user\[cq]s login sessions are authenticated separately.
+By default, \f[CR]sudo\-rs\f[R] uses a separate record for each
+terminal, which means that a user\[cq]s login sessions are authenticated
+separately.
+The timestamp_type option can be used to select the type of timestamp
+record sudoers will use.
 .SS Logging
 By default, \f[CR]sudo\-rs\f[R] logs both successful and unsuccessful
 attempts (as well as errors).


### PR DESCRIPTION
Attempts to fix #1361.