### PR TITLE
Clippy

### DIFF
--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/env/check.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/env/check.rs
@@ -301,7 +301,7 @@ fn bad_tz() {
     // "It is longer than the value of PATH_MAX."
     let long_path = "/usr/share/zoneinfo/"
         .chars()
-        .chain(iter::repeat('a').take(PATH_MAX))
+        .chain(iter::repeat_n('a', PATH_MAX))
         .collect::<String>();
 
     let env = Env([


### PR DESCRIPTION
https://github.com/trifectatechfoundation/sudo-rs/pull/1356 made Clippy complain about this as Clippy would no longer use 1.70 as MSRV for the compliance tests. This wasn't caught in CI as we only run clippy on the compliance tests when the test-framework directory changes, which that PR didn't touch.