### PR TITLE
Fix FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: Cirrus CI / freebsd unit tests
   freebsd_instance:
-    image_family: freebsd-14-2
+    image_family: freebsd-15-0-amd64-ufs
     memory: 2GB
   setup_rust_script:
     - pkg install -y git-tiny


### PR DESCRIPTION
Cirrus CI no longer offers FreeBSD 14.2