### PR TITLE
Remove a few unwrap()'s

### DIFF
--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -112,7 +112,7 @@ pub fn run_command(
         ));
 
         #[cfg(target_os = "linux")]
-        Some(noexec::add_noexec_filter(&mut command))
+        Some(noexec::add_noexec_filter(&mut command)?)
     } else {
         None
     };

--- a/src/exec/noexec.rs
+++ b/src/exec/noexec.rs
@@ -366,8 +366,8 @@ const GUEST_SYSCALL: (i64, i64) = if cfg!(target_arch = "aarch64") {
 // Bit that is set on syscalls when using the X32 ABI; see man seccomp.
 const __X32_SYSCALL_BIT: u32 = 0x40000000;
 
-pub(crate) fn add_noexec_filter(command: &mut Command) -> SpawnNoexecHandler {
-    let (tx_fd, rx_fd) = UnixStream::pair().unwrap();
+pub(crate) fn add_noexec_filter(command: &mut Command) -> io::Result<SpawnNoexecHandler> {
+    let (tx_fd, rx_fd) = UnixStream::pair()?;
 
     // wrap tx_fd so it can be moved into the closure
     let mut tx_fd = Some(tx_fd);
@@ -465,5 +465,5 @@ pub(crate) fn add_noexec_filter(command: &mut Command) -> SpawnNoexecHandler {
         });
     }
 
-    SpawnNoexecHandler(rx_fd)
+    Ok(SpawnNoexecHandler(rx_fd))
 }

--- a/src/sudo/edit.rs
+++ b/src/sudo/edit.rs
@@ -64,7 +64,7 @@ pub(super) fn edit_files(
         })?;
 
         // Create socket
-        let (parent_socket, child_socket) = UnixStream::pair().unwrap();
+        let (parent_socket, child_socket) = UnixStream::pair()?;
 
         files.push(ParentFileInfo {
             path,
@@ -85,7 +85,7 @@ pub(super) fn edit_files(
 
     // Spawn child
     // SAFETY: There should be no other threads at this point.
-    let ForkResult::Parent(command_pid) = unsafe { fork() }.unwrap() else {
+    let ForkResult::Parent(command_pid) = unsafe { fork() }? else {
         drop(files);
         handle_child(editor, child_files)
     };

--- a/src/visudo/cli.rs
+++ b/src/visudo/cli.rs
@@ -128,9 +128,7 @@ impl VisudoOptions {
             // if the argument starts with -- it must be a full length option name
             if arg.starts_with("--") {
                 // parse assignments like '--file=/etc/sudoers'
-                if arg.contains('=') {
-                    // convert assignment to normal tokens
-                    let (key, value) = arg.split_once('=').unwrap();
+                if let Some((key, value)) = arg.split_once('=') {
                     // lookup the option by name
                     if let Some(option) = Self::VISUDO_OPTIONS.iter().find(|o| o.long == &key[2..])
                     {


### PR DESCRIPTION
Inspired by some recent unasked-for advice aimed at a certain company, I decided to have a look at all the nice presents elves put in our code base for us to unwrap. Most of them are nice and proper (e.g. the line on line 379 in noexec.rs stands out as a perfect example).

But I found a few in which we might as well change the code (although it will have no noticable effect).

According to experts, this makes our code less dangerous.