### PR TITLE
Fix the publish to crates.io workflow

### DIFF
--- a/.github/workflows/publish-crates-io.yml
+++ b/.github/workflows/publish-crates-io.yml
@@ -14,8 +14,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
     - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
       id: auth
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install libpam0g-dev
+
     - run: cargo publish --locked
       env:
         CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Pam needs to be installed for the pre-publish verification of cargo to succeed.