### PR TITLE
Cleanup unit tests

### DIFF
--- a/src/pam/securemem.rs
+++ b/src/pam/securemem.rs
@@ -26,7 +26,7 @@ impl PamBuffer {
     }
 
     // initialize the buffer with already existing data (otherwise populating it is a bit hairy)
-    // this is inferior than placing the data into the securebuffer directly
+    // this is inferior to placing the data into the securebuffer directly
     #[cfg(test)]
     pub fn new(mut src: impl AsMut<[u8]>) -> Self {
         let mut buffer = PamBuffer::default();

--- a/src/su/cli.rs
+++ b/src/su/cli.rs
@@ -15,21 +15,6 @@ impl SuAction {
     pub fn from_env() -> Result<Self, String> {
         SuOptions::parse_arguments(std::env::args())?.validate()
     }
-
-    #[cfg(test)]
-    pub fn parse_arguments(args: impl IntoIterator<Item = String>) -> Result<Self, String> {
-        SuOptions::parse_arguments(args)?.validate()
-    }
-
-    #[cfg(test)]
-    #[allow(clippy::result_large_err)]
-    pub fn try_into_run(self) -> Result<SuRunOptions, Self> {
-        if let Self::Run(v) = self {
-            Ok(v)
-        } else {
-            Err(self)
-        }
-    }
 }
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
@@ -195,7 +180,7 @@ impl<T> IsAbsent for Vec<T> {
 }
 
 #[derive(Debug, Default, PartialEq)]
-struct SuOptions {
+pub(super) struct SuOptions {
     // -c
     command: Option<String>,
     // -g
@@ -380,7 +365,9 @@ impl SuOptions {
     ];
 
     /// parse su arguments into SuOptions struct
-    fn parse_arguments(arguments: impl IntoIterator<Item = String>) -> Result<SuOptions, String> {
+    pub(super) fn parse_arguments(
+        arguments: impl IntoIterator<Item = String>,
+    ) -> Result<SuOptions, String> {
         let mut options: SuOptions = SuOptions::default();
         let mut arg_iter = arguments.into_iter().skip(1);
 
@@ -460,7 +447,7 @@ impl SuOptions {
         Ok(options)
     }
 
-    fn validate(self) -> Result<SuAction, String> {
+    pub(super) fn validate(self) -> Result<SuAction, String> {
         let action = if self.help {
             SuAction::Help(self.try_into()?)
         } else if self.version {

--- a/src/su/context.rs
+++ b/src/su/context.rs
@@ -226,7 +226,7 @@ mod tests {
 
     use crate::{
         common::Error,
-        su::cli::{SuAction, SuRunOptions},
+        su::cli::{SuAction, SuOptions, SuRunOptions},
     };
 
     use super::SuContext;
@@ -234,10 +234,15 @@ mod tests {
     fn get_options(args: &[&str]) -> SuRunOptions {
         let mut args = args.iter().map(|s| s.to_string()).collect::<Vec<String>>();
         args.insert(0, "/bin/su".to_string());
-        SuAction::parse_arguments(args)
+        let SuAction::Run(options) = SuOptions::parse_arguments(args)
             .unwrap()
-            .try_into_run()
+            .validate()
             .unwrap()
+        else {
+            panic!();
+        };
+
+        options
     }
 
     #[test]

--- a/src/sudo/cli/mod.rs
+++ b/src/sudo/cli/mod.rs
@@ -44,64 +44,6 @@ impl SudoAction {
         let opts = SudoOptions::try_parse_from(iter)?;
         opts.validate()
     }
-
-    #[cfg(test)]
-    #[must_use]
-    pub fn is_edit(&self) -> bool {
-        matches!(self, Self::Edit(..))
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub fn is_help(&self) -> bool {
-        matches!(self, Self::Help(..))
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub fn is_remove_timestamp(&self) -> bool {
-        matches!(self, Self::RemoveTimestamp(..))
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub fn is_reset_timestamp(&self) -> bool {
-        matches!(self, Self::ResetTimestamp(..))
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub fn is_list(&self) -> bool {
-        matches!(self, Self::List(..))
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub fn is_version(&self) -> bool {
-        matches!(self, Self::Version(..))
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub fn is_validate(&self) -> bool {
-        matches!(self, Self::Validate(..))
-    }
-
-    #[cfg(test)]
-    #[allow(clippy::result_large_err)]
-    pub fn try_into_run(self) -> Result<SudoRunOptions, Self> {
-        if let Self::Run(v) = self {
-            Ok(v)
-        } else {
-            Err(self)
-        }
-    }
-
-    #[cfg(test)]
-    #[must_use]
-    pub fn is_run(&self) -> bool {
-        matches!(self, Self::Run(..))
-    }
 }
 
 // sudo -h | -K | -k | -V

--- a/src/sudo/cli/tests.rs
+++ b/src/sudo/cli/tests.rs
@@ -1,6 +1,57 @@
 use crate::common::SudoPath;
 
-use super::{SudoAction, SudoOptions};
+use super::{SudoAction, SudoOptions, SudoRunOptions};
+
+impl SudoAction {
+    #[must_use]
+    pub fn is_edit(&self) -> bool {
+        matches!(self, Self::Edit(..))
+    }
+
+    #[must_use]
+    pub fn is_help(&self) -> bool {
+        matches!(self, Self::Help(..))
+    }
+
+    #[must_use]
+    pub fn is_remove_timestamp(&self) -> bool {
+        matches!(self, Self::RemoveTimestamp(..))
+    }
+
+    #[must_use]
+    pub fn is_reset_timestamp(&self) -> bool {
+        matches!(self, Self::ResetTimestamp(..))
+    }
+
+    #[must_use]
+    pub fn is_list(&self) -> bool {
+        matches!(self, Self::List(..))
+    }
+
+    #[must_use]
+    pub fn is_version(&self) -> bool {
+        matches!(self, Self::Version(..))
+    }
+
+    #[must_use]
+    pub fn is_validate(&self) -> bool {
+        matches!(self, Self::Validate(..))
+    }
+
+    #[allow(clippy::result_large_err)]
+    pub fn try_into_run(self) -> Result<SudoRunOptions, Self> {
+        if let Self::Run(v) = self {
+            Ok(v)
+        } else {
+            Err(self)
+        }
+    }
+
+    #[must_use]
+    pub fn is_run(&self) -> bool {
+        matches!(self, Self::Run(..))
+    }
+}
 
 /// Passing '-E' with a variable fails
 #[test]

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -18,17 +18,6 @@ pub enum Qualified<T> {
     Forbid(T) = HARDENED_ENUM_VALUE_1,
 }
 
-impl<T> Qualified<T> {
-    #[cfg(test)]
-    pub fn as_allow(&self) -> Option<&T> {
-        if let Self::Allow(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-}
-
 /// Type aliases; many items can be replaced by ALL, aliases, and negated.
 pub type Spec<T> = Qualified<Meta<T>>;
 pub type SpecList<T> = Vec<Spec<T>>;
@@ -171,51 +160,6 @@ pub enum Sudo {
     Include(String, Span) = HARDENED_ENUM_VALUE_2,
     IncludeDir(String, Span) = HARDENED_ENUM_VALUE_3,
     LineComment = HARDENED_ENUM_VALUE_4,
-}
-
-impl Sudo {
-    #[cfg(test)]
-    pub fn is_spec(&self) -> bool {
-        matches!(self, Self::Spec(..))
-    }
-
-    #[cfg(test)]
-    pub fn is_decl(&self) -> bool {
-        matches!(self, Self::Decl(..))
-    }
-
-    #[cfg(test)]
-    pub fn is_line_comment(&self) -> bool {
-        matches!(self, Self::LineComment)
-    }
-
-    #[cfg(test)]
-    pub fn is_include(&self) -> bool {
-        matches!(self, Self::Include(..))
-    }
-
-    #[cfg(test)]
-    pub fn is_include_dir(&self) -> bool {
-        matches!(self, Self::IncludeDir(..))
-    }
-
-    #[cfg(test)]
-    pub fn as_include(&self) -> &str {
-        if let Self::Include(v, _) = self {
-            v
-        } else {
-            panic!()
-        }
-    }
-
-    #[cfg(test)]
-    pub fn as_spec(&self) -> Option<&PermissionSpec> {
-        if let Self::Spec(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
 }
 
 /// grammar:

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -5,6 +5,60 @@ use super::char_stream::CharStream;
 use super::*;
 use basic_parser::{parse_eval, parse_lines, parse_string};
 
+impl<T> Qualified<T> {
+    pub fn as_allow(&self) -> Option<&T> {
+        if let Self::Allow(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
+impl<T> Meta<T> {
+    pub fn is_alias(&self) -> bool {
+        matches!(self, Self::Alias(..))
+    }
+}
+
+impl Sudo {
+    pub fn is_spec(&self) -> bool {
+        matches!(self, Self::Spec(..))
+    }
+
+    pub fn is_decl(&self) -> bool {
+        matches!(self, Self::Decl(..))
+    }
+
+    pub fn is_line_comment(&self) -> bool {
+        matches!(self, Self::LineComment)
+    }
+
+    pub fn is_include(&self) -> bool {
+        matches!(self, Self::Include(..))
+    }
+
+    pub fn is_include_dir(&self) -> bool {
+        matches!(self, Self::IncludeDir(..))
+    }
+
+    pub fn as_include(&self) -> &str {
+        if let Self::Include(v, _) = self {
+            v
+        } else {
+            panic!()
+        }
+    }
+
+    pub fn as_spec(&self) -> Option<&PermissionSpec> {
+        if let Self::Spec(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(PartialEq)]
 struct Named(&'static str);
 

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -100,13 +100,6 @@ pub enum Meta<T> {
     Alias(String) = HARDENED_ENUM_VALUE_2,
 }
 
-impl<T> Meta<T> {
-    #[cfg(test)]
-    pub fn is_alias(&self) -> bool {
-        matches!(self, Self::Alias(..))
-    }
-}
-
 impl<T: Token> Token for Meta<T> {
     fn construct(raw: String) -> Result<Self, String> {
         // `T` may accept whitespace resulting in `raw` having trailing whitespace which would make

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -979,14 +979,6 @@ mod tests {
     }
 
     #[test]
-    fn get_process_start_time() {
-        let time = super::Process::starting_time(WithProcess::Current).unwrap();
-        let now = super::ProcessCreateTime::now().unwrap();
-        assert!(time.secs() > now.secs() - 24 * 60 * 60);
-        assert!(time < now);
-    }
-
-    #[test]
     fn pgid_test() {
         use super::{getpgid, setpgid};
 


### PR DESCRIPTION
Working in the AST again after a while was a pleasant experience, but I noticed we had accumulated quite a bit of #[cfg(test)] accessory functions that have only been added because `assert_matches!()` has still not landed. I didn't like having the mixed in with production code for readability, but also at some point one could be tempted to write test code that is only exercising the auxilliary function that are only there to aid testing.

So this PR has some commits that move things around.

In any case I do want to changes in the `sudoers/` folder to stick, but I think the same change also helps in the CLI.