### PR TITLE
Remove process field from Context

### DIFF
--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -5,7 +5,7 @@ use crate::exec::RunOptions;
 use crate::sudo::{SudoEditOptions, SudoListOptions, SudoRunOptions, SudoValidateOptions};
 use crate::sudoers::Sudoers;
 use crate::sudoers::{DirChange, Restrictions};
-use crate::system::{audit::sudo_call, Group, Hostname, Process, User};
+use crate::system::{audit::sudo_call, Group, Hostname, User};
 
 use super::{
     command::CommandAndArguments,
@@ -30,7 +30,6 @@ pub struct Context {
     // system
     pub hostname: Hostname,
     pub current_user: CurrentUser,
-    pub process: Process,
     // sudoedit
     pub files_to_edit: Vec<Option<SudoPath>>,
 }
@@ -98,7 +97,6 @@ impl Context {
             bell: sudo_options.bell,
             prompt,
             non_interactive: sudo_options.non_interactive,
-            process: Process::new(),
             files_to_edit: vec![],
         })
     }
@@ -166,7 +164,6 @@ impl Context {
             bell: sudo_options.bell,
             prompt: sudo_options.prompt,
             non_interactive: sudo_options.non_interactive,
-            process: Process::new(),
             files_to_edit,
         })
     }
@@ -190,7 +187,6 @@ impl Context {
             bell: sudo_options.bell,
             prompt: sudo_options.prompt,
             non_interactive: sudo_options.non_interactive,
-            process: Process::new(),
             files_to_edit: vec![],
         })
     }
@@ -237,7 +233,6 @@ impl Context {
             bell: sudo_options.bell,
             prompt: sudo_options.prompt,
             non_interactive: sudo_options.non_interactive,
-            process: Process::new(),
             files_to_edit: vec![],
         })
     }

--- a/src/su/context.rs
+++ b/src/su/context.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::common::{error::Error, resolve::CurrentUser};
 use crate::exec::{RunOptions, Umask};
 use crate::log::user_warn;
-use crate::system::{Group, Process, User};
+use crate::system::{Group, User};
 use crate::{common::resolve::is_valid_executable, system::interface::UserId};
 
 type Environment = HashMap<OsString, OsString>;
@@ -32,7 +32,6 @@ pub(crate) struct SuContext {
     pub(crate) user: User,
     pub(crate) requesting_user: CurrentUser,
     group: Group,
-    pub(crate) process: Process,
 }
 
 /// check that a shell is not restricted / exists in /etc/shells
@@ -50,8 +49,6 @@ fn is_restricted(shell: &Path) -> bool {
 
 impl SuContext {
     pub(crate) fn from_env(options: SuRunOptions) -> Result<SuContext, Error> {
-        let process = crate::system::Process::new();
-
         // resolve environment, reset if this is a login
         let mut environment = if options.login {
             Environment::default()
@@ -197,7 +194,6 @@ impl SuContext {
             user,
             requesting_user,
             group,
-            process,
         })
     }
 }

--- a/src/su/mod.rs
+++ b/src/su/mod.rs
@@ -5,6 +5,7 @@ use crate::exec::ExitReason;
 use crate::log::user_warn;
 use crate::pam::{PamContext, PamError, PamErrorType};
 use crate::system::term::current_tty_name;
+use crate::system::Process;
 
 use std::{env, process};
 
@@ -105,8 +106,6 @@ fn run(options: SuRunOptions) -> Result<(), Error> {
     let mut environment = context.environment.clone();
     environment.extend(pam.env()?);
 
-    let pid = context.process.pid;
-
     // run command and return corresponding exit code
     let command_exit_reason = crate::exec::run_command(context.as_run_options(), environment);
 
@@ -115,7 +114,7 @@ fn run(options: SuRunOptions) -> Result<(), Error> {
     match command_exit_reason? {
         ExitReason::Code(code) => process::exit(code),
         ExitReason::Signal(signal) => {
-            crate::system::kill(pid, signal)?;
+            crate::system::kill(Process::process_id(), signal)?;
         }
     }
 

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -5,7 +5,7 @@ use crate::sudo::{
     env::environment::{get_target_environment, Environment},
 };
 use crate::system::interface::{GroupId, UserId};
-use crate::system::{Group, Hostname, Process, User};
+use crate::system::{Group, Hostname, User};
 use std::collections::{HashMap, HashSet};
 
 const TESTS: &str = "
@@ -130,7 +130,6 @@ fn create_test_context(sudo_options: SudoRunOptions) -> Context {
         stdin: sudo_options.stdin,
         prompt: sudo_options.prompt,
         non_interactive: sudo_options.non_interactive,
-        process: Process::new(),
         use_session_records: false,
         bell: false,
         files_to_edit: vec![],

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -105,8 +105,6 @@ pub fn run(mut cmd_opts: SudoRunOptions) -> Result<(), Error> {
 
     environment::dangerous_extend(&mut target_env, trusted_vars);
 
-    let pid = context.process.pid;
-
     // prepare switch of apparmor profile
     #[cfg(feature = "apparmor")]
     if let Some(profile) = &controls.apparmor_profile {
@@ -128,7 +126,7 @@ pub fn run(mut cmd_opts: SudoRunOptions) -> Result<(), Error> {
     match command_exit_reason? {
         ExitReason::Code(code) => exit(code),
         ExitReason::Signal(signal) => {
-            crate::system::kill(pid, signal)?;
+            crate::system::kill(Process::process_id(), signal)?;
         }
     }
 

--- a/src/sudo/pipeline/edit.rs
+++ b/src/sudo/pipeline/edit.rs
@@ -5,7 +5,7 @@ use crate::common::{Context, Error};
 use crate::exec::ExitReason;
 use crate::log::{user_error, user_info};
 use crate::sudoers::Authorization;
-use crate::system::audit;
+use crate::system::{audit, Process};
 
 pub fn run_edit(edit_opts: SudoEditOptions) -> Result<(), Error> {
     let policy = super::read_sudoers()?;
@@ -19,8 +19,6 @@ pub fn run_edit(edit_opts: SudoEditOptions) -> Result<(), Error> {
     };
 
     let mut pam_context = super::auth_and_update_record_file(&context, auth)?;
-
-    let pid = context.process.pid;
 
     let mut opened_files = Vec::with_capacity(context.files_to_edit.len());
     for (path, arg) in context.files_to_edit.iter().zip(&context.command.arguments) {
@@ -67,7 +65,7 @@ pub fn run_edit(edit_opts: SudoEditOptions) -> Result<(), Error> {
     match command_exit_reason? {
         ExitReason::Code(code) => exit(code),
         ExitReason::Signal(signal) => {
-            crate::system::kill(pid, signal)?;
+            crate::system::kill(Process::process_id(), signal)?;
         }
     }
 

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -610,21 +610,13 @@ impl WithProcess {
 
 #[derive(Debug, Clone)]
 pub struct Process {
-    pub pid: ProcessId,
     pub parent_pid: Option<ProcessId>,
     pub session_id: ProcessId,
-}
-
-impl Default for Process {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl Process {
     pub fn new() -> Process {
         Process {
-            pid: Self::process_id(),
             parent_pid: Self::parent_id(),
             session_id: Self::session_id(),
         }


### PR DESCRIPTION
This simplifies some things and is required for correctness once we implement --background as we need to kill the forked process rather than the original process that no longer exists.