### PR TITLE
Handle usage of socketpair for pipelines by the shell

### DIFF
--- a/src/exec/use_pty/parent.rs
+++ b/src/exec/use_pty/parent.rs
@@ -107,7 +107,7 @@ pub(in crate::exec) fn exec_pty(
     // the pipes. Investigate why.
     if !io::stdin().is_terminal_for_pgrp(parent_pgrp) {
         dev_info!("stdin is not a terminal, command will inherit it");
-        if io::stdin().is_pipe() {
+        if io::stdin().is_pipe_or_socket() {
             exec_bg = true;
         }
         command.stdin(Stdio::inherit());
@@ -122,7 +122,7 @@ pub(in crate::exec) fn exec_pty(
 
     if !io::stdout().is_terminal_for_pgrp(parent_pgrp) {
         dev_info!("stdout is not a terminal, command will inherit it");
-        if io::stdout().is_pipe() {
+        if io::stdout().is_pipe_or_socket() {
             exec_bg = true;
             preserve_oflag = true;
         }
@@ -136,7 +136,7 @@ pub(in crate::exec) fn exec_pty(
 
     // If there is another process later in the pipeline, don't interfere
     // with its access to the Tty
-    if io::stdout().is_pipe() {
+    if io::stdout().is_pipe_or_socket() {
         foreground = false;
     }
 

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -11,7 +11,7 @@ use std::{
 
 use libc::{ioctl, winsize, TIOCSWINSZ};
 
-use crate::cutils::{cerr, is_fifo, os_string_from_ptr, safe_isatty};
+use crate::cutils::{cerr, is_fifo_or_sock, os_string_from_ptr, safe_isatty};
 
 use super::interface::ProcessId;
 
@@ -187,7 +187,7 @@ pub(crate) trait Terminal: sealed::Sealed {
     where
         Self: sealed::SafeTty;
     fn ttyname(&self) -> io::Result<OsString>;
-    fn is_pipe(&self) -> bool;
+    fn is_pipe_or_socket(&self) -> bool;
     fn tcgetsid(&self) -> io::Result<ProcessId>
     where
         Self: sealed::SafeTty;
@@ -241,8 +241,8 @@ impl<F: AsFd> Terminal for F {
         Ok(unsafe { os_string_from_ptr(buf.as_ptr()) })
     }
 
-    fn is_pipe(&self) -> bool {
-        is_fifo(self.as_fd())
+    fn is_pipe_or_socket(&self) -> bool {
+        is_fifo_or_sock(self.as_fd())
     }
 
     fn tcgetsid(&self) -> io::Result<ProcessId> {


### PR DESCRIPTION
Unlike most shells, ksh uses socketpair rather than pipe for creating pipelines. This matches the fix done by og-sudo in https://github.com/sudo-project/sudo/commit/bcbaca6f69c68a9c249fed96514889a9cc886048.

Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/1416