### PR TITLE
Fix broken CVD link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ also follow the steps at https://www.sudo.ws/security/policy/
 We prefer to receive reports in English. If necessary, we also understand Spanish, German and Dutch.
 
 ## Disclosure Policy
-Like original sudo, we adhere to the principle of [Coordinated Vulnerability Disclosure](https://vuls.cert.org/confluence/display/CVD/Executive+Summary).
+Like original sudo, we adhere to the principle of [Coordinated Vulnerability Disclosure](https://certcc.github.io/CERT-Guide-to-CVD/tutorials/cvd_in_a_nutshell/).
 
 # Security Advisories
 Security advisories will be published [on GitHub](https://github.com/trifectatechfoundation/sudo-rs/security/advisories) and possibly through other channels.


### PR DESCRIPTION
I'm fairly certain the contents from the old link (<https://vuls.cert.org/confluence/display/CVD/Executive+Summary>) are now at  <https://certcc.github.io/CERT-Guide-to-CVD/tutorials/cvd_in_a_nutshell/>, as the contents on this page seem to match the executive summary [here](https://cyberlaw.stanford.edu/content/files/asset_files/SpecialReport/2017_003_001_503340.pdf) and the old link redirects to certcc.github.io.

Fixes #1424