### PR TITLE
Fix year in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.12] - 2025-02-09
+## [0.2.12] - 2026-02-09
 
 ### Added
 - Support for `-b / --background` to run commands in the background

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
-Copyright (c) 2022-2025 Trifecta Tech Foundation and contributors
+Copyright (c) 2022-2026 Trifecta Tech Foundation and contributors
 Copyright (c) 1994-1996, 1998-2024 Todd C. Miller <Todd.Miller@sudo.ws>
 
 Except as otherwise noted (below and/or in individual files), sudo-rs is

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2022-2025 Trifecta Tech Foundation
+Copyright (c) 2022-2026 Trifecta Tech Foundation
 and contributors
 Copyright (c) 1994-1996, 1998-2024 Todd C. Miller
 


### PR DESCRIPTION
Happy new year. 


We don't distribute this date into the actual executable or other parts of the documentation. Also bumps the year in the copyright notice.