### PR TITLE
Avoid installing libpam for a CI job that doesn't need it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -363,11 +363,6 @@ jobs:
           rustup override set nightly
           rustup component add miri
 
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install libpam0g-dev
-
       - name: Register rust problem matcher
         run: echo "::add-matcher::.github/problem-matchers/rust.json"
 


### PR DESCRIPTION
This job is not on the critical path, so it won't really matter for CI performance.