### PR TITLE
Check for the no new privs flag

### DIFF
--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -12,7 +12,8 @@ pub enum Error {
         hostname: Hostname,
         other_user: Option<SudoString>,
     },
-    SelfCheck,
+    SelfCheckSetuid,
+    SelfCheckNoNewPrivs,
     CommandNotFound(PathBuf),
     InvalidCommand(PathBuf),
     ChDirNotAllowed {
@@ -64,8 +65,16 @@ impl fmt::Display for Error {
                     )
                 }
             }
-            Error::SelfCheck => {
+            Error::SelfCheckSetuid => {
                 xlat_write!(f, "sudo must be owned by uid 0 and have the setuid bit set")
+            }
+            Error::SelfCheckNoNewPrivs => {
+                xlat_write!(
+                    f,
+                    "The \"no new privileges\" flag is set, which prevents sudo from running as root.\n\
+                    If sudo is running in a container, you may need to adjust the container \
+                    configuration to disable the flag."
+                )
             }
             Error::CommandNotFound(p) => {
                 xlat_write!(f, "'{path}': command not found", path = p.display())

--- a/src/sudo/diagnostic.rs
+++ b/src/sudo/diagnostic.rs
@@ -42,11 +42,15 @@ macro_rules! diagnostic {
         if let Some(range) = $pos {
             $crate::sudo::diagnostic::cited_error(&format!($str), range, $path);
         } else {
-            eprintln_ignore_io_error!("sudo: {}", format!($str));
+            for line in format!($str).split('\n') {
+                eprintln_ignore_io_error!("sudo: {}", line);
+            }
         }
     };
     ($str:expr) => {{
-        eprintln_ignore_io_error!("sudo: {}", format!($str));
+        for line in format!($str).split('\n') {
+            eprintln_ignore_io_error!("sudo: {}", line);
+        }
     }};
 }
 

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -15,6 +15,14 @@ use super::{
 };
 use crate::common::resolve::CurrentUser;
 
+#[cfg(target_os = "linux")]
+pub(crate) fn no_new_privs_enabled() -> io::Result<bool> {
+    // SAFETY: prctl(PR_GET_NO_NEW_PRIVS) can never cause UB
+    let no_new_privs =
+        crate::cutils::cerr(unsafe { libc::prctl(libc::PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0) })?;
+    Ok(no_new_privs != 0)
+}
+
 /// Temporary change privileges --- essentially a 'mini sudo'
 /// This is only used for sudoedit.
 pub(crate) fn sudo_call<T>(


### PR DESCRIPTION
And emit a nicer error message.

Tested using `systemd-run --user --property=NoNewPrivileges=true -t ./sudo-rs true`.

Fixes https://github.com/trifectatechfoundation/sudo-rs/issues/1164