### PR TITLE
Add error messages on wildcards and accept a 'final' wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,9 @@ Some other notable restrictions to be aware of:
 * sudo-rs will not include the sendmail support of original sudo.
 * The sudoers file must be valid UTF-8.
 * To prevent a common configuration mistake in the sudoers file, wildcards
-  are not supported in *argument positions* for a command.
+  are only supported in *argument positions* for a command as the final argument.
   E.g., `%sudoers ALL = /sbin/fsck*` will allow `sudo fsck` and `sudo fsck_exfat` as expected,
+  and `%sudoers ALL = /sbin/service ntp *` will allow a user to control the `ntp` service.
   but `%sudoers ALL = /bin/rm *.txt` will not allow an operator to run `sudo rm README.txt`,
   nor `sudo rm -rf /home .txt`, as with original sudo.
 

--- a/docs/man/sudoers.5.md
+++ b/docs/man/sudoers.5.md
@@ -139,7 +139,7 @@ A Host_List is made up of one or more host names.  Again, the value of an item m
                    Cmnd ',' Cmnd_List
 
      command name ::= file name |
-                      file name args |
+                      file name args ['*'] |
                       file name '""'
 
      Cmnd ::= '!'* command name |
@@ -148,7 +148,7 @@ A Host_List is made up of one or more host names.  Again, the value of an item m
               '!'* "list"
               '!'* "sudoedit" [file name]
 
-A Cmnd_List is a list of one or more command names, directories, and other aliases.  A command name is a fully qualified file name which may include shell-style wildcards (see the Wildcards section below).  A simple file name allows the user to run the command with any arguments they wish.  However, you may also specify command line arguments (which in sudo-rs may *not* include wildcards). Alternately, you can specify "" to indicate that the command may only be run without command line arguments.  A directory is a fully qualified path name ending in a ‘/’.  When you specify a directory in a Cmnd_List, the user will be able to run any file within that directory (but not in any sub-directories therein).
+A Cmnd_List is a list of one or more command names, directories, and other aliases.  A command name is a fully qualified file name which may include shell-style wildcards (see the Wildcards section below).  A simple file name allows the user to run the command with any arguments they wish.  However, you may also specify command line arguments that have to be used, in which case the command line has to match exactly. You can use the special argument "" to indicate that the command may only be run *without* command line arguments, or the argument ‘*’ to match any trailing arguments. You cannot use wildcards inside the argument list.  A directory is a fully qualified path name ending in a ‘/’.  When you specify a directory in a Cmnd_List, the user will be able to run any file within that directory (but not in any sub-directories therein).
 
 If a Cmnd has associated command line arguments, then the arguments in the Cmnd must match exactly those given by the user on the command line.
 Note that the following characters must be escaped with a ‘\\’ if they are used in command arguments: ‘,’, ‘:’, ‘=’, ‘\\’.
@@ -319,7 +319,7 @@ sudo allows shell-style wildcards (aka meta or glob characters) to be used in ho
 
 Note that these are not regular expressions.  Unlike a regular expression there is no way to match one or more characters within a range.
 
-Wildcards in command line arguments are not supported---using these in original versions of sudo was usually a sign of mis-configuration and consequently sudo-rs simply forbids using them.
+Wildcards in command line arguments are not supported---using these in original versions of sudo was usually a sign of mis-configuration and consequently sudo-rs simply forbids using them. The only supported use is ‘*’ as the final argument to indicate "zero or more subsequent arguments" as noted above.
 
 ## Including other files from within sudoers
 

--- a/src/sudoers/entry.rs
+++ b/src/sudoers/entry.rs
@@ -6,7 +6,7 @@ use crate::sudoers::{
     tokens::{ChDir, Meta},
 };
 use crate::{
-    common::{SudoString, resolve::CurrentUser},
+    common::{DisplayOsStr, SudoString, resolve::CurrentUser},
     system::{User, interface::UserId},
 };
 
@@ -257,7 +257,7 @@ fn write_spec<'a>(
             match args {
                 Args::Exact(args) => {
                     for arg in args {
-                        write!(f, " {arg}")?;
+                        write!(f, " {}", DisplayOsStr(arg))?;
                     }
                     if args.is_empty() {
                         write!(f, " \"\"")?;
@@ -265,7 +265,7 @@ fn write_spec<'a>(
                 }
                 Args::Prefix(args) => {
                     for arg in args {
-                        write!(f, " {arg}")?;
+                        write!(f, " {}", DisplayOsStr(arg))?;
                     }
                     if !args.is_empty() {
                         write!(f, " *")?;

--- a/src/sudoers/entry.rs
+++ b/src/sudoers/entry.rs
@@ -14,7 +14,7 @@ use self::verbose::Verbose;
 
 use super::{
     ast::{Authenticate, Def, EnvironmentControl, ExecControl, RunAs, Tag},
-    tokens::Command,
+    tokens::{Args, Command},
 };
 
 mod verbose;
@@ -254,7 +254,7 @@ fn write_spec<'a>(
 
         Meta::Only((cmd, args)) => {
             write!(f, "{cmd}")?;
-            if let Some(args) = args {
+            if let Args::Exact(args) = args {
                 for arg in args.iter() {
                     write!(f, " {arg}")?;
                 }

--- a/src/sudoers/entry.rs
+++ b/src/sudoers/entry.rs
@@ -254,9 +254,22 @@ fn write_spec<'a>(
 
         Meta::Only((cmd, args)) => {
             write!(f, "{cmd}")?;
-            if let Args::Exact(args) = args {
-                for arg in args.iter() {
-                    write!(f, " {arg}")?;
+            match args {
+                Args::Exact(args) => {
+                    for arg in args {
+                        write!(f, " {arg}")?;
+                    }
+                    if args.is_empty() {
+                        write!(f, " \"\"")?;
+                    }
+                }
+                Args::Prefix(args) => {
+                    for arg in args {
+                        write!(f, " {arg}")?;
+                    }
+                    if !args.is_empty() {
+                        write!(f, " *")?;
+                    }
                 }
             }
         }

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -634,9 +634,10 @@ fn match_command<'a>((cmd, args): (&'a Path, &'a [OsString])) -> impl Fn(&Comman
     };
     move |(cmdpat, argpat)| {
         cmdpat.matches_path_with(cmd, opts)
-            && argpat
-                .as_ref()
-                .is_none_or(|vec| args.iter().eq(vec.into_iter().map(OsStr::new)))
+            && match argpat {
+                Args::All => true,
+                Args::Exact(vec) => args.iter().eq(vec.into_iter().map(OsStr::new)),
+            }
     }
 }
 
@@ -763,7 +764,9 @@ fn analyze(
                             cfg.customisers.cmnd.push((
                                 specs
                                     .into_iter()
-                                    .map(|spec| spec.map(|simple_command| (simple_command, None)))
+                                    .map(|spec| {
+                                        spec.map(|simple_command| (simple_command, Args::All))
+                                    })
                                     .collect(),
                                 params,
                             ));

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -635,7 +635,11 @@ fn match_command<'a>((cmd, args): (&'a Path, &'a [OsString])) -> impl Fn(&Comman
     move |(cmdpat, argpat)| {
         cmdpat.matches_path_with(cmd, opts)
             && match argpat {
-                Args::All => true,
+                Args::Prefix(vec) => args
+                    .iter()
+                    .take(vec.len())
+                    .eq(vec.into_iter().map(OsStr::new)),
+
                 Args::Exact(vec) => args.iter().eq(vec.into_iter().map(OsStr::new)),
             }
     }
@@ -765,7 +769,9 @@ fn analyze(
                                 specs
                                     .into_iter()
                                     .map(|spec| {
-                                        spec.map(|simple_command| (simple_command, Args::All))
+                                        spec.map(|simple_command| {
+                                            (simple_command, Args::Prefix(Box::default()))
+                                        })
                                     })
                                     .collect(),
                                 params,

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -10,7 +10,7 @@ mod entry;
 mod tokens;
 
 use std::collections::{HashMap, HashSet};
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -635,12 +635,8 @@ fn match_command<'a>((cmd, args): (&'a Path, &'a [OsString])) -> impl Fn(&Comman
     move |(cmdpat, argpat)| {
         cmdpat.matches_path_with(cmd, opts)
             && match argpat {
-                Args::Prefix(vec) => args
-                    .iter()
-                    .take(vec.len())
-                    .eq(vec.into_iter().map(OsStr::new)),
-
-                Args::Exact(vec) => args.iter().eq(vec.into_iter().map(OsStr::new)),
+                Args::Prefix(vec) => args.starts_with(vec),
+                Args::Exact(vec) => args == vec.as_ref(),
             }
     }
 }

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -228,6 +228,11 @@ fn permission_test() {
     FAIL!(["user ALL=/bin/hel* me"], "user" => root(), "server"; "/bin/help");
     pass!(["user ALL=/bin/hel* me"], "user" => root(), "server"; "/bin/help me");
     FAIL!(["user ALL=/bin/hel* me"], "user" => root(), "server"; "/bin/help me please");
+    FAIL!(["user ALL=/bin/hel* me"], "user" => root(), "server"; "/bin/help only me");
+    pass!(["user ALL=/bin/hel*"], "user" => root(), "server"; "/bin/help me please");
+    pass!(["user ALL=/bin/hel* *"], "user" => root(), "server"; "/bin/help me please");
+    pass!(["user ALL=/bin/hel* me *"], "user" => root(), "server"; "/bin/help me please");
+    pass!(["user ALL=/bin/hel* me please *"], "user" => root(), "server"; "/bin/help me please");
 
     pass!(["user ALL=(ALL:ALL) /bin/foo"], "user" => root(), "server"; "/bin/foo" => [authenticate: Authenticate::None]);
     pass!(["root ALL=(ALL:ALL) /bin/foo"], "root" => root(), "server"; "/bin/foo" => [authenticate: Authenticate::Nopasswd]);
@@ -421,6 +426,12 @@ fn invalid_directive() {
 #[should_panic = "embedded $ in username"]
 fn invalid_username() {
     parse_eval::<ast::Sudo>("User_Alias FOO = $dollar");
+}
+
+#[test]
+#[should_panic = "wildcards are not allowed in command arguments"]
+fn wildcard_in_argument() {
+    parse_eval::<ast::Sudo>("user ALL=/bin/hello w*");
 }
 
 #[test]

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -441,7 +441,8 @@ fn sudoedit_recognized() {
         panic!();
     };
     assert_eq!(cmd.as_str(), "sudoedit");
-    assert_eq!(args.unwrap().as_ref(), &["/etc/tmux.conf"][..]);
+    let Args::Exact(args) = args else { panic!() };
+    assert_eq!(args.as_ref(), &["/etc/tmux.conf"][..]);
 }
 
 #[test]

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -1,6 +1,7 @@
 //! Various tokens
 
 use crate::common::{SudoPath, SudoString};
+use std::ffi::OsString;
 
 use super::basic_parser::{Many, Token};
 use crate::common::{HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2};
@@ -157,7 +158,6 @@ impl Token for AliasName {
 
 /// A struct that represents valid command strings; this can contain escape sequences and are
 /// limited to 1024 characters.
-use std::ffi::OsString;
 #[derive(PartialEq)]
 #[repr(u32)]
 pub enum Args {

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -188,6 +188,9 @@ impl Token for Command {
                 // if the magic "" appears, no (further) arguments are allowed
                 args.pop();
             }
+            if args.iter().any(|arg| arg.chars().any(|c| "?*".contains(c))) {
+                return Err("wildcards are not allowed in command arguments".to_string());
+            }
             Some(args.into_boxed_slice())
         };
 


### PR DESCRIPTION
Resurrection of #781 (which I couldn't re-open because I force-pushed first)

First commit is from that old PR; second is a conservative change that rewrites the Option into an Enum; the third adds Prefix-matching. 

The fourth commit is optional: this pushes the String->OsString change deeper into the stack; this has some disadvantages in the tokenizer and in `entry.rs` but advantages in the `sudoers/mod.rs` since it makes the argpat-matching more readable. I'm not sure if this is necessary.