### PR TITLE
Debounce bell

### DIFF
--- a/src/pam/mod.rs
+++ b/src/pam/mod.rs
@@ -63,7 +63,7 @@ impl PamContext {
         target_user: Option<&str>,
     ) -> PamResult<PamContext> {
         let converser = CLIConverser {
-            bell,
+            bell: bell.into(),
             name: converser_name.to_owned(),
             use_askpass,
             use_stdin,


### PR DESCRIPTION
Closes #1180

This also removes the bell being run with `askpass`. I'm not sure what setting askpass+bell makes sense, or will actually result in a bell being heard (since we're not opening a TTY), but in any case ogsudo doesn't ring a bell if I use systemd-ask-password. Maybe we should even emit an error that `--bell` and `-A` are incompatible (but then we should probably also emit an error that `-A` and `-p` are incompatible, and so on and on, that would be a different issue)

Never thought I would want to use `Cell` for something, but in this case it does precisely the trick.

Basically, whenever we open the TTY in converse, that means we're going to be wanting the user's attention for something, and that's the moment to ring the bell *once*.