### PR TITLE
Revert "test for SignalState"

### DIFF
--- a/test-framework/sudo-compliance-tests/src/sudo/misc.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/misc.rs
@@ -400,16 +400,3 @@ fn rootpw_takes_priority_over_targetpw() {
         .output(&env);
     assert!(!output.status().success());
 }
-
-#[test]
-fn signal_handlers_should_be_restored_before_execve() {
-    let env = Env([SUDOERS_ALL_ALL_NOPASSWD]).build();
-
-    let stdout = Command::new("/bin/sh")
-        .args(["-c", "(false | timeout 1 sudo head /dev/tty); true"])
-        .tty(true)
-        .output(&env)
-        .stdout();
-
-    assert_eq!(stdout, "");
-}


### PR DESCRIPTION
Reverts trifectatechfoundation/sudo-rs#1465

Unfortunately it caused a deadlock in two separate tries of the CI for https://github.com/trifectatechfoundation/sudo-rs/pull/1488: https://github.com/trifectatechfoundation/sudo-rs/actions/runs/22582419574/job/65423172393?pr=1488 We should reland a fixed test later, but for now remove it to unblock CI.