### PR TITLE
Add a 'no echo' mode

### DIFF
--- a/docs/man/sudoers.5.md
+++ b/docs/man/sudoers.5.md
@@ -384,7 +384,7 @@ sudo's behavior can be modified by Default_Entry lines, as explained earlier.  A
 
 * pwfeedback
 
-  By default, sudo reads the password like most other Unix programs, by turning off echo until the user hits the return (or enter) key.  Some users become confused by this as it appears to them that sudo has hung at this point.  When pwfeedback is set, sudo will provide visual feedback when the user presses a key.  Note that this does have a security impact as an onlooker may be able to determine the length of the password being entered.  This flag is on by default.
+  By default, sudo reads the password like most other Unix programs, by turning off echo until the user hits the return (or enter) key.  Some users become confused by this as it appears to them that sudo has hung at this point.  When pwfeedback is set, sudo will provide visual feedback when the user presses a key.  Feedback can always be turned off by using the TAB key.  This flag is on by default.
 
 * rootpw
 

--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -190,6 +190,11 @@ fn read_unbuffered(
                 pw_len = 0;
                 continue;
             }
+
+            if read_byte == b'\t' && feedback.visible_len.take().is_some() {
+                feedback.clear();
+                let _ = feedback.sink.write(b"(no echo)");
+            }
         }
 
         if let Some(dest) = password.get_mut(pw_len) {


### PR DESCRIPTION
Closes #1487

(Note: this will still allow a "TAB" as part of a password if the pwfeedback is disabled as an escape hatch for that certain person who is adventurous enough to have that key in his passphrase.)