### PR TITLE
docs: add example sudoers file

### DIFF
--- a/docs/examples/sudoers.example
+++ b/docs/examples/sudoers.example
@@ -1,0 +1,17 @@
+# Example sudoers file for sudo-rs
+#
+# Copy to /etc/sudoers (or an include dir) and run:
+#   visudo -c
+# to validate syntax before use.
+
+Defaults        env_reset
+Defaults        mail_badpass
+
+# User privilege specification
+root    ALL=(ALL:ALL) ALL
+
+# Allow members of group sudo to run any command
+%sudo   ALL=(ALL:ALL) ALL
+
+# Uncomment to allow passwordless sudo for the sudo group
+# %sudo ALL=(ALL:ALL) NOPASSWD: ALL

--- a/docs/man/sudoers.5.md
+++ b/docs/man/sudoers.5.md
@@ -10,6 +10,8 @@ title: SUDOERS(5) sudo-rs 0.2.13 | sudo-rs
 
 The `sudo-rs` policy determines a user's sudo privileges. The policy is driven by the */etc/sudoers file*.  The policy format is described in detail in the **SUDOERS FILE FORMAT** section.
 
+For a minimal starter configuration, see `docs/examples/sudoers.example` in the source tree. Copy it to */etc/sudoers* (or an include directory) and validate with `visudo -c` before use.
+
 The format used by sudo-rs is a subset of the one used by the sudo-project as maintained by Todd Miller, but syntax-compatible.
 
 ## User Authentication


### PR DESCRIPTION
## Summary
- add a minimal example sudoers file under docs/examples
- mention the example in sudoers(5) man page with visudo validation reminder

## Rationale
- provides a ready-to-use starting point for sudo-rs configuration, per issue #1505

## Changes
- docs/examples/sudoers.example: starter config with sudo group and optional NOPASSWD
- docs/man/sudoers.5.md: link to the example and advise 

Fixes #1505