### PR TITLE
Allow space between Defaults@ and hostname list

### DIFF
--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -663,13 +663,14 @@ fn get_directive<'a>(
             const DEFAULTS_LEN: usize = "Defaults".len();
             let allow_scope_modifier = stream.get_pos().0 == begin_pos.0
                 && (stream.get_pos().1 - begin_pos.1 == DEFAULTS_LEN
-                    || keyword.len() > DEFAULTS_LEN);
+                    || keyword[DEFAULTS_LEN..].starts_with('@'));
 
             let scope = if allow_scope_modifier {
                 if keyword[DEFAULTS_LEN..].starts_with('@') {
                     // Backtrack and start parsing following the '@' sign
                     *stream = begin_state;
                     stream.advance(DEFAULTS_LEN + 1);
+                    skip_trailing_whitespace(stream)?;
 
                     ConfigScope::Host(expect_nonterminal(stream)?)
                 } else if is_syntax(':', stream)? {

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -661,9 +661,9 @@ fn get_directive<'a>(
             // an acceptable hostname is subset of an acceptable username, so that's actually OK.
             // This resolves an ambiguity in the grammar similarly to how MetaOrTag does that.
             const DEFAULTS_LEN: usize = "Defaults".len();
-            let allow_scope_modifier = stream.get_pos().0 == begin_pos.0
-                && (stream.get_pos().1 - begin_pos.1 == DEFAULTS_LEN
-                    || keyword[DEFAULTS_LEN..].starts_with('@'));
+            let allow_scope_modifier = keyword[DEFAULTS_LEN..].starts_with('@')
+                || (stream.get_pos().0 == begin_pos.0
+                    && stream.get_pos().1 - begin_pos.1 == DEFAULTS_LEN);
 
             let scope = if allow_scope_modifier {
                 if keyword[DEFAULTS_LEN..].starts_with('@') {

--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -144,7 +144,7 @@ impl Parse for Comment {
     }
 }
 
-fn skip_trailing_whitespace(stream: &mut CharStream) -> Parsed<()> {
+pub(super) fn skip_trailing_whitespace(stream: &mut CharStream) -> Parsed<()> {
     TrailingWhitespace::parse(stream)?;
     make(())
 }

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -607,9 +607,9 @@ fn specific_defaults() {
 fn defaults_hostname_shenanigans() {
     assert!(parse_line("Defaults@ hostname use_pty").is_decl());
     assert!(try_parse_line("Defaults@ # comment\n use_pty").is_none());
-    /* due to a technicality, this is rejected, but ogsudo doesn't accept this either */
-    assert!(try_parse_line("Defaults@\\\nhost use_pty").is_none());
-    /* ogsudo also rejects the following, but sudo-rs has no problems with these */
+    /* ogsudo also rejects the following, probably due to hack in the parser
+    not too dissimilar from ours -- but sudo-rs has no problems with these */
+    assert!(parse_line("Defaults@\\\nhost use_pty").is_decl());
     assert!(parse_line("Defaults:\\\nuser use_pty").is_decl());
     assert!(parse_line("Defaults>\\\nuser use_pty").is_decl());
     assert!(parse_line("Defaults!\\\nCMD use_pty").is_decl());

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -604,6 +604,18 @@ fn specific_defaults() {
 }
 
 #[test]
+fn defaults_hostname_shenanigans() {
+    assert!(parse_line("Defaults@ hostname use_pty").is_decl());
+    assert!(try_parse_line("Defaults@ # comment\n use_pty").is_none());
+    /* due to a technicality, this is rejected, but ogsudo doesn't accept this either */
+    assert!(try_parse_line("Defaults@\\\nhost use_pty").is_none());
+    /* ogsudo also rejects the following, but sudo-rs has no problems with these */
+    assert!(parse_line("Defaults:\\\nuser use_pty").is_decl());
+    assert!(parse_line("Defaults>\\\nuser use_pty").is_decl());
+    assert!(parse_line("Defaults!\\\nCMD use_pty").is_decl());
+}
+
+#[test]
 fn at_sign_ambiguity() {
     assert!(parse_line("Defaults@host env_keep=ALL").is_decl());
     assert!(parse_line("defaults@host env_keep=ALL").is_spec());


### PR DESCRIPTION
Closes #1508 

Needs regression tests in sudoers/test/mod.rs to also check edge cases such as:

```
Defaults@\
  ALL lecture
 ```
 ~~are accepted~~ (**edit** ogsudo rejects these too) and that
 
 ```
 Defaults@# a comment ALL lecture
 ```
 and
```
Defaults@# a comment
ALL lecture
 ```
and
```
Defaults@# a comment \
ALL lecture
```
are rejected