### PR TITLE
Pin docker image to avoid a recently introduced bug in ogsudo

### DIFF
--- a/test-framework/sudo-test/src/theirs.linux.Dockerfile
+++ b/test-framework/sudo-test/src/theirs.linux.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim
+FROM debian:trixie-slim@sha256:1d3c811171a08a5adaa4a163fbafd96b61b87aa871bbc7aa15431ac275d3d430
 RUN apt-get update && \
     apt-get install -y --no-install-recommends sudo procps sshpass rsyslog socat acl && \
     rm /etc/sudoers


### PR DESCRIPTION
Closes #1517 

This avoids a regression introduced in ogsudo