### PR TITLE
Implemented close_range (sort of) for Mac

### DIFF
--- a/src/cutils/mod.rs
+++ b/src/cutils/mod.rs
@@ -110,7 +110,8 @@ pub fn is_fifo_or_sock(fildes: BorrowedFd) -> bool {
 }
 
 #[cfg(target_os = "macos")]
-/// # Safety the same as libc::pipe
+/// # Safety
+/// Same as `libc::pipe`.
 pub unsafe extern "C" fn pipe2(fds: *mut c_int, flags: c_int) -> c_int {
     // SAFETY: the caller has to ensure this call is safe
     unsafe {

--- a/src/exec/mod.rs
+++ b/src/exec/mod.rs
@@ -119,8 +119,7 @@ pub fn run_command(
 
     let spawn_noexec_handler = if options.noexec {
         #[cfg(not(target_os = "linux"))]
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
+        return Err(io::Error::other(
             "NOEXEC is currently only supported on Linux",
         ));
 

--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -479,13 +479,15 @@ mod test {
     use libc::O_CLOEXEC;
 
     use super::*;
-    use crate::cutils::pipe2;
 
     fn make_pipe() -> (File, File) {
         // SAFETY: A valid pointer to a mutable array of 2 fds is passed in.
         unsafe {
             let mut pipes = [-1, -1];
-            cerr(pipe2(pipes.as_mut_ptr(), O_CLOEXEC)).unwrap();
+            #[cfg(not(target_os = "macos"))]
+            cerr(libc::pipe2(pipes.as_mut_ptr(), O_CLOEXEC)).unwrap();
+            #[cfg(target_os = "macos")]
+            cerr(crate::cutils::pipe2(pipes.as_mut_ptr(), O_CLOEXEC)).unwrap();
             (File::from_raw_fd(pipes[0]), File::from_raw_fd(pipes[1]))
         }
     }

--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -479,12 +479,13 @@ mod test {
     use libc::O_CLOEXEC;
 
     use super::*;
+    use crate::cutils::pipe2;
 
     fn make_pipe() -> (File, File) {
         // SAFETY: A valid pointer to a mutable array of 2 fds is passed in.
         unsafe {
             let mut pipes = [-1, -1];
-            cerr(libc::pipe2(pipes.as_mut_ptr(), O_CLOEXEC)).unwrap();
+            cerr(pipe2(pipes.as_mut_ptr(), O_CLOEXEC)).unwrap();
             (File::from_raw_fd(pipes[0]), File::from_raw_fd(pipes[1]))
         }
     }

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -258,6 +258,7 @@ fn open_at(parent: BorrowedFd, file_name: &CStr, create: bool) -> io::Result<Own
     }
 }
 
+#[allow(dead_code)]
 fn faccess_at(parent: BorrowedFd, path: &CStr, mode: c_int, flags: c_int) -> io::Result<()> {
     // SAFETY: by design, a correct CStr pointer is passed to faccessat
     cerr(unsafe { libc::faccessat(parent.as_raw_fd(), path.as_ptr(), mode, flags) }).map(|_| ())

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -51,6 +51,10 @@ pub(crate) fn _exit(status: c_int) -> ! {
 #[cfg(not(target_os = "macos"))]
 pub(crate) fn mark_fds_as_cloexec() -> io::Result<()> {
     let lowfd = STDERR_FILENO + 1;
+fn set_cloexec(fd: c_int) -> io::Result<()> {
+    // SAFETY: This only sets the CLOEXEC flag; it does not close or invalidate the fd.
+    unsafe { cerr(libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC)) }.map(|_| ())
+}
 
     // SAFETY: this function is safe to call:
     // - any errors while closing a specific fd will be effectively ignored

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -16,10 +16,9 @@ use crate::{
 };
 use interface::{DeviceId, GroupId, ProcessId, UserId};
 pub use libc::PATH_MAX;
-#[cfg(target_os = "macos")]
 use libc::STDERR_FILENO;
 #[cfg(not(target_os = "macos"))]
-use libc::{CLOSE_RANGE_CLOEXEC, EINVAL, ENOSYS, STDERR_FILENO};
+use libc::{CLOSE_RANGE_CLOEXEC, EINVAL, ENOSYS};
 use time::ProcessCreateTime;
 
 use self::signal::SignalNumber;

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -109,12 +109,51 @@ fn set_cloexec(fd: c_int) -> io::Result<()> {
                     cerr(libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC))?;
                 }
             }
+/// Attempts to set CLOEXEC on all fds >= lowfd via proc_pidinfo(PROC_PIDLISTFDS).
+/// Returns Ok(true) on success, Ok(false) if proc_pidinfo is unavailable, Err on failure.
+#[cfg(target_os = "macos")]
+fn try_proc_pidinfo(lowfd: c_int) -> io::Result<bool> {
+    const WIGGLE_ROOM: i32 = 4;
 
-            Ok(())
-        }
-        Err(err) => Err(err),
-        Ok(_) => Ok(()),
+    let pid = unsafe { libc::getpid() };
+
+    // SAFETY: passing a null buffer with size 0 just queries the required buffer size.
+    let needed =
+        unsafe { libc::proc_pidinfo(pid, libc::PROC_PIDLISTFDS, 0, std::ptr::null_mut(), 0) };
+
+    // If needed is zero, there are no open files.
+    // If needed is less than zero, alternate methods should be considered
+    // Either way, we want to recover, so throw unavailable.
+    if needed <= 0 {
+        return Ok(false);
     }
+
+    // Allocate with wiggle room for any extraneous fds opened between the two calls.
+    let cap = needed + (libc::PROC_PIDLISTFD_SIZE * WIGGLE_ROOM);
+    let count = cap as usize / std::mem::size_of::<libc::proc_fdinfo>();
+    let mut buf: Vec<libc::proc_fdinfo> = Vec::with_capacity(count);
+
+    // SAFETY: since proc_fdinfo is a plain C struct... we assume that proc_pidinfo fills the allocation safely.
+    let filled =
+        unsafe { libc::proc_pidinfo(pid, libc::PROC_PIDLISTFDS, 0, buf.as_mut_ptr().cast(), cap) };
+
+    if filled <= 0 {
+        return Ok(false);
+    }
+
+    let pidlistfd_size = std::mem::size_of::<libc::proc_fdinfo>();
+    let n = filled as usize / pidlistfd_size;
+
+    // SAFETY: proc_pidinfo wrote `n` valid entries into the buffer.
+    unsafe { buf.set_len(n) };
+
+    for info in &buf {
+        if info.proc_fd >= lowfd {
+            set_cloexec(info.proc_fd)?;
+        }
+    }
+
+    Ok(true)
 }
 
 pub(crate) enum ForkResult {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -47,15 +47,15 @@ pub(crate) fn _exit(status: c_int) -> ! {
     unsafe { libc::_exit(status) }
 }
 
-/// Mark every file descriptor that is not one of the IO streams as CLOEXEC.
-#[cfg(not(target_os = "macos"))]
-pub(crate) fn mark_fds_as_cloexec() -> io::Result<()> {
-    let lowfd = STDERR_FILENO + 1;
 fn set_cloexec(fd: c_int) -> io::Result<()> {
     // SAFETY: This only sets the CLOEXEC flag; it does not close or invalidate the fd.
     unsafe { cerr(libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC)) }.map(|_| ())
 }
 
+/// Attempts close_range(CLOSE_RANGE_CLOEXEC) for all fds >= lowfd.
+/// Returns Ok(true) on success, Ok(false) if unsupported, Err on any other failure.
+#[cfg(not(target_os = "macos"))]
+fn try_close_range(lowfd: c_int) -> io::Result<bool> {
     // SAFETY: this function is safe to call:
     // - any errors while closing a specific fd will be effectively ignored
     #[allow(clippy::diverging_sub_expression)]
@@ -78,56 +78,110 @@ fn set_cloexec(fd: c_int) -> io::Result<()> {
             ));
         }
     };
-
     match res {
-        Err(err) if err.raw_os_error() == Some(ENOSYS) || err.raw_os_error() == Some(EINVAL) => {
-            mark_fds_as_cloexec_fallback(lowfd);
-        }
-        Err(err) => Err(err),
-        Ok(_) => Ok(()),
+        Ok(_) => Ok(true),
+        Err(e) if e.raw_os_error() == Some(ENOSYS) || e.raw_os_error() == Some(EINVAL) => Ok(false),
+        Err(e) => Err(e),
     }
 }
 
+/// Attempts to set CLOEXEC on all fds >= lowfd via proc_pidinfo(PROC_PIDLISTFDS).
+/// Returns Ok(true) on success, Ok(false) if proc_pidinfo is unavailable, Err on failure.
 #[cfg(target_os = "macos")]
-pub(crate) fn mark_fds_as_cloexec() -> io::Result<()> {
-    mark_fds_as_cloexec_fallback(STDERR_FILENO + 1)
+fn try_proc_pidinfo(lowfd: c_int) -> io::Result<bool> {
+    const WIGGLE_ROOM: i32 = 4;
+
+    let pid = unsafe { libc::getpid() };
+
+    // SAFETY: passing a null buffer with size 0 just queries the required buffer size.
+    let needed =
+        unsafe { libc::proc_pidinfo(pid, libc::PROC_PIDLISTFDS, 0, std::ptr::null_mut(), 0) };
+
+    // If needed is zero, there are no open files.
+    // If needed is less than zero, alternate methods should be considered
+    // Either way, we want to recover, so throw unavailable.
+    if needed <= 0 {
+        return Ok(false);
+    }
+
+    // Allocate with wiggle room for any extraneous fds opened between the two calls.
+    let cap = needed + (libc::PROC_PIDLISTFD_SIZE * WIGGLE_ROOM);
+    let count = cap as usize / std::mem::size_of::<libc::proc_fdinfo>();
+    let mut buf: Vec<libc::proc_fdinfo> = Vec::with_capacity(count);
+
+    // SAFETY: since proc_fdinfo is a plain C struct... we assume that proc_pidinfo fills the allocation safely.
+    let filled =
+        unsafe { libc::proc_pidinfo(pid, libc::PROC_PIDLISTFDS, 0, buf.as_mut_ptr().cast(), cap) };
+
+    if filled <= 0 {
+        return Ok(false);
+    }
+
+    let pidlistfd_size = std::mem::size_of::<libc::proc_fdinfo>();
+    let n = filled as usize / pidlistfd_size;
+
+    // SAFETY: proc_pidinfo wrote `n` valid entries into the buffer.
+    unsafe { buf.set_len(n) };
+
+    for info in &buf {
+        if info.proc_fd >= lowfd {
+            set_cloexec(info.proc_fd)?;
+        }
+    }
+
+    Ok(true)
 }
 
-fn mark_fds_as_cloexec_fallback(lowfd: i32) -> io::Result<()> {
-    // If the kernel doesn't support close_range or CLOSE_RANGE_CLOEXEC,
-    // fallback to finding all open fds using /proc/self/fd or /dev/fd
+/// Sets CLOEXEC on all fds >= lowfd by walking an fd directory
+/// (/proc/self/fd on Linux/FreeBSD, /dev/fd on macOS).
+fn cloexec_via_fd_dir(lowfd: c_int, path: &str) -> io::Result<()> {
+    for entry in fs::read_dir(path)? {
+        let file_name = entry?.file_name();
 
-    for entry in fs::read_dir(if cfg!(target_os = "linux") {
-        "/proc/self/fd"
-    } else {
-        "/dev/fd"
-    })? {
-        let entry = entry?;
-        let file_name = entry.file_name();
-        let file_name = file_name.to_str().ok_or(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "procfs returned non-integer fd name",
-        ))?;
         if file_name == "." || file_name == ".." {
             continue;
         }
-        let fd = file_name.parse::<c_int>().map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "procfs returned non-integer fd name",
-            )
-        })?;
-        if fd < lowfd {
-            continue;
-        }
-        // SAFETY: This only sets the CLOEXEC flag for the given fd. Nothing is
-        // going to need it after exec.
-        unsafe {
-            cerr(libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC))?;
+
+        let fd = file_name
+            .to_str()
+            .and_then(|s| s.parse::<c_int>().ok())
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "fd directory returned non-integer fd name",
+                )
+            })?;
+
+        if fd >= lowfd {
+            set_cloexec(fd)?;
         }
     }
-
     Ok(())
+}
+
+/// Mark every file descriptor that is not one of the IO streams as CLOEXEC.
+pub(crate) fn mark_fds_as_cloexec() -> io::Result<()> {
+    let lowfd = STDERR_FILENO + 1;
+
+    // The kernel doesn't support close_range or CLOSE_RANGE_CLOEXEC,
+    // so our fallback on all platforms to finding all open fds using /proc/self/fd.
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        if try_close_range(lowfd)? {
+            return Ok(());
+        }
+
+        cloexec_via_fd_dir(lowfd, "/proc/self/fd")
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if try_proc_pidinfo(lowfd)? {
+            return Ok(());
+        }
+        cloexec_via_fd_dir(lowfd, "/dev/fd")
+    }
 }
 
 pub(crate) enum ForkResult {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -170,7 +170,7 @@ pub(crate) fn mark_fds_as_cloexec() -> io::Result<()> {
             return Ok(());
         }
 
-        return cloexec_via_fd_dir(lowfd, "/proc/self/fd");
+        cloexec_via_fd_dir(lowfd, "/proc/self/fd")
     }
 
     #[cfg(target_os = "macos")]

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -80,32 +80,6 @@ fn set_cloexec(fd: c_int) -> io::Result<()> {
             // The kernel doesn't support close_range or CLOSE_RANGE_CLOEXEC,
             // fallback to finding all open fds using /proc/self/fd.
 
-            // FIXME use /dev/fd on macOS
-            for entry in fs::read_dir("/proc/self/fd")? {
-                let entry = entry?;
-                let file_name = entry.file_name();
-                let file_name = file_name.to_str().ok_or(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "procfs returned non-integer fd name",
-                ))?;
-                if file_name == "." || file_name == ".." {
-                    continue;
-                }
-                let fd = file_name.parse::<c_int>().map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "procfs returned non-integer fd name",
-                    )
-                })?;
-                if fd < lowfd {
-                    continue;
-                }
-                // SAFETY: This only sets the CLOEXEC flag for the given fd. Nothing is
-                // going to need it after exec.
-                unsafe {
-                    cerr(libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC))?;
-                }
-            }
 /// Attempts to set CLOEXEC on all fds >= lowfd via proc_pidinfo(PROC_PIDLISTFDS).
 /// Returns Ok(true) on success, Ok(false) if proc_pidinfo is unavailable, Err on failure.
 #[cfg(target_os = "macos")]
@@ -151,6 +125,33 @@ fn try_proc_pidinfo(lowfd: c_int) -> io::Result<bool> {
     }
 
     Ok(true)
+}
+
+/// Sets CLOEXEC on all fds >= lowfd by walking an fd directory
+/// (/proc/self/fd on Linux/FreeBSD, /dev/fd on macOS).
+fn cloexec_via_fd_dir(lowfd: c_int, path: &str) -> io::Result<()> {
+    for entry in fs::read_dir(path)? {
+        let file_name = entry?.file_name();
+
+        if file_name == "." || file_name == ".." {
+            continue;
+        }
+
+        let fd = file_name
+            .to_str()
+            .and_then(|s| s.parse::<c_int>().ok())
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "fd directory returned non-integer fd name",
+                )
+            })?;
+
+        if fd >= lowfd {
+            set_cloexec(fd)?;
+        }
+    }
+    Ok(())
 }
 
 /// Mark every file descriptor that is not one of the IO streams as CLOEXEC.

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -56,6 +56,8 @@ fn set_cloexec(fd: c_int) -> io::Result<()> {
 /// Returns Ok(true) on success, Ok(false) if unsupported, Err on any other failure.
 #[cfg(not(target_os = "macos"))]
 fn try_close_range(lowfd: c_int) -> io::Result<bool> {
+    // SAFETY: this function is safe to call:
+    // - any errors while closing a specific fd will be effectively ignored
     #[allow(clippy::diverging_sub_expression)]
     let res = unsafe {
         'a: {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -50,6 +50,10 @@ pub(crate) fn _exit(status: c_int) -> ! {
 /// Mark every file descriptor that is not one of the IO streams as CLOEXEC.
 pub(crate) fn mark_fds_as_cloexec() -> io::Result<()> {
     let lowfd = STDERR_FILENO + 1;
+fn set_cloexec(fd: c_int) -> io::Result<()> {
+    // SAFETY: This only sets the CLOEXEC flag; it does not close or invalidate the fd.
+    unsafe { cerr(libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC)) }.map(|_| ())
+}
 
     // SAFETY: this function is safe to call:
     // - any errors while closing a specific fd will be effectively ignored

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -16,7 +16,9 @@ use crate::{
 };
 use interface::{DeviceId, GroupId, ProcessId, UserId};
 pub use libc::PATH_MAX;
-use libc::{CLOSE_RANGE_CLOEXEC, EINVAL, ENOSYS, STDERR_FILENO};
+use libc::STDERR_FILENO;
+#[cfg(not(target_os = "macos"))]
+use libc::{CLOSE_RANGE_CLOEXEC, EINVAL, ENOSYS};
 use time::ProcessCreateTime;
 
 use self::signal::SignalNumber;

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -47,9 +47,6 @@ pub(crate) fn _exit(status: c_int) -> ! {
     unsafe { libc::_exit(status) }
 }
 
-/// Mark every file descriptor that is not one of the IO streams as CLOEXEC.
-pub(crate) fn mark_fds_as_cloexec() -> io::Result<()> {
-    let lowfd = STDERR_FILENO + 1;
 fn set_cloexec(fd: c_int) -> io::Result<()> {
     // SAFETY: This only sets the CLOEXEC flag; it does not close or invalidate the fd.
     unsafe { cerr(libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC)) }.map(|_| ())
@@ -154,6 +151,31 @@ fn try_proc_pidinfo(lowfd: c_int) -> io::Result<bool> {
     }
 
     Ok(true)
+}
+
+/// Mark every file descriptor that is not one of the IO streams as CLOEXEC.
+pub(crate) fn mark_fds_as_cloexec() -> io::Result<()> {
+    let lowfd = STDERR_FILENO + 1;
+
+    // The kernel doesn't support close_range or CLOSE_RANGE_CLOEXEC,
+    // so our fallback on all platforms to finding all open fds using /proc/self/fd.
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        if try_close_range(lowfd)? {
+            return Ok(());
+        }
+
+        return cloexec_via_fd_dir(lowfd, "/proc/self/fd");
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if try_proc_pidinfo(lowfd)? {
+            return Ok(());
+        }
+        cloexec_via_fd_dir(lowfd, "/dev/fd")
+    }
 }
 
 pub(crate) enum ForkResult {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -56,8 +56,6 @@ fn set_cloexec(fd: c_int) -> io::Result<()> {
 /// Returns Ok(true) on success, Ok(false) if unsupported, Err on any other failure.
 #[cfg(not(target_os = "macos"))]
 fn try_close_range(lowfd: c_int) -> io::Result<bool> {
-    // SAFETY: this function is safe to call:
-    // - any errors while closing a specific fd will be effectively ignored
     #[allow(clippy::diverging_sub_expression)]
     let res = unsafe {
         'a: {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -2,7 +2,7 @@
 #[cfg(target_os = "linux")]
 use std::str::FromStr;
 use std::{
-    ffi::{CStr, c_int, c_long, c_uint},
+    ffi::{CStr, c_int, c_long},
     fmt, fs, io,
     mem::MaybeUninit,
     ops,
@@ -19,6 +19,8 @@ pub use libc::PATH_MAX;
 use libc::STDERR_FILENO;
 #[cfg(not(target_os = "macos"))]
 use libc::{CLOSE_RANGE_CLOEXEC, EINVAL, ENOSYS};
+#[cfg(not(target_os = "macos"))]
+use std::ffi::c_uint;
 use time::ProcessCreateTime;
 
 use self::signal::SignalNumber;
@@ -91,6 +93,7 @@ fn try_close_range(lowfd: c_int) -> io::Result<bool> {
 fn try_proc_pidinfo(lowfd: c_int) -> io::Result<bool> {
     const WIGGLE_ROOM: i32 = 4;
 
+    // SAFETY: getpid() is always safe to call.
     let pid = unsafe { libc::getpid() };
 
     // SAFETY: passing a null buffer with size 0 just queries the required buffer size.
@@ -667,6 +670,7 @@ impl Group {
 
 pub enum WithProcess {
     Current,
+    #[allow(dead_code)]
     Other(ProcessId),
 }
 
@@ -804,7 +808,7 @@ impl Process {
     /// Returns the device identifier of the TTY device that is currently
     /// attached to the given process
     #[cfg(target_os = "macos")]
-    pub fn tty_device_id(pid: WithProcess) -> std::io::Result<Option<DeviceId>> {
+    pub fn tty_device_id(_pid: WithProcess) -> std::io::Result<Option<DeviceId>> {
         Ok(None)
     }
 
@@ -841,7 +845,7 @@ impl Process {
 
     /// Get the process starting time of a specific process
     #[cfg(target_os = "macos")]
-    pub fn starting_time(pid: WithProcess) -> io::Result<ProcessCreateTime> {
+    pub fn starting_time(_pid: WithProcess) -> io::Result<ProcessCreateTime> {
         Ok(ProcessCreateTime::new(0, 0))
     }
 }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -52,8 +52,10 @@ fn set_cloexec(fd: c_int) -> io::Result<()> {
     unsafe { cerr(libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC)) }.map(|_| ())
 }
 
-    // SAFETY: this function is safe to call:
-    // - any errors while closing a specific fd will be effectively ignored
+/// Attempts close_range(CLOSE_RANGE_CLOEXEC) for all fds >= lowfd.
+/// Returns Ok(true) on success, Ok(false) if unsupported, Err on any other failure.
+#[cfg(not(target_os = "macos"))]
+fn try_close_range(lowfd: c_int) -> io::Result<bool> {
     #[allow(clippy::diverging_sub_expression)]
     let res = unsafe {
         'a: {
@@ -74,11 +76,12 @@ fn set_cloexec(fd: c_int) -> io::Result<()> {
             ));
         }
     };
-
     match res {
-        Err(err) if err.raw_os_error() == Some(ENOSYS) || err.raw_os_error() == Some(EINVAL) => {
-            // The kernel doesn't support close_range or CLOSE_RANGE_CLOEXEC,
-            // fallback to finding all open fds using /proc/self/fd.
+        Ok(_) => Ok(true),
+        Err(e) if e.raw_os_error() == Some(ENOSYS) || e.raw_os_error() == Some(EINVAL) => Ok(false),
+        Err(e) => Err(e),
+    }
+}
 
 /// Attempts to set CLOEXEC on all fds >= lowfd via proc_pidinfo(PROC_PIDLISTFDS).
 /// Returns Ok(true) on success, Ok(false) if proc_pidinfo is unavailable, Err on failure.


### PR DESCRIPTION
Just like on Linux, there really isn't a close_range function (If we consider libc authoritative).

But there are some other solutions! I basically stole from the [C sudo project](https://github.com/sudo-project/sudo) (As recommended in the original thread). 

Specifically, this implements using /dev/fd on macOS. In the original C implementation this uses some [odd abstraction](https://github.com/sudo-project/sudo/blob/116115229a625afe068ac6c593a5ce2176a96a08/lib/util/closefrom.c#L161) which vaguely concerns me, but here we use a literal like on Linux.

And also specifically, this uses the [recommended](https://github.com/trifectatechfoundation/sudo-rs/issues/901#issuecomment-2676437187) proc_pidinfo approach as the main solution (the /dev/fd is a fallback).

Funniest here is the WIGGLE_ROOM constant, which just covers from some expected user entropy. I would like feedback on what could happen if WIGGLE_ROOM is exceeded. All in all, it sticks fairly close to the C implementation, linked in the relevant commit.

Tried to stick to the code style I saw elsewhere in the codebase, but outside of that likely comment, I was interested in what the expectation is for testing? Left out of this PR (for now) so I'm marking it as a draft, just because it is the area of expertise I lack the most in. Commentary there would be MOST appreciated.

Also... I can't compile because I'm on Mac, so the other reason for delayed testing is me setting up a Linux VM.

@squell 

Closes #901 