### PR TITLE
Detect panics early in test framework Output construction

### DIFF
--- a/test-framework/sudo-test/src/docker/command.rs
+++ b/test-framework/sudo-test/src/docker/command.rs
@@ -228,15 +228,11 @@ impl TryFrom<process::Output> for Output {
 
         // detect Rust panics early: exit code 101 is the default panic exit code
         if output.status.code() == Some(101) {
-            panic!(
-                "program panicked (exit code 101)\nstdout:\n{stdout}\n\nstderr:\n{stderr}"
-            );
+            panic!("program panicked (exit code 101)\nstdout:\n{stdout}\n\nstderr:\n{stderr}");
         }
 
         if stderr.contains("panicked") {
-            panic!(
-                "program panicked\nstdout:\n{stdout}\n\nstderr:\n{stderr}"
-            );
+            panic!("program panicked\nstdout:\n{stdout}\n\nstderr:\n{stderr}");
         }
 
         Ok(Output {

--- a/test-framework/sudo-test/src/docker/command.rs
+++ b/test-framework/sudo-test/src/docker/command.rs
@@ -227,12 +227,8 @@ impl TryFrom<process::Output> for Output {
         }
 
         // detect Rust panics early: exit code 101 is the default panic exit code
-        if output.status.code() == Some(101) {
-            panic!("program panicked (exit code 101)\nstdout:\n{stdout}\n\nstderr:\n{stderr}");
-        }
-
-        if stderr.contains("panicked") {
-            panic!("program panicked\nstdout:\n{stdout}\n\nstderr:\n{stderr}");
+        if output.status.code() == Some(101) || stderr.contains("panicked") {
+            panic!("program panicked with {}\nstdout:\n{stdout}\n\nstderr:\n{stderr}", output.status);
         }
 
         Ok(Output {

--- a/test-framework/sudo-test/src/docker/command.rs
+++ b/test-framework/sudo-test/src/docker/command.rs
@@ -226,6 +226,19 @@ impl TryFrom<process::Output> for Output {
             stdout.pop();
         }
 
+        // detect Rust panics early: exit code 101 is the default panic exit code
+        if output.status.code() == Some(101) {
+            panic!(
+                "program panicked (exit code 101)\nstdout:\n{stdout}\n\nstderr:\n{stderr}"
+            );
+        }
+
+        if stderr.contains("panicked") {
+            panic!(
+                "program panicked\nstdout:\n{stdout}\n\nstderr:\n{stderr}"
+            );
+        }
+
         Ok(Output {
             status: output.status,
             stderr,

--- a/test-framework/sudo-test/src/docker/command.rs
+++ b/test-framework/sudo-test/src/docker/command.rs
@@ -228,7 +228,10 @@ impl TryFrom<process::Output> for Output {
 
         // detect Rust panics early: exit code 101 is the default panic exit code
         if output.status.code() == Some(101) || stderr.contains("panicked") {
-            panic!("program panicked with {}\nstdout:\n{stdout}\n\nstderr:\n{stderr}", output.status);
+            panic!(
+                "program panicked with {}\nstdout:\n{stdout}\n\nstderr:\n{stderr}",
+                output.status
+            );
         }
 
         Ok(Output {


### PR DESCRIPTION
Closes #1375

This adds automatic panic detection when constructing `Output` from `process::Output` in the test framework. Instead of silently succeeding when a tested program panics, the test now fails immediately with a clear message.

Two checks are added in `TryFrom<process::Output>`:

- **Exit code 101** — Rust uses this as the default exit code when a thread panics. If the process exited with code 101, the test fails.
- **"panicked" in stderr** — Rust panic output contains the word "panicked" (e.g. `thread 'main' panicked at ...`). If stderr contains this, the test fails regardless of exit code.

Both checks run before the `Output` is returned, so any panic is caught at the earliest possible point rather than relying on individual tests to check for it manually.