### PR TITLE
docs: Fix missing dash in sudo -p option

### DIFF
--- a/docs/man/sudo.8.man
+++ b/docs/man/sudo.8.man
@@ -128,7 +128,7 @@ Avoid prompting the user for input of any kind.
 If any input is required for the \f[I]command\f[R] to run, sudo\-rs will
 display an error message and exit.
 .TP
-\f[CR]p\f[R], \f[CR]\-\-prompt\f[R]=\f[I]prompt\f[R]
+\f[CR]\-p\f[R], \f[CR]\-\-prompt\f[R]=\f[I]prompt\f[R]
 Use a custom authentication prompt with optional escape sequences.
 The following percent (`%') escape sequences are supported:
 .RS

--- a/docs/man/sudo.8.md
+++ b/docs/man/sudo.8.md
@@ -91,7 +91,7 @@ are introduced.
 :   Avoid prompting the user for input of any kind. If any input is required for
     the *command* to run, sudo-rs will display an error message and exit.
 
-`p`, `--prompt`=*prompt*
+`-p`, `--prompt`=*prompt*
 :   Use a custom authentication prompt with optional escape sequences. The
     following percent (‘%’) escape sequences are supported:
 


### PR DESCRIPTION
`./util/generate-docs.sh` also applied some pre-existing changes to su.1.man. I erred toward excluding them and keeping the PR self contained.