### PR TITLE
Proposed changes to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,5 +23,11 @@ We prefer to receive reports in English. If necessary, we also understand Spanis
 ## Disclosure Policy
 Like original sudo, we adhere to the principle of [Coordinated Vulnerability Disclosure](https://certcc.github.io/CERT-Guide-to-CVD/tutorials/cvd_in_a_nutshell/).
 
+## Reporter Expectations
+
+Vulnerability reports are considered Contributions in the legal sense of the Apache 2.0 license. Our [Contributor Expectations](https://github.com/trifectatechfoundation/sudo-rs/?tab=contributing-ov-file#expectations-for-contributors) apply as well. 
+
+If we determine a submitted report to not constitute a security vulnerability, it will be disclosed on our issue tracker.
+
 # Security Advisories
 Security advisories will be published [on GitHub](https://github.com/trifectatechfoundation/sudo-rs/security/advisories) and possibly through other channels.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,11 +23,11 @@ We prefer to receive reports in English. If necessary, we also understand Spanis
 ## Disclosure Policy
 Like original sudo, we adhere to the principle of [Coordinated Vulnerability Disclosure](https://certcc.github.io/CERT-Guide-to-CVD/tutorials/cvd_in_a_nutshell/).
 
+If we determine a submitted report to not constitute a security vulnerability, it will be disclosed to our issue tracker.
+
 ## Reporter Expectations
 
 Vulnerability reports are considered Contributions in the legal sense of the Apache 2.0 license. Our [Contributor Expectations](https://github.com/trifectatechfoundation/sudo-rs/?tab=contributing-ov-file#expectations-for-contributors) apply as well. 
-
-If we determine a submitted report to not constitute a security vulnerability, it will be disclosed on our issue tracker.
 
 # Security Advisories
 Security advisories will be published [on GitHub](https://github.com/trifectatechfoundation/sudo-rs/security/advisories) and possibly through other channels.


### PR DESCRIPTION
I have discussed these briefly with @davidv1992, and received these ideas after reading https://daniel.haxx.se/blog/2026/02/25/curl-security-moves-again/.

Textually, I have added a section that mirrors our "contributor expectations".

Basically, the policy changes are two-folds:

- We make explicit that our contributor expectations apply; this links directly to the section that contains are stance on generative AI, which is mostly what this is aimed at. And our stance here is of course quite clear: a reporter has to do a first review. Maybe this part could be more explicit.

- A minor legal point: reports are contributions just like issues; which means Apache 2.0 applies and we can use whatever someone submits to us under that license. And that also means we can publish them for full transparency.