### PR TITLE
Add feature gate 'unstable-remote-sudoers'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ apparmor = []
 # whether to enable 'gettext' support for giving localized user-facing messages
 gettext = []
 
+# whether to enable the unstable '@socket' feature for fetching a remote sudoers
+unstable-remote-sudoers = []
+
 # enable detailed logging (use for development only) to /tmp
 # this will compromise the security of sudo-rs somewhat
 dev = []

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -158,6 +158,7 @@ pub enum Sudo {
     Decl(Directive) = HARDENED_ENUM_VALUE_1,
     Include(String, Span) = HARDENED_ENUM_VALUE_2,
     IncludeDir(String, Span) = HARDENED_ENUM_VALUE_3,
+    #[cfg(feature = "unstable-remote-sudoers")]
     Remote(String, Span) = HARDENED_ENUM_VALUE_4,
     LineComment = HARDENED_ENUM_VALUE_5,
 }
@@ -593,6 +594,7 @@ fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
             let (path, span) = get_path(stream, key_pos)?;
             Sudo::IncludeDir(path, span)
         }
+        #[cfg(feature = "unstable-remote-sudoers")]
         Some(Username(key)) if key == "socket" => {
             let (path, span) = get_path(stream, key_pos)?;
             Sudo::Remote(path, span)

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![cfg_attr(not(feature = "unstable-remote-sudoers"), allow(unused_imports))]
 
 //! Code that checks (and in the future: lists) permissions in the sudoers file
 
@@ -413,6 +414,7 @@ fn open_subsudoers(path: &Path) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
     read_sudoers(source)
 }
 
+#[cfg(feature = "unstable-remote-sudoers")]
 fn open_remote_sudoers(path: &Path) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
     let source = audit::secure_open_remote_sudoers(path)?;
     read_sudoers(source)
@@ -700,6 +702,7 @@ fn analyze(
     #[derive(Clone, Copy)]
     #[repr(u32)]
     enum IncludeState {
+        #[cfg(feature = "unstable-remote-sudoers")]
         Forbidden = HARDENED_ENUM_VALUE_0,
         Allowed(u8) = HARDENED_ENUM_VALUE_1,
     }
@@ -707,6 +710,10 @@ fn analyze(
     impl IncludeState {
         #[inline]
         fn inc(&mut self) -> &mut Self {
+            #[cfg_attr(
+                not(feature = "unstable-remote-sudoers"),
+                allow(irrefutable_let_patterns)
+            )]
             if let IncludeState::Allowed(x) = self {
                 *x += 1;
             }
@@ -716,6 +723,7 @@ fn analyze(
         #[inline]
         fn limit_reached(&self) -> bool {
             match self {
+                #[cfg(feature = "unstable-remote-sudoers")]
                 IncludeState::Forbidden => true,
                 IncludeState::Allowed(x) => *x >= INCLUDE_LIMIT,
             }
@@ -727,6 +735,7 @@ fn analyze(
     enum IncludeDirective {
         Include = HARDENED_ENUM_VALUE_0,
         IncludeDir = HARDENED_ENUM_VALUE_1,
+        #[cfg(feature = "unstable-remote-sudoers")]
         Remote = HARDENED_ENUM_VALUE_2,
     }
 
@@ -735,6 +744,7 @@ fn analyze(
             let s = match self {
                 IncludeDirective::Include => "@include",
                 IncludeDirective::IncludeDir => "@includedir",
+                #[cfg(feature = "unstable-remote-sudoers")]
                 IncludeDirective::Remote => "@socket",
             };
             write!(f, "{s}")
@@ -768,6 +778,7 @@ fn analyze(
                 IncludeState::Allowed(_) => {
                     format!("include file limit reached opening '{}'", path.display())
                 }
+                #[cfg(feature = "unstable-remote-sudoers")]
                 IncludeState::Forbidden => {
                     format!("{} forbidden at this stage", include_source)
                 }
@@ -779,6 +790,7 @@ fn analyze(
             });
         } else {
             let (res, next_state, kind) = match include_source {
+                #[cfg(feature = "unstable-remote-sudoers")]
                 IncludeDirective::Remote => (
                     open_remote_sudoers(path),
                     &mut IncludeState::Forbidden,
@@ -861,6 +873,7 @@ fn analyze(
                         IncludeDirective::Include,
                     ),
 
+                    #[cfg(feature = "unstable-remote-sudoers")]
                     Sudo::Remote(path, span) => {
                         let socket_path = Path::new(&path);
                         if socket_path.is_relative() {

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "unstable-remote-sudoers"), allow(unused_imports))]
 use std::collections::HashSet;
 use std::ffi::{CStr, CString, c_int, c_uint};
 use std::fs::{self, DirBuilder, File, Metadata, OpenOptions};
@@ -139,6 +140,7 @@ pub fn secure_open_sudoers(path: impl AsRef<Path>, check_parent_dir: bool) -> io
     secure_open_impl(path.as_ref(), &mut open_options, check_parent_dir, false)
 }
 
+#[cfg(feature = "unstable-remote-sudoers")]
 pub fn secure_open_remote_sudoers(path: impl AsRef<Path>) -> io::Result<BufReader<UnixStream>> {
     secure_open_socket_impl(path.as_ref())
 }
@@ -242,6 +244,7 @@ fn secure_open_impl(
 
 // Open the socket at path, provided that it is "secure".
 // "Secure" means that it passes the `checks` function above.
+#[cfg(feature = "unstable-remote-sudoers")]
 fn secure_open_socket_impl(path: &Path) -> io::Result<BufReader<UnixStream>> {
     let meta = fs::metadata(path)?;
     checks(path, meta)?;

--- a/test-framework/sudo-test/src/docker.rs
+++ b/test-framework/sudo-test/src/docker.rs
@@ -222,6 +222,7 @@ pub fn build_base_image() {
                         "pam-login",
                         #[cfg(feature = "apparmor")]
                         "apparmor",
+                        "unstable-remote-sudoers",
                     ]
                     .join(",")
                 });


### PR DESCRIPTION
Closes #1548 

Since this is a temporary gate I've squelched some unused import errors by just ignoring those if the feature is turned off. 