### PR TITLE
Correctly use extern "C" for signal handlers

### DIFF
--- a/src/system/signal/set.rs
+++ b/src/system/signal/set.rs
@@ -59,7 +59,7 @@ impl SignalAction {
 
 static PENDING_SIGNALS: [AtomicBool; 64] = [const { AtomicBool::new(false) }; 64];
 
-fn store_pending(signal: SignalNumber) {
+extern "C" fn store_pending(signal: SignalNumber) {
     PENDING_SIGNALS[signal as usize].store(true, Ordering::SeqCst);
 }
 

--- a/src/system/signal/set.rs
+++ b/src/system/signal/set.rs
@@ -57,10 +57,13 @@ impl SignalAction {
     }
 }
 
-static PENDING_SIGNALS: [AtomicBool; 64] = [const { AtomicBool::new(false) }; 64];
+static PENDING_SIGNALS: [AtomicBool; 65] = [const { AtomicBool::new(false) }; 65];
 
 extern "C" fn store_pending(signal: SignalNumber) {
-    PENDING_SIGNALS[signal as usize].store(true, Ordering::SeqCst);
+    /* ignore any weird signals */
+    if let Some(flag) = PENDING_SIGNALS.get(signal as usize) {
+        flag.store(true, Ordering::SeqCst);
+    }
 }
 
 pub(crate) fn take_first_pending() -> Option<SignalNumber> {

--- a/src/system/signal/stream.rs
+++ b/src/system/signal/stream.rs
@@ -23,7 +23,7 @@ static STREAM: OnceLock<SignalStream> = OnceLock::new();
 /// # Safety
 ///
 /// The `info` parameters has to point to a valid instance of SignalInfo
-pub(super) unsafe fn send_siginfo(
+pub(super) unsafe extern "C" fn send_siginfo(
     _signal: SignalNumber,
     info: *const SignalInfo,
     _context: *const c_void,


### PR DESCRIPTION
Strictly speaking using the Rust ABI here is UB, but to the best of my knowledge no rustc version from the past 10 years would miscompile this on mainstream targets given that all arguments are 32bit int or pointer types rather than structs. Other than on x86 (which uses the stack) all mainstream targets pass these (possibly sign extended) in registers. The current Rust ABI has only differed in omitting this sign extension, but we ignore the argument that gets sign extended anyway.