### PR TITLE
Make secure_open checks in audit.rs uniform

### DIFF
--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -404,7 +404,7 @@ fn read_sudoers<R: io::Read>(mut reader: R) -> io::Result<Vec<basic_parser::Pars
 }
 
 fn open_sudoers(path: &Path) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
-    let source = audit::secure_open_sudoers(path, true)?;
+    let source = audit::secure_open_sudoers(path)?;
     read_sudoers(source)
 }
 

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -404,7 +404,7 @@ fn read_sudoers<R: io::Read>(mut reader: R) -> io::Result<Vec<basic_parser::Pars
 }
 
 fn open_sudoers(path: &Path) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
-    let source = audit::secure_open_sudoers(path, false)?;
+    let source = audit::secure_open_sudoers(path, true)?;
     read_sudoers(source)
 }
 

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -408,11 +408,6 @@ fn open_sudoers(path: &Path) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
     read_sudoers(source)
 }
 
-fn open_subsudoers(path: &Path) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
-    let source = audit::secure_open_sudoers(path, true)?;
-    read_sudoers(source)
-}
-
 fn open_remote_sudoers(path: &Path) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
     let source = audit::secure_open_remote_sudoers(path)?;
     read_sudoers(source)
@@ -784,7 +779,7 @@ fn analyze(
                     &mut IncludeState::Forbidden,
                     "socket",
                 ),
-                _ => (open_subsudoers(path), include_state.inc(), "file"),
+                _ => (open_sudoers(path), include_state.inc(), "file"),
             };
 
             match res {

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -245,6 +245,17 @@ fn secure_open_impl(
 fn secure_open_socket_impl(path: &Path) -> io::Result<BufReader<UnixStream>> {
     let meta = fs::metadata(path)?;
     checks(path, meta)?;
+    if let Some(parent_dir) = path.parent() {
+        let parent_meta = std::fs::metadata(parent_dir)?;
+        checks(parent_dir, parent_meta)?;
+    } else {
+        let error = |msg| Error::new(ErrorKind::PermissionDenied, msg);
+
+        return Err(error(xlat!(
+            "{path} has no valid parent directory",
+            path = path.display()
+        )));
+    }
 
     let stream = UnixStream::connect(path)?;
     stream.shutdown(Shutdown::Write)?;

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -132,11 +132,11 @@ fn mode(who: Category, what: Op) -> u32 {
 }
 
 /// Open sudo configuration using various security checks
-pub fn secure_open_sudoers(path: impl AsRef<Path>, check_parent_dir: bool) -> io::Result<File> {
+pub fn secure_open_sudoers(path: impl AsRef<Path>) -> io::Result<File> {
     let mut open_options = OpenOptions::new();
     open_options.read(true);
 
-    secure_open_impl(path.as_ref(), &mut open_options, check_parent_dir, false)
+    secure_open_impl(path.as_ref(), &mut open_options, false)
 }
 
 pub fn secure_open_remote_sudoers(path: impl AsRef<Path>) -> io::Result<BufReader<UnixStream>> {
@@ -153,7 +153,7 @@ pub fn secure_open_cookie_file(path: impl AsRef<Path>) -> io::Result<File> {
         .truncate(false)
         .mode(mode(Category::Owner, Op::Write) | mode(Category::Owner, Op::Read));
 
-    secure_open_impl(path.as_ref(), &mut open_options, true, true)
+    secure_open_impl(path.as_ref(), &mut open_options, true)
 }
 
 /// Return the system zoneinfo path after validating that it is safe
@@ -201,11 +201,10 @@ fn checks(path: &Path, meta: Metadata) -> io::Result<()> {
 fn secure_open_impl(
     path: &Path,
     open_options: &mut OpenOptions,
-    check_parent_dir: bool,
     create_parent_dirs: bool,
 ) -> io::Result<File> {
     let error = |msg| Error::new(ErrorKind::PermissionDenied, msg);
-    if check_parent_dir || create_parent_dirs {
+    if true || create_parent_dirs {
         if let Some(parent_dir) = path.parent() {
             // if we should create parent dirs and it does not yet exist, create it
             if create_parent_dirs && !parent_dir.exists() {
@@ -221,7 +220,7 @@ fn secure_open_impl(
                     .create(parent_dir)?;
             }
 
-            if check_parent_dir {
+            if true {
                 let parent_meta = std::fs::metadata(parent_dir)?;
                 checks(parent_dir, parent_meta)?;
             }
@@ -420,24 +419,24 @@ mod test {
     fn secure_open_is_predictable() {
         // /etc/hosts should be readable and "secure" (if this test fails, you have been compromised)
         assert!(std::fs::File::open("/etc/hosts").is_ok());
-        assert!(secure_open_sudoers("/etc/hosts", false).is_ok());
+        assert!(secure_open_sudoers("/etc/hosts").is_ok());
 
         // /tmp should be readable, but not secure (writable by group other than root)
         assert!(std::fs::File::open("/tmp").is_ok());
-        assert!(secure_open_sudoers("/tmp", false).is_err());
+        assert!(secure_open_sudoers("/tmp").is_err());
 
         #[cfg(target_os = "linux")]
         {
             // /var/log/wtmp should be readable, but not secure (writable by group other than root)
             // It doesn't exist on many non-Linux systems however.
             if std::fs::File::open("/var/log/wtmp").is_ok() {
-                assert!(secure_open_sudoers("/var/log/wtmp", false).is_err());
+                assert!(secure_open_sudoers("/var/log/wtmp").is_err());
             }
         }
 
         // /etc/shadow should not be readable
         assert!(std::fs::File::open("/etc/shadow").is_err());
-        assert!(secure_open_sudoers("/etc/shadow", false).is_err());
+        assert!(secure_open_sudoers("/etc/shadow").is_err());
     }
 
     #[test]

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -204,32 +204,28 @@ fn secure_open_impl(
     create_parent_dirs: bool,
 ) -> io::Result<File> {
     let error = |msg| Error::new(ErrorKind::PermissionDenied, msg);
-    if true || create_parent_dirs {
-        if let Some(parent_dir) = path.parent() {
-            // if we should create parent dirs and it does not yet exist, create it
-            if create_parent_dirs && !parent_dir.exists() {
-                DirBuilder::new()
-                    .recursive(true)
-                    .mode(
-                        mode(Category::Owner, Op::Write)
-                            | mode(Category::Owner, Op::Read)
-                            | mode(Category::Owner, Op::Exec)
-                            | mode(Category::Group, Op::Exec)
-                            | mode(Category::World, Op::Exec),
-                    )
-                    .create(parent_dir)?;
-            }
-
-            if true {
-                let parent_meta = std::fs::metadata(parent_dir)?;
-                checks(parent_dir, parent_meta)?;
-            }
-        } else {
-            return Err(error(xlat!(
-                "{path} has no valid parent directory",
-                path = path.display()
-            )));
+    if let Some(parent_dir) = path.parent() {
+        // if we should create parent dirs and it does not yet exist, create it
+        if create_parent_dirs && !parent_dir.exists() {
+            DirBuilder::new()
+                .recursive(true)
+                .mode(
+                    mode(Category::Owner, Op::Write)
+                        | mode(Category::Owner, Op::Read)
+                        | mode(Category::Owner, Op::Exec)
+                        | mode(Category::Group, Op::Exec)
+                        | mode(Category::World, Op::Exec),
+                )
+                .create(parent_dir)?;
         }
+
+        let parent_meta = std::fs::metadata(parent_dir)?;
+        checks(parent_dir, parent_meta)?;
+    } else {
+        return Err(error(xlat!(
+            "{path} has no valid parent directory",
+            path = path.display()
+        )));
     }
 
     let file = open_options.open(path)?;


### PR DESCRIPTION
This removes a distinction introduced in #694.

The individual commits are purposefully tiny.

Helps with but does not close fully #1549 