### PR TITLE
Automate generation of release notes further

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,14 +66,21 @@ jobs:
           path: release_files
 
       - name: Prepare release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "Release files:"
           ls -l release_files
           echo
 
+          # Add the fixed header to the release notes
+          echo 'To use the precompiled binaries attached below, consult our [manual installation instructions](https://github.com/trifectatechfoundation/sudo-rs?tab=readme-ov-file#installing-our-pre-compiled-x86-64-binaries)' > notes.md
+
           # Extract the first changelog entry from CHANGELOG.md
           echo "Changelog:"
-          sed -n '4,${ /^## /q; p; }' CHANGELOG.md | tee changes.md
+          sed -n '4,${ /^## /q; p; }' CHANGELOG.md | tee -a notes.md
+
+          util/gh-credits.sh >> notes.md
 
       - name: Create release
         env:
@@ -87,6 +94,6 @@ jobs:
 
           gh release create "$RELEASE" --draft \
             --title "Version ${RELEASE#v}" \
-            --notes-file changes.md release_files/* \
+            --notes-file notes.md release_files/* \
             --verify-tag
           echo "Draft release successfully created. Please review and publish."

--- a/util/gh-credits.sh
+++ b/util/gh-credits.sh
@@ -1,0 +1,42 @@
+#! /bin/bash
+
+# the time of the most recent release
+SINCE="$(gh release list --limit 1 --json publishedAt --jq '.[] | .publishedAt')"
+
+cur_contributors() {
+    gh pr ls --state merged --limit 100 --json author,mergedAt \
+        --jq "map(select(.mergedAt >= \"$SINCE\")) | unique_by(.author.login) | sort_by(.mergedAt) | reverse | .[] | .author.login" | \
+        grep -v 'app/dependabot'
+}
+
+prev_contributors() {
+    gh pr ls --state merged --limit 10000 --json author,mergedAt \
+        --jq ".[] | select(.mergedAt < \"$SINCE\") | .author.login"
+}
+
+cur_issuers() {
+    gh issue ls --state closed --json author,closedAt,stateReason \
+        --jq "map(select(.stateReason == \"COMPLETED\" and .closedAt >= \"$SINCE\")) | unique_by(.author.login) | sort_by(.closedAt) | .[] | .author.login" | \
+        grep -v 'app/dependabot'
+}
+
+fmt_handles() {
+    sed 's/^/@/' | tr '\n' ',' | sed 's/,@/, @/g;s/,$//'
+}
+
+# cache the results
+CONTRIBUTORS="$(cur_contributors)"
+OLD_CONTRIBUTORS="$(prev_contributors)"
+
+echo "###### Contributors for this release"
+
+# create a list of contributors, where we separate new from repeat contributors
+
+AGAIN=$(grep -Fxf <(echo "$OLD_CONTRIBUTORS") <(echo "$CONTRIBUTORS") | fmt_handles)
+FRESH=$(grep -v -Fxf <(echo "$OLD_CONTRIBUTORS") <(echo "$CONTRIBUTORS") | fmt_handles)
+echo "Merged pull requests: $AGAIN${FRESH:+${AGAIN:+, }*new contributors:* $FRESH}"
+
+# this list is for people who have only opened issues *only*
+
+REPORTERS=$(grep -v -Fxf <(echo "$CONTRIBUTORS") <(cur_issuers) | fmt_handles)
+echo "Closed issues opened by: $REPORTERS"


### PR DESCRIPTION
Last few releases I was simply following an algorithm, so let's code that.

This automates the generation of the header (about the binaries) and the contributor list.

Note: it could be sped up by caching the list of contributors in the repo. But right now fetching all the PR's is still doable and that should remain the case for quite some time.