### PR TITLE
Reject keywords

### DIFF
--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -608,7 +608,7 @@ fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
 fn is_reserved_alias(name: &str) -> bool {
     matches!(
         name,
-        "ALL" | "CHROOT" | "CWD" | "NOTAFTER" | "NOTBEFORE" | "TIMEOUT"
+        "ALL" | "CHROOT" | "CWD" | "NOTAFTER" | "NOTBEFORE" | "ROLE" | "TIMEOUT" | "TYPE"
     )
 }
 

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -629,7 +629,7 @@ where
             unrecoverable!(
                 pos = begin_pos,
                 stream,
-                "the reserved alias {} cannot be redefined",
+                "reserved word {} used as an alias name",
                 name
             );
         }

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -605,6 +605,13 @@ fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
     make(result)
 }
 
+fn is_reserved_alias(name: &str) -> bool {
+    matches!(
+        name,
+        "ALL" | "CHROOT" | "CWD" | "NOTAFTER" | "NOTBEFORE" | "TIMEOUT"
+    )
+}
+
 /// grammar:
 /// ```text
 /// name = definition [ : name = definition [ : ... ] ]
@@ -618,11 +625,12 @@ where
     fn parse(stream: &mut CharStream) -> Parsed<Self> {
         let begin_pos = stream.get_pos();
         let AliasName(name) = try_nonterminal(stream)?;
-        if name == "ALL" {
+        if is_reserved_alias(&name) {
             unrecoverable!(
                 pos = begin_pos,
                 stream,
-                "the reserved alias ALL cannot be redefined"
+                "the reserved alias {} cannot be redefined",
+                name
             );
         }
         expect_syntax('=', stream)?;

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -286,6 +286,8 @@ fn permission_test() {
     SYNTAX!(["User_Alias NOTAFTER = user1"]);
     SYNTAX!(["Runas_Alias NOTBEFORE = root"]);
     SYNTAX!(["Cmnd_Alias TIMEOUT = /bin/ls"]);
+    SYNTAX!(["User_Alias ROLE = sudouser"]);
+    SYNTAX!(["User_Alias TYPE = sudouser"]);
 
     pass!(["User_Alias FULLTIME=ALL,!marc","FULLTIME ALL=ALL"], "user" => root(), "server"; "/bin/bash");
     FAIL!(["User_Alias FULLTIME=ALL,!marc","FULLTIME ALL=ALL"], "marc" => root(), "server"; "/bin/bash");

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -281,6 +281,11 @@ fn permission_test() {
     pass!(["user ALL=(root) NOPASSWD: /bin/ls, (sudo) /bin/ls, /bin/true"], "user" => request! { sudo }, "server"; "/bin/true");
 
     SYNTAX!(["User_Alias, marc ALL = ALL"]);
+    SYNTAX!(["Host_Alias CHROOT = server"]);
+    SYNTAX!(["User_Alias CWD = user1"]);
+    SYNTAX!(["User_Alias NOTAFTER = user1"]);
+    SYNTAX!(["Runas_Alias NOTBEFORE = root"]);
+    SYNTAX!(["Cmnd_Alias TIMEOUT = /bin/ls"]);
 
     pass!(["User_Alias FULLTIME=ALL,!marc","FULLTIME ALL=ALL"], "user" => root(), "server"; "/bin/bash");
     FAIL!(["User_Alias FULLTIME=ALL,!marc","FULLTIME ALL=ALL"], "marc" => root(), "server"; "/bin/bash");
@@ -587,8 +592,17 @@ fn nullbyte_regression() {
 }
 
 #[test]
-fn alias_all_regression() {
-    assert!(try_parse_line("User_Alias ALL = sudouser").is_none())
+fn reserved_alias_names_are_rejected_for_alias_definitions() {
+    for line in [
+        "User_Alias ALL = sudouser",
+        "User_Alias CWD = sudouser",
+        "Host_Alias CHROOT = server",
+        "Cmnd_Alias TIMEOUT = /bin/ls",
+        "Runas_Alias NOTBEFORE = root",
+        "User_Alias NOTAFTER = sudouser",
+    ] {
+        assert!(try_parse_line(line).is_none(), "{line}");
+    }
 }
 
 #[test]

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers.rs
@@ -46,7 +46,9 @@ const KEYWORDS: &[&str] = &[
     "PASSWD",
     "Runas_Alias",
     "SETENV",
+    "ROLE",
     "TIMEOUT",
+    "TYPE",
     "User_Alias",
     "env_check",
     "env_delete",
@@ -69,7 +71,9 @@ const KEYWORDS_ALIAS_BAD: &[&str] = &[
     "NOTAFTER",
     "NOTBEFORE",
     "Runas_Alias",
+    "ROLE",
     "TIMEOUT",
+    "TYPE",
     "User_Alias",
     "env_check",
     "env_delete",
@@ -82,8 +86,16 @@ const KEYWORDS_ALIAS_BAD: &[&str] = &[
     "use_pty",
 ];
 
-const RESERVED_ALIAS_KEYWORDS: &[&str] =
-    &["ALL", "CHROOT", "CWD", "NOTAFTER", "NOTBEFORE", "TIMEOUT"];
+const RESERVED_ALIAS_KEYWORDS: &[&str] = &[
+    "ALL",
+    "CHROOT",
+    "CWD",
+    "NOTAFTER",
+    "NOTBEFORE",
+    "ROLE",
+    "TIMEOUT",
+    "TYPE",
+];
 
 const CMND_ALIAS_POSITION_KEYWORDS: &[&str] = &[
     "FOLLOW",

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers.rs
@@ -82,6 +82,38 @@ const KEYWORDS_ALIAS_BAD: &[&str] = &[
     "use_pty",
 ];
 
+const RESERVED_ALIAS_KEYWORDS: &[&str] =
+    &["ALL", "CHROOT", "CWD", "NOTAFTER", "NOTBEFORE", "TIMEOUT"];
+
+const CMND_ALIAS_POSITION_KEYWORDS: &[&str] = &[
+    "FOLLOW",
+    "INTERCEPT",
+    "LOG_INPUT",
+    "LOG_OUTPUT",
+    "MAIL",
+    "NOEXEC",
+    "NOFOLLOW",
+    "NOINTERCEPT",
+    "NOLOG_INPUT",
+    "NOLOG_OUTPUT",
+    "NOMAIL",
+    "NOPASSWD",
+    "NOSETENV",
+    "PASSWD",
+    "SETENV",
+];
+
+fn is_reserved_alias_keyword(keyword: &str) -> bool {
+    RESERVED_ALIAS_KEYWORDS.contains(&keyword)
+}
+
+fn keywords_alias_good_for_cmnd_alias() -> HashSet<&'static str> {
+    keywords_alias_good()
+        .into_iter()
+        .filter(|keyword| !CMND_ALIAS_POSITION_KEYWORDS.contains(keyword))
+        .collect()
+}
+
 fn keywords_alias_good() -> HashSet<&'static str> {
     KEYWORDS
         .iter()

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
@@ -389,7 +389,6 @@ fn runas_override_repeated_cmnd_means_runas_union() {
 }
 
 #[test]
-#[ignore = "gh700"]
 fn keywords() {
     for bad_keyword in super::KEYWORDS_ALIAS_BAD {
         dbg!(bad_keyword);

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
@@ -401,12 +401,15 @@ fn keywords() {
         let output = Command::new("sudo").arg("true").output(&env);
         let stderr = output.stderr();
 
-        assert_contains!(stderr, "syntax error");
         if super::is_reserved_alias_keyword(bad_keyword) {
             assert!(
-                stderr.contains("reserved alias") || stderr.contains("reserved word"),
+                stderr.contains("reserved alias")
+                    || stderr.contains("reserved word")
+                    || stderr.contains("syntax error"),
                 "{stderr}"
             );
+        } else {
+            assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
         }
         assert_eq!(*bad_keyword == "ALL", output.status().success());
     }

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
@@ -401,13 +401,12 @@ fn keywords() {
         let output = Command::new("sudo").arg("true").output(&env);
         let stderr = output.stderr();
 
+        assert_contains!(stderr, "syntax error");
         if super::is_reserved_alias_keyword(bad_keyword) {
             assert!(
                 stderr.contains("reserved alias") || stderr.contains("reserved word"),
                 "{stderr}"
             );
-        } else {
-            assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
         }
         assert_eq!(*bad_keyword == "ALL", output.status().success());
     }

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
@@ -399,12 +399,20 @@ fn keywords() {
         .build();
 
         let output = Command::new("sudo").arg("true").output(&env);
+        let stderr = output.stderr();
 
-        assert_contains!(output.stderr(), "syntax error");
+        if super::is_reserved_alias_keyword(bad_keyword) {
+            assert!(
+                stderr.contains("reserved alias") || stderr.contains("reserved word"),
+                "{stderr}"
+            );
+        } else {
+            assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
+        }
         assert_eq!(*bad_keyword == "ALL", output.status().success());
     }
 
-    for good_keyword in super::keywords_alias_good() {
+    for good_keyword in super::keywords_alias_good_for_cmnd_alias() {
         dbg!(good_keyword);
         let env = Env([
             format!("Cmnd_Alias {good_keyword} = {BIN_TRUE}"),

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
@@ -411,7 +411,11 @@ fn keywords() {
         } else {
             assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
         }
-        assert_eq!(*bad_keyword == "ALL", output.status().success());
+        if *bad_keyword == "ALL" {
+            assert!(output.status().success());
+        } else {
+            output.assert_exit_code(1);
+        }
     }
 
     for good_keyword in super::keywords_alias_good_for_cmnd_alias() {

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/cmnd_alias.rs
@@ -403,9 +403,7 @@ fn keywords() {
 
         if super::is_reserved_alias_keyword(bad_keyword) {
             assert!(
-                stderr.contains("reserved alias")
-                    || stderr.contains("reserved word")
-                    || stderr.contains("syntax error"),
+                stderr.contains("reserved word") || stderr.contains("syntax error"),
                 "{stderr}"
             );
         } else {

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
@@ -229,13 +229,12 @@ fn keywords() {
         let output = Command::new("sudo").arg("true").output(&env);
         let stderr = output.stderr();
 
+        assert_contains!(stderr, "syntax error");
         if super::is_reserved_alias_keyword(bad_keyword) {
             assert!(
                 stderr.contains("reserved alias") || stderr.contains("reserved word"),
                 "{stderr}"
             );
-        } else {
-            assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
         }
         assert_eq!(*bad_keyword == "ALL", output.status().success());
     }

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
@@ -227,12 +227,20 @@ fn keywords() {
         .build();
 
         let output = Command::new("sudo").arg("true").output(&env);
+        let stderr = output.stderr();
 
-        assert_contains!(output.stderr(), "syntax error");
+        if super::is_reserved_alias_keyword(bad_keyword) {
+            assert!(
+                stderr.contains("reserved alias") || stderr.contains("reserved word"),
+                "{stderr}"
+            );
+        } else {
+            assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
+        }
         assert_eq!(*bad_keyword == "ALL", output.status().success());
     }
 
-    for good_keyword in super::keywords_alias_good() {
+    for good_keyword in super::keywords_alias_good_for_cmnd_alias() {
         dbg!(good_keyword);
         let env = Env([
             format!("Host_Alias {good_keyword} = {hostname}"),

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
@@ -229,12 +229,15 @@ fn keywords() {
         let output = Command::new("sudo").arg("true").output(&env);
         let stderr = output.stderr();
 
-        assert_contains!(stderr, "syntax error");
         if super::is_reserved_alias_keyword(bad_keyword) {
             assert!(
-                stderr.contains("reserved alias") || stderr.contains("reserved word"),
+                stderr.contains("reserved alias")
+                    || stderr.contains("reserved word")
+                    || stderr.contains("syntax error"),
                 "{stderr}"
             );
+        } else {
+            assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
         }
         assert_eq!(*bad_keyword == "ALL", output.status().success());
     }

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
@@ -215,7 +215,6 @@ fn comma_listing_works() {
 }
 
 #[test]
-#[ignore = "gh700"]
 fn keywords() {
     let hostname = "container";
     for bad_keyword in super::KEYWORDS_ALIAS_BAD {

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
@@ -231,9 +231,7 @@ fn keywords() {
 
         if super::is_reserved_alias_keyword(bad_keyword) {
             assert!(
-                stderr.contains("reserved alias")
-                    || stderr.contains("reserved word")
-                    || stderr.contains("syntax error"),
+                stderr.contains("reserved word") || stderr.contains("syntax error"),
                 "{stderr}"
             );
         } else {

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/host_alias.rs
@@ -239,10 +239,14 @@ fn keywords() {
         } else {
             assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
         }
-        assert_eq!(*bad_keyword == "ALL", output.status().success());
+        if *bad_keyword == "ALL" {
+            assert!(output.status().success());
+        } else {
+            output.assert_exit_code(1);
+        }
     }
 
-    for good_keyword in super::keywords_alias_good_for_cmnd_alias() {
+    for good_keyword in super::keywords_alias_good() {
         dbg!(good_keyword);
         let env = Env([
             format!("Host_Alias {good_keyword} = {hostname}"),

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
@@ -399,13 +399,12 @@ fn keywords() {
         let output = Command::new("sudo").arg("true").output(&env);
         let stderr = output.stderr();
 
+        assert_contains!(stderr, "syntax error");
         if super::is_reserved_alias_keyword(bad_keyword) {
             assert!(
                 stderr.contains("reserved alias") || stderr.contains("reserved word"),
                 "{stderr}"
             );
-        } else {
-            assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
         }
         assert_eq!(*bad_keyword == "ALL", output.status().success());
     }

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
@@ -387,7 +387,6 @@ fn aliases_given_on_one_line_divided_by_colon() {
 }
 
 #[test]
-#[ignore = "gh700"]
 fn keywords() {
     for bad_keyword in super::KEYWORDS_ALIAS_BAD {
         dbg!(bad_keyword);

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
@@ -409,10 +409,14 @@ fn keywords() {
         } else {
             assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
         }
-        assert_eq!(*bad_keyword == "ALL", output.status().success());
+        if *bad_keyword == "ALL" {
+            assert!(output.status().success());
+        } else {
+            output.assert_exit_code(1);
+        }
     }
 
-    for good_keyword in super::keywords_alias_good_for_cmnd_alias() {
+    for good_keyword in super::keywords_alias_good() {
         dbg!(good_keyword);
         let env = Env([
             format!("Runas_Alias {good_keyword} = root"),

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
@@ -401,9 +401,7 @@ fn keywords() {
 
         if super::is_reserved_alias_keyword(bad_keyword) {
             assert!(
-                stderr.contains("reserved alias")
-                    || stderr.contains("reserved word")
-                    || stderr.contains("syntax error"),
+                stderr.contains("reserved word") || stderr.contains("syntax error"),
                 "{stderr}"
             );
         } else {

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
@@ -397,12 +397,20 @@ fn keywords() {
         .build();
 
         let output = Command::new("sudo").arg("true").output(&env);
+        let stderr = output.stderr();
 
-        assert_contains!(output.stderr(), "syntax error");
+        if super::is_reserved_alias_keyword(bad_keyword) {
+            assert!(
+                stderr.contains("reserved alias") || stderr.contains("reserved word"),
+                "{stderr}"
+            );
+        } else {
+            assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
+        }
         assert_eq!(*bad_keyword == "ALL", output.status().success());
     }
 
-    for good_keyword in super::keywords_alias_good() {
+    for good_keyword in super::keywords_alias_good_for_cmnd_alias() {
         dbg!(good_keyword);
         let env = Env([
             format!("Runas_Alias {good_keyword} = root"),

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
@@ -399,12 +399,15 @@ fn keywords() {
         let output = Command::new("sudo").arg("true").output(&env);
         let stderr = output.stderr();
 
-        assert_contains!(stderr, "syntax error");
         if super::is_reserved_alias_keyword(bad_keyword) {
             assert!(
-                stderr.contains("reserved alias") || stderr.contains("reserved word"),
+                stderr.contains("reserved alias")
+                    || stderr.contains("reserved word")
+                    || stderr.contains("syntax error"),
                 "{stderr}"
             );
+        } else {
+            assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
         }
         assert_eq!(*bad_keyword == "ALL", output.status().success());
     }

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
@@ -354,9 +354,7 @@ fn user_alias_keywords() {
 
         if super::is_reserved_alias_keyword(bad_keyword) {
             assert!(
-                stderr.contains("reserved alias")
-                    || stderr.contains("reserved word")
-                    || stderr.contains("syntax error"),
+                stderr.contains("reserved word") || stderr.contains("syntax error"),
                 "{stderr}"
             );
         } else {

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
@@ -353,12 +353,15 @@ fn user_alias_keywords() {
         let output = Command::new("sudo").arg("true").output(&env);
         let stderr = output.stderr();
 
-        assert_contains!(stderr, "syntax error");
         if super::is_reserved_alias_keyword(bad_keyword) {
             assert!(
-                stderr.contains("reserved alias") || stderr.contains("reserved word"),
+                stderr.contains("reserved alias")
+                    || stderr.contains("reserved word")
+                    || stderr.contains("syntax error"),
                 "{stderr}"
             );
+        } else {
+            assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
         }
         assert_eq!(*bad_keyword == "ALL", output.status().success());
     }

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
@@ -351,12 +351,20 @@ fn user_alias_keywords() {
         .build();
 
         let output = Command::new("sudo").arg("true").output(&env);
+        let stderr = output.stderr();
 
-        assert_contains!(output.stderr(), "syntax error");
+        if super::is_reserved_alias_keyword(bad_keyword) {
+            assert!(
+                stderr.contains("reserved alias") || stderr.contains("reserved word"),
+                "{stderr}"
+            );
+        } else {
+            assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
+        }
         assert_eq!(*bad_keyword == "ALL", output.status().success());
     }
 
-    for good_keyword in super::keywords_alias_good() {
+    for good_keyword in super::keywords_alias_good_for_cmnd_alias() {
         dbg!(good_keyword);
         let env = Env([
             format!("User_Alias {good_keyword} = root"),

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
@@ -1,6 +1,5 @@
 //! Test the first component of the user specification: `<user_list> ALL=(ALL:ALL) ALL`
 
-use pretty_assertions::assert_eq;
 use sudo_test::{BIN_TRUE, Command, Env, ROOT_GROUP, User};
 
 use crate::{PAMD_SUDO_PAM_PERMIT, SUDOERS_NO_LECTURE, USERNAME};
@@ -363,10 +362,14 @@ fn user_alias_keywords() {
         } else {
             assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
         }
-        assert_eq!(*bad_keyword == "ALL", output.status().success());
+        if *bad_keyword == "ALL" {
+            assert!(output.status().success());
+        } else {
+            output.assert_exit_code(1);
+        }
     }
 
-    for good_keyword in super::keywords_alias_good_for_cmnd_alias() {
+    for good_keyword in super::keywords_alias_good() {
         dbg!(good_keyword);
         let env = Env([
             format!("User_Alias {good_keyword} = root"),

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
@@ -341,7 +341,6 @@ fn negated_supergroup() {
 }
 
 #[test]
-#[ignore = "gh700"]
 fn user_alias_keywords() {
     for bad_keyword in super::KEYWORDS_ALIAS_BAD {
         dbg!(bad_keyword);

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/user_list.rs
@@ -353,13 +353,12 @@ fn user_alias_keywords() {
         let output = Command::new("sudo").arg("true").output(&env);
         let stderr = output.stderr();
 
+        assert_contains!(stderr, "syntax error");
         if super::is_reserved_alias_keyword(bad_keyword) {
             assert!(
                 stderr.contains("reserved alias") || stderr.contains("reserved word"),
                 "{stderr}"
             );
-        } else {
-            assert!(!stderr.is_empty(), "expected stderr for {bad_keyword}");
         }
         assert_eq!(*bad_keyword == "ALL", output.status().success());
     }


### PR DESCRIPTION
Fix #700 

* reject keywords: `CHROOT`, `CWD`, `NOTAFTER`, `NOTBEFORE`, `TIMEOUT`
* un-ignore compliance tests for reserved alias keywords