### PR TITLE
README:Modify the prompt regarding the use of sudo-rs in Ubuntu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ To avoid that and/or to get the latest version, you can use our prepackaged bina
 
 ### Ubuntu 25.10 (Questing Quokka) and later versions
 
+#### Versions
+| Ubuntu Version | sudo-rs Version |
+|----------------|----------------|
+| 25.10          | 0.2.8-1ubuntu5.2 |
+| 26.04 LTS      | 0.2.13-0ubuntu1 |
 sudo-rs is installed and enabled by default; you can control which sudo version is being used by running
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ only change your own invocations of `sudo` to sudo-rs and not affect other progr
 
 To avoid that and/or to get the latest version, you can use our prepackaged binaries (see below).
 
-### Ubuntu 25.10 (Questing Quokka) /Ubuntu 26.04 LTS and later versions
+### Ubuntu 25.10 (Questing Quokka) and later versions
 
 sudo-rs is installed and enabled by default; you can control which sudo version is being used by running
 

--- a/README.md
+++ b/README.md
@@ -23,18 +23,17 @@ only change your own invocations of `sudo` to sudo-rs and not affect other progr
 
 To avoid that and/or to get the latest version, you can use our prepackaged binaries (see below).
 
-### Ubuntu 25.10 (Questing Quokka) and later versions
+### Ubuntu 25.10 (Questing Quokka) and 26.04 (Resolute Raccoon)
 
 #### Versions
-The sudo-rs package in Ubuntu 25.10 is based on v0.2.8 with additional bug fixes that will be part of v0.2.9.  
-The package in Ubuntu 26.04 LTS is based on v0.2.13 with an additional bug fix that will be part of v0.2.14.
+The sudo-rs package in Ubuntu 25.10 is based on v0.2.8 with additional bug fixes backported from newer versions.
+
+The package in Ubuntu 26.04 LTS is based on v0.2.13 with additional bug fixes.
 sudo-rs is installed and enabled by default; you can control which sudo version is being used by running
 
 ```sh
 update-alternatives --config sudo
 ```
-
-The sudo-rs package is based on v0.2.8 with additional bug fixes that will be part of v0.2.9.
 
 ### Arch Linux
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ To avoid that and/or to get the latest version, you can use our prepackaged bina
 
 ### Ubuntu 25.10 (Questing Quokka) and 26.04 (Resolute Raccoon)
 
-#### Versions
 sudo-rs is installed and enabled by default; you can control which sudo version is being used by running
 
 ```sh
 update-alternatives --config sudo
 ```
 
+#### Versions
 The sudo-rs package in Ubuntu 25.10 is based on v0.2.8 with additional bug fixes backported from newer versions.
 The package in Ubuntu 26.04 LTS is based on v0.2.13 with additional bug fixes.
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ To avoid that and/or to get the latest version, you can use our prepackaged bina
 ### Ubuntu 25.10 (Questing Quokka) and 26.04 (Resolute Raccoon)
 
 #### Versions
-The sudo-rs package in Ubuntu 25.10 is based on v0.2.8 with additional bug fixes backported from newer versions.
-
-The package in Ubuntu 26.04 LTS is based on v0.2.13 with additional bug fixes.
 sudo-rs is installed and enabled by default; you can control which sudo version is being used by running
 
 ```sh
 update-alternatives --config sudo
 ```
+
+The sudo-rs package in Ubuntu 25.10 is based on v0.2.8 with additional bug fixes backported from newer versions.
+The package in Ubuntu 26.04 LTS is based on v0.2.13 with additional bug fixes.
 
 ### Arch Linux
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,8 @@ To avoid that and/or to get the latest version, you can use our prepackaged bina
 ### Ubuntu 25.10 (Questing Quokka) and later versions
 
 #### Versions
-| Ubuntu Version | sudo-rs Version |
-|----------------|----------------|
-| 25.10          | 0.2.8-1ubuntu5.2 |
-| 26.04 LTS      | 0.2.13-0ubuntu1 |
+The sudo-rs package in Ubuntu 25.10 is based on v0.2.8 with additional bug fixes that will be part of v0.2.9.  
+The package in Ubuntu 26.04 LTS is based on v0.2.13 with an additional bug fix that will be part of v0.2.14.
 sudo-rs is installed and enabled by default; you can control which sudo version is being used by running
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ only change your own invocations of `sudo` to sudo-rs and not affect other progr
 
 To avoid that and/or to get the latest version, you can use our prepackaged binaries (see below).
 
-### Ubuntu 25.10 (Questing Quokka)
+### Ubuntu 25.10 (Questing Quokka) /Ubuntu 26.04 LTS and later versions
 
 sudo-rs is installed and enabled by default; you can control which sudo version is being used by running
 


### PR DESCRIPTION
I discovered that Ubuntu 25.10 was the first non-LTS release to use sudo-rs, while Ubuntu 26.04 LTS, released a few days ago, fully utilizes sudo-rs. It's the first LTS distribution to use sudo-rs. I think the readme should be revised to be more rigorous.

Below is the sudo-rs version I used on a clean install of Ubuntu 26.40 LTS. No default sudo modifications were made.

```bash
oliver@oliver-ThinkPad-P50s:~$ sudo  --version
sudo-rs 0.2.13-0ubuntu1
```