### PR TITLE
parser: implement line continuation (fix #1571)

### DIFF
--- a/src/sudoers/basic_parser.rs
+++ b/src/sudoers/basic_parser.rs
@@ -232,9 +232,12 @@ impl<T: Token> Parse for T {
                 } else if pred(ESCAPE) {
                     Ok(ESCAPE)
                 } else if stream.eat_char('\n') {
-                    // we've just consumed some whitespace, we should end
-                    // parsing the token but not abort it
-                    reject()
+                    if pred(' ') {
+                        // escape + newline = line continuation (whitespace)
+                        Ok(' ')
+                    } else {
+                        reject()
+                    }
                 } else {
                     unrecoverable!(stream, "illegal escape sequence")
                 }

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -326,6 +326,23 @@ fn permission_test() {
     // list
     pass!(["ALL ALL=(ALL:ALL) /bin/ls, list"], "user" => root(), "server"; "list");
     FAIL!(["ALL ALL=(ALL:ALL) ALL, !list"], "user" => root(), "server"; "list");
+
+    // line continuation
+    pass!(["user ALL=/bin/hello \\", "arg"], "user" => root(), "server"; "/bin/hello arg");
+    pass!(["user ALL=/bin/hello \\", "arg1 \\", "arg2"], "user" => root(), "server"; "/bin/hello arg1 arg2");
+    pass!(
+        ["user ALL=(root) NOPASSWD: /usr/bin/true \\", "arg1 \\", "arg2"],
+        "user" => root(), "server";
+        "/usr/bin/true arg1 arg2" => [authenticate: Authenticate::Nopasswd]
+    );
+    pass!(["user ALL=/bin/hello\\", "arg"], "user" => root(), "server"; "/bin/hello arg");
+    pass!(
+        ["user ALL=/bin/hello \\", "\\", "arg"],
+        "user" => root(), "server";
+        "/bin/hello arg"
+    );
+    SYNTAX!(["us\\\ner ALL=ALL"]);
+    SYNTAX!(["user ALL=/bin/hello\\"]);
 }
 
 #[test]


### PR DESCRIPTION
This PR makes the following modification:

- `\n` after an escape sequence is considered as a line continuation (whitespace)
- add 7 tests to cover typical usage of line continuation between command and arguments

# Details

Fix for #1571

We observed the following behavior difference between regular `sudo` and `sudo-rs`:

**Ubuntu 24.04**

```
siemens@snx2:~$ sudo cat /tmp/sudoers-newline-test
dabo ALL=(root) NOPASSWD: /usr/bin/true \
arg1 \
arg2
siemens@snx2:~$ sudo sha256sum /tmp/sudoers-newline-test
15d48069be804531f4e16ae128bb6eba865735194baf715d140f47050c62fe1a  /tmp/sudoers-newline-test
siemens@snx2:~$ sudo --version
Sudo version 1.9.13p3
Sudoers policy plugin version 1.9.13p3
Sudoers file grammar version 50
Sudoers I/O plugin version 1.9.13p3
Sudoers audit plugin version 1.9.13p3
siemens@snx2:~$ sudo visudo -cf /tmp/sudoers-newline-test
/tmp/sudoers-newline-test: parsed OK
siemens@snx2:~$ 
```

**Ubuntu 26.04**

```
dabo@u2604:~$ sudo cat /tmp/sudoers-newline-test 
dabo ALL=(root) NOPASSWD: /usr/bin/true \
arg1 \
arg2
dabo@u2604:~$ sudo sha256sum /tmp/sudoers-newline-test
15d48069be804531f4e16ae128bb6eba865735194baf715d140f47050c62fe1a  /tmp/sudoers-newline-test
dabo@u2604:~$ sudo --version
sudo-rs 0.2.13-0ubuntu1
dabo@u2604:~$ sudo visudo -cf /tmp/sudoers-newline-test
/tmp/sudoers-newline-test:2:1: syntax error: garbage at end of line
arg1 \
^
/tmp/sudoers-newline-test:3:5: syntax error: expected host name
arg2
    ^
visudo: invalid sudoers file
dabo@u2604:~$ 
```

Refering to sudoers(5): *Long lines can be continued with a backslash (‘\’) as the last character on the line.*