### PR TITLE
Check the peer credentials when opening a remote socket

### DIFF
--- a/docs/man/sudoers.5.man
+++ b/docs/man/sudoers.5.man
@@ -675,18 +675,27 @@ by a server application over a unix domain socket.
 For example, providing:
 .IP
 .EX
-     \[at]socket /var/run/providers/sudoers.socket
+     \[at]socket (sssd:sssd) /var/run/providers/sudoers.socket
 .EE
 .PP
-will make sudo open that socket, read the rules and close it, as if it
+will make sudo open that socket, read the rules, and close it, as if it
 was an included file.
 The rules must follow the same syntax used in the sudoers files.
 There is, however, one exception: when reading from a socket, the
-\[at]include, \[at]includedir and \[at]socket directives are not
+\[at]include, \[at]includedir, and \[at]socket directives are not
 accepted.
 .PP
-Please note that the contents read from a socket are immutable from
-sudo\[cq]s point of view and visudo will not be able to edit them.
+For security reasons, a user and optionally a group must be given,
+enclosed in parentheses and separated by a colon. Users and groups can
+be specified either by their name or by their numeric id preceded by a
+hash sign (#). When the socket is opened, and before any interaction with
+it, sudo will check that the peer process at the other side of the socket
+runs as the declared user and group (if the latter was provided). If any
+of these conditions fail, the socket is immediately closed and discarded.
+Only POSIX groups can be used.
+.PP
+Please note that visudo cannot read from a socket. Furthermore, the
+contents retrieved from a socket are considered immutable by sudo.
 .SS Other special characters and reserved words
 The pound sign (`#') is used to indicate a comment (unless it is part of
 a #include directive or unless it occurs in the context of a user name

--- a/docs/man/sudoers.5.md
+++ b/docs/man/sudoers.5.md
@@ -343,13 +343,15 @@ sudo will suspend processing of the current file and read each file in /etc/sudo
 
 Note that unlike files included via @include, visudo will not edit the files in a @includedir directory unless one of them contains a syntax error.  It is still possible to run visudo with the -f flag to edit the files directly, but this will not catch the redefinition of an alias that is also present in a different file.
 
-When managing enterprise-wide sudoers rules, it is sometimes preferable to store them in a centralized repository. The @socket directive can be used to include the contents provided by a server application over a unix domain socket. For example, providing:
+When managing enterprise-wide sudoers rules, it is sometimes preferable to store them in a centralized repository. The @socket directive can be used to include the contents provided by a server application over a Unix domain socket. For example, providing:
 
-         @socket /var/run/providers/sudoers.socket
+         @socket (sssd:sssd) /var/run/providers/sudoers.socket
 
-will make sudo open that socket, read the rules and close it, as if it was an included file. The rules must follow the same syntax used in the sudoers files. There is, however, one exception: when reading from a socket, the @include, @includedir and @socket directives are not accepted.
+will make sudo open that socket, read the rules, and close it, as if it was an included file. The rules must follow the same syntax used in the sudoers files. There is, however, one exception: when reading from a socket, the @include, @includedir, and @socket directives are not accepted.
 
-Please note that the contents read from a socket are immutable from sudo's point of view and visudo will not be able to edit them.
+For security reasons, a user and optionally a group must be given, enclosed in parentheses and separated by a colon. Users and groups can be specified either by their name or by their numeric id preceded by a hash sign (#). When the socket is opened, and before any interaction with it, sudo will check that the peer process at the other side of the socket runs as the declared user and group (if the latter was provided). If any of these conditions fail, the socket is immediately closed and discarded. Only POSIX groups can be used.
+
+Please note that visudo cannot read from a socket. Furthermore, the contents retrieved from a socket are considered immutable by sudo.
 
 ## Other special characters and reserved words
 

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -574,8 +574,6 @@ fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
         } else {
             let value_pos = stream.get_pos();
             let IncludePath(path) = expect_nonterminal(stream)?;
-            skip_trailing_whitespace(stream)?;
-            // After skipping whitespaces, the next char should be '\n'
             if stream.peek() != Some('\n') {
                 unrecoverable!(
                     pos = value_pos,

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -564,6 +564,24 @@ impl Parse for Sudo {
     }
 }
 
+#[cfg(feature = "unstable-remote-sudoers")]
+impl Parse for PeerSpec {
+    fn parse(stream: &mut CharStream) -> Parsed<Self> {
+        try_syntax('(', stream)?;
+
+        let user = expect_nonterminal(stream)?;
+
+        let group = if is_syntax(':', stream)? {
+            Some(expect_nonterminal(stream)?)
+        } else {
+            None
+        };
+
+        expect_syntax(')', stream)?;
+        make(PeerSpec { user, group })
+    }
+}
+
 /// Parse the include/include dir part that comes after the '#' or '@' prefix symbol
 fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
     fn get_path(stream: &mut CharStream, key_pos: (usize, usize)) -> Parsed<(String, Span)> {
@@ -592,37 +610,6 @@ fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
         ))
     }
 
-    #[cfg(feature = "unstable-remote-sudoers")]
-    fn get_peer(stream: &mut CharStream, key_pos: (usize, usize)) -> Parsed<(PeerSpec, Span)> {
-        if !stream.eat_char('(') {
-            unrecoverable!(
-                pos = stream.get_pos(),
-                stream,
-                "expected user credentials in parentheses"
-            )
-        }
-
-        // Parse user identifier (can be name or #id)
-        let user = expect_nonterminal::<Identifier>(stream)?;
-
-        // Parse optional group after ':'
-        let group = if stream.eat_char(':') {
-            // Group identifier (can be name or #id)
-            Some(expect_nonterminal::<Identifier>(stream)?)
-        } else {
-            None
-        };
-
-        expect_syntax(')', stream)?;
-        make((
-            PeerSpec { user, group },
-            Span {
-                start: key_pos,
-                end: stream.get_pos(),
-            },
-        ))
-    }
-
     let key_pos = stream.get_pos();
     let result = match try_nonterminal(stream)? {
         Some(Username(key)) if key == "include" => {
@@ -635,7 +622,7 @@ fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
         }
         #[cfg(feature = "unstable-remote-sudoers")]
         Some(Username(key)) if key == "socket" => {
-            let (peer_spec, _peer_span) = get_peer(stream, key_pos)?;
+            let peer_spec = expect_nonterminal(stream)?;
             let (path, span) = get_path(stream, key_pos)?;
             Sudo::Remote(path, peer_spec, span)
         }

--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -54,6 +54,14 @@ pub enum UserSpecifier {
     NonunixGroup(Identifier) = HARDENED_ENUM_VALUE_2,
 }
 
+/// Peer credentials specification for @socket directive
+#[cfg(feature = "unstable-remote-sudoers")]
+#[cfg_attr(test, derive(Clone, Debug))]
+pub struct PeerSpec {
+    pub user: Identifier,
+    pub group: Option<Identifier>,
+}
+
 /// The RunAs specification consists of a (possibly empty) list of userspecifiers, followed by a (possibly empty) list of groups.
 pub struct RunAs {
     pub users: SpecList<UserSpecifier>,
@@ -159,7 +167,7 @@ pub enum Sudo {
     Include(String, Span) = HARDENED_ENUM_VALUE_2,
     IncludeDir(String, Span) = HARDENED_ENUM_VALUE_3,
     #[cfg(feature = "unstable-remote-sudoers")]
-    Remote(String, Span) = HARDENED_ENUM_VALUE_4,
+    Remote(String, PeerSpec, Span) = HARDENED_ENUM_VALUE_4,
     LineComment = HARDENED_ENUM_VALUE_5,
 }
 
@@ -566,6 +574,8 @@ fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
         } else {
             let value_pos = stream.get_pos();
             let IncludePath(path) = expect_nonterminal(stream)?;
+            skip_trailing_whitespace(stream)?;
+            // After skipping whitespaces, the next char should be '\n'
             if stream.peek() != Some('\n') {
                 unrecoverable!(
                     pos = value_pos,
@@ -577,6 +587,37 @@ fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
         };
         make((
             path,
+            Span {
+                start: key_pos,
+                end: stream.get_pos(),
+            },
+        ))
+    }
+
+    #[cfg(feature = "unstable-remote-sudoers")]
+    fn get_peer(stream: &mut CharStream, key_pos: (usize, usize)) -> Parsed<(PeerSpec, Span)> {
+        if !stream.eat_char('(') {
+            unrecoverable!(
+                pos = stream.get_pos(),
+                stream,
+                "expected user credentials in parentheses"
+            )
+        }
+
+        // Parse user identifier (can be name or #id)
+        let user = expect_nonterminal::<Identifier>(stream)?;
+
+        // Parse optional group after ':'
+        let group = if stream.eat_char(':') {
+            // Group identifier (can be name or #id)
+            Some(expect_nonterminal::<Identifier>(stream)?)
+        } else {
+            None
+        };
+
+        expect_syntax(')', stream)?;
+        make((
+            PeerSpec { user, group },
             Span {
                 start: key_pos,
                 end: stream.get_pos(),
@@ -596,8 +637,9 @@ fn parse_include(stream: &mut CharStream) -> Parsed<Sudo> {
         }
         #[cfg(feature = "unstable-remote-sudoers")]
         Some(Username(key)) if key == "socket" => {
+            let (peer_spec, _peer_span) = get_peer(stream, key_pos)?;
             let (path, span) = get_path(stream, key_pos)?;
-            Sudo::Remote(path, span)
+            Sudo::Remote(path, peer_spec, span)
         }
         _ => unrecoverable!(pos = key_pos, stream, "unknown directive"),
     };

--- a/src/sudoers/ast_names.rs
+++ b/src/sudoers/ast_names.rs
@@ -120,6 +120,11 @@ mod names {
     impl<T: UserFriendly> UserFriendly for tokens::Unquoted<T> {
         const DESCRIPTION: &'static str = T::DESCRIPTION;
     }
+
+    #[cfg(feature = "unstable-remote-sudoers")]
+    impl UserFriendly for PeerSpec {
+        const DESCRIPTION: &'static str = "user credentials in parentheses";
+    }
 }
 
 #[cfg(test)]

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -25,6 +25,8 @@ use ast::*;
 use tokens::*;
 
 pub type Settings = defaults::Settings;
+#[cfg(feature = "unstable-remote-sudoers")]
+pub use ast::{Identifier, PeerSpec, UserSpecifier};
 pub use basic_parser::Span;
 
 /// How many nested include files do we allow?
@@ -410,8 +412,11 @@ fn open_sudoers(path: &Path) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
 }
 
 #[cfg(feature = "unstable-remote-sudoers")]
-fn open_remote_sudoers(path: &Path) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
-    let source = audit::secure_open_remote_sudoers(path)?;
+fn open_remote_sudoers(
+    path: &Path,
+    peer_spec: &ast::PeerSpec,
+) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
+    let source = audit::secure_open_remote_sudoers(path, peer_spec)?;
     read_sudoers(source)
 }
 
@@ -758,55 +763,66 @@ fn analyze(
         }
     }
 
-    fn include(
-        cfg: &mut Sudoers,
-        parent: &Path,
+    struct IncludeContext<'a> {
+        path: &'a Path,
+        parent: &'a Path,
         span: Span,
-        path: &Path,
-        diagnostics: &mut Vec<Error>,
-        include_state: &mut IncludeState,
+        diagnostics: &'a mut Vec<Error>,
+        include_state: &'a mut IncludeState,
         include_source: IncludeDirective,
-    ) {
+        #[cfg(feature = "unstable-remote-sudoers")]
+        peer_spec: Option<&'a ast::PeerSpec>,
+    }
+
+    fn include(cfg: &mut Sudoers, ctx: IncludeContext) {
         // IncludeState::limit_reached() will also detect forbidden includes
-        if include_state.limit_reached() {
-            let message = match include_state {
+        if ctx.include_state.limit_reached() {
+            let message = match ctx.include_state {
                 IncludeState::Allowed(_) => {
-                    format!("include file limit reached opening '{}'", path.display())
+                    format!(
+                        "include file limit reached opening '{}'",
+                        ctx.path.display()
+                    )
                 }
                 #[cfg(feature = "unstable-remote-sudoers")]
                 IncludeState::Forbidden => {
-                    format!("{} forbidden at this stage", include_source)
+                    format!("{} forbidden at this stage", ctx.include_source)
                 }
             };
-            diagnostics.push(Error {
-                source: Some(parent.to_owned()),
-                location: Some(span),
+            ctx.diagnostics.push(Error {
+                source: Some(ctx.parent.to_owned()),
+                location: Some(ctx.span),
                 message,
             });
         } else {
-            let (res, next_state, kind) = match include_source {
+            let (res, next_state, kind) = match ctx.include_source {
                 #[cfg(feature = "unstable-remote-sudoers")]
-                IncludeDirective::Remote => (
-                    open_remote_sudoers(path),
-                    &mut IncludeState::Forbidden,
-                    "socket",
-                ),
-                _ => (open_sudoers(path), include_state.inc(), "file"),
+                IncludeDirective::Remote => {
+                    let peer = ctx
+                        .peer_spec
+                        .expect("peer_spec required for Remote include");
+                    (
+                        open_remote_sudoers(ctx.path, peer),
+                        &mut IncludeState::Forbidden,
+                        "socket",
+                    )
+                }
+                _ => (open_sudoers(ctx.path), ctx.include_state.inc(), "file"),
             };
 
             match res {
-                Ok(subsudoer) => process(cfg, path, subsudoer, diagnostics, next_state),
+                Ok(subsudoer) => process(cfg, ctx.path, subsudoer, ctx.diagnostics, next_state),
                 Err(e) => {
                     let message = if e.kind() == io::ErrorKind::NotFound {
                         // improve the error message in this case
-                        format!("cannot open sudoers {} '{}'", kind, path.display())
+                        format!("cannot open sudoers {} '{}'", kind, ctx.path.display())
                     } else {
                         e.to_string()
                     };
 
-                    diagnostics.push(Error {
-                        source: Some(parent.to_owned()),
-                        location: Some(span),
+                    ctx.diagnostics.push(Error {
+                        source: Some(ctx.parent.to_owned()),
+                        location: Some(ctx.span),
                         message,
                     })
                 }
@@ -860,16 +876,20 @@ fn analyze(
 
                     Sudo::Include(path, span) => include(
                         cfg,
-                        cur_path,
-                        span,
-                        &resolve_relative(cur_path, path),
-                        diagnostics,
-                        include_state,
-                        IncludeDirective::Include,
+                        IncludeContext {
+                            path: &resolve_relative(cur_path, path),
+                            parent: cur_path,
+                            span,
+                            diagnostics,
+                            include_state,
+                            include_source: IncludeDirective::Include,
+                            #[cfg(feature = "unstable-remote-sudoers")]
+                            peer_spec: None,
+                        },
                     ),
 
                     #[cfg(feature = "unstable-remote-sudoers")]
-                    Sudo::Remote(path, span) => {
+                    Sudo::Remote(path, peer_spec, span) => {
                         let socket_path = Path::new(&path);
                         if socket_path.is_relative() {
                             diagnostics.push(Error {
@@ -882,12 +902,15 @@ fn analyze(
                         } else {
                             include(
                                 cfg,
-                                cur_path,
-                                span,
-                                socket_path,
-                                diagnostics,
-                                include_state,
-                                IncludeDirective::Remote,
+                                IncludeContext {
+                                    path: socket_path,
+                                    parent: cur_path,
+                                    span,
+                                    diagnostics,
+                                    include_state,
+                                    include_source: IncludeDirective::Remote,
+                                    peer_spec: Some(&peer_spec),
+                                },
                             );
                         }
                     }
@@ -929,12 +952,16 @@ fn analyze(
                         for file in safe_files {
                             include(
                                 cfg,
-                                cur_path,
-                                span,
-                                file.as_ref(),
-                                diagnostics,
-                                include_state,
-                                IncludeDirective::IncludeDir,
+                                IncludeContext {
+                                    path: file.as_ref(),
+                                    parent: cur_path,
+                                    span,
+                                    diagnostics,
+                                    include_state,
+                                    include_source: IncludeDirective::IncludeDir,
+                                    #[cfg(feature = "unstable-remote-sudoers")]
+                                    peer_spec: None,
+                                },
                             )
                         }
                     }

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -736,7 +736,7 @@ fn analyze(
         Include = HARDENED_ENUM_VALUE_0,
         IncludeDir = HARDENED_ENUM_VALUE_1,
         #[cfg(feature = "unstable-remote-sudoers")]
-        Remote = HARDENED_ENUM_VALUE_2,
+        Remote(PeerSpec) = HARDENED_ENUM_VALUE_2,
     }
 
     impl fmt::Display for IncludeDirective {
@@ -745,7 +745,7 @@ fn analyze(
                 IncludeDirective::Include => "@include",
                 IncludeDirective::IncludeDir => "@includedir",
                 #[cfg(feature = "unstable-remote-sudoers")]
-                IncludeDirective::Remote => "@socket",
+                IncludeDirective::Remote(_) => "@socket",
             };
             write!(f, "{s}")
         }
@@ -770,8 +770,6 @@ fn analyze(
         diagnostics: &'a mut Vec<Error>,
         include_state: &'a mut IncludeState,
         include_source: IncludeDirective,
-        #[cfg(feature = "unstable-remote-sudoers")]
-        peer_spec: Option<&'a ast::PeerSpec>,
     }
 
     fn include(cfg: &mut Sudoers, ctx: IncludeContext) {
@@ -797,16 +795,11 @@ fn analyze(
         } else {
             let (res, next_state, kind) = match ctx.include_source {
                 #[cfg(feature = "unstable-remote-sudoers")]
-                IncludeDirective::Remote => {
-                    let peer = ctx
-                        .peer_spec
-                        .expect("peer_spec required for Remote include");
-                    (
-                        open_remote_sudoers(ctx.path, peer),
-                        &mut IncludeState::Forbidden,
-                        "socket",
-                    )
-                }
+                IncludeDirective::Remote(peer) => (
+                    open_remote_sudoers(ctx.path, &peer),
+                    &mut IncludeState::Forbidden,
+                    "socket",
+                ),
                 _ => (open_sudoers(ctx.path), ctx.include_state.inc(), "file"),
             };
 
@@ -883,8 +876,6 @@ fn analyze(
                             diagnostics,
                             include_state,
                             include_source: IncludeDirective::Include,
-                            #[cfg(feature = "unstable-remote-sudoers")]
-                            peer_spec: None,
                         },
                     ),
 
@@ -908,8 +899,7 @@ fn analyze(
                                     span,
                                     diagnostics,
                                     include_state,
-                                    include_source: IncludeDirective::Remote,
-                                    peer_spec: Some(&peer_spec),
+                                    include_source: IncludeDirective::Remote(peer_spec),
                                 },
                             );
                         }
@@ -959,8 +949,6 @@ fn analyze(
                                     diagnostics,
                                     include_state,
                                     include_source: IncludeDirective::IncludeDir,
-                                    #[cfg(feature = "unstable-remote-sudoers")]
-                                    peer_spec: None,
                                 },
                             )
                         }

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -763,19 +763,6 @@ fn regression_check_recursion() {
 }
 
 #[cfg(feature = "unstable-remote-sudoers")]
-enum ExpectedUser<'a> {
-    Name(&'a str),
-    Uid(u32),
-}
-
-#[cfg(feature = "unstable-remote-sudoers")]
-enum ExpectedGroup<'a> {
-    Name(&'a str),
-    Gid(u32),
-    None,
-}
-
-#[cfg(feature = "unstable-remote-sudoers")]
 fn assert_remote_failure(line: &str, expected_msg: &str) {
     let [Err(Status::Fatal(_, msg)), ..] = &parse_lines::<Sudo>(&mut CharStream::new(line))[..]
     else {
@@ -789,50 +776,17 @@ fn assert_remote_failure(line: &str, expected_msg: &str) {
 fn assert_remote(
     line: &str,
     expected_path: &str,
-    expected_user: ExpectedUser,
-    expected_group: ExpectedGroup,
+    expected_user: Identifier,
+    expected_group: Option<Identifier>,
 ) {
-    use crate::sudoers::ast::{Identifier, Sudo};
-
     let result = parse_line(line);
-    let Sudo::Remote(path, peer_spec, _) = result else {
+    let ast::Sudo::Remote(path, peer_spec, _) = result else {
         panic!("Expected Sudo::Remote");
     };
 
     assert_eq!(path, expected_path);
-
-    match expected_user {
-        ExpectedUser::Name(name) => {
-            let Identifier::Name(actual_name) = &peer_spec.user else {
-                panic!("Expected user name '{}'", name);
-            };
-            assert_eq!(actual_name.as_ref(), name);
-        }
-        ExpectedUser::Uid(uid) => {
-            let Identifier::ID(actual_uid) = &peer_spec.user else {
-                panic!("Expected user ID {}", uid);
-            };
-            assert_eq!(*actual_uid, uid);
-        }
-    }
-
-    match expected_group {
-        ExpectedGroup::Name(name) => {
-            let Some(Identifier::Name(actual_name)) = &peer_spec.group else {
-                panic!("Expected group name '{}'", name);
-            };
-            assert_eq!(actual_name.as_ref(), name);
-        }
-        ExpectedGroup::Gid(gid) => {
-            let Some(Identifier::ID(actual_gid)) = &peer_spec.group else {
-                panic!("Expected group ID {}", gid);
-            };
-            assert_eq!(*actual_gid, gid);
-        }
-        ExpectedGroup::None => {
-            assert!(peer_spec.group.is_none(), "Expected no group");
-        }
-    }
+    assert_eq!(expected_user, peer_spec.user);
+    assert_eq!(expected_group, peer_spec.group);
 }
 
 #[test]
@@ -841,29 +795,29 @@ fn remote_parsing() {
     assert_remote(
         "@socket (user1:group1) /var/run/fake-1.socket",
         "/var/run/fake-1.socket",
-        ExpectedUser::Name("user1"),
-        ExpectedGroup::Name("group1"),
+        Identifier::Name("user1".into()),
+        Some(Identifier::Name("group1".into())),
     );
 
     assert_remote(
         "@socket (#2000:#2000) /var/run/fake-2.socket",
         "/var/run/fake-2.socket",
-        ExpectedUser::Uid(2000),
-        ExpectedGroup::Gid(2000),
+        Identifier::ID(2000),
+        Some(Identifier::ID(2000)),
     );
 
     assert_remote(
         "@socket (user3:#3000) /var/run/fake-3.socket",
         "/var/run/fake-3.socket",
-        ExpectedUser::Name("user3"),
-        ExpectedGroup::Gid(3000),
+        Identifier::Name("user3".into()),
+        Some(Identifier::ID(3000)),
     );
 
     assert_remote(
         "@socket (user4) /var/run/fake-4.socket",
         "/var/run/fake-4.socket",
-        ExpectedUser::Name("user4"),
-        ExpectedGroup::None,
+        Identifier::Name("user4".into()),
+        None,
     );
 
     assert_remote_failure("@socket", "expected user credentials in parentheses");

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -3,7 +3,7 @@ use std::ffi::CStr;
 use super::ast;
 use super::char_stream::CharStream;
 use super::*;
-use basic_parser::{parse_eval, parse_lines, parse_string};
+use basic_parser::{Status, parse_eval, parse_lines, parse_string};
 
 impl<T> Qualified<T> {
     pub fn as_allow(&self) -> Option<&T> {
@@ -119,6 +119,14 @@ macro_rules! sudoer {
         parse_lines(&mut CharStream::new(&[$($e),*, ""].join("\n")))
             .into_iter()
             .map(|x| Ok::<_,basic_parser::Status>(x.unwrap()))
+    }
+}
+
+#[cfg(feature = "unstable-remote-sudoers")]
+macro_rules! sudoer_err {
+    ($($e:expr),*) => {
+        parse_lines(&mut CharStream::new(&[$($e),*, ""].join("\n")))
+            .into_iter()
     }
 }
 
@@ -760,6 +768,125 @@ fn regression_check_recursion() {
     );
 
     assert!(!error.is_empty());
+}
+
+#[cfg(feature = "unstable-remote-sudoers")]
+enum ExpectedUser<'a> {
+    Name(&'a str),
+    Uid(u32),
+}
+
+#[cfg(feature = "unstable-remote-sudoers")]
+enum ExpectedGroup<'a> {
+    Name(&'a str),
+    Gid(u32),
+    None,
+}
+
+#[cfg(feature = "unstable-remote-sudoers")]
+fn assert_remote_failure(line: &str, expected_msg: &str) {
+    let option: Option<Result<Sudo, Status>> = sudoer_err![line].next();
+    let result = option.expect("Expected Some");
+
+    let Err(status) = result else {
+        panic!("Expected Err");
+    };
+
+    let Status::Fatal(_, msg) = status else {
+        panic!("Expected Fatal status");
+    };
+    assert_eq!(msg, expected_msg);
+}
+
+#[cfg(feature = "unstable-remote-sudoers")]
+fn assert_remote(
+    line: &str,
+    expected_path: &str,
+    expected_user: ExpectedUser,
+    expected_group: ExpectedGroup,
+) {
+    use crate::sudoers::ast::{Identifier, Sudo};
+
+    let result = parse_line(line);
+    let Sudo::Remote(path, peer_spec, _) = result else {
+        panic!("Expected Sudo::Remote");
+    };
+
+    assert_eq!(path, expected_path);
+
+    match expected_user {
+        ExpectedUser::Name(name) => {
+            let Identifier::Name(actual_name) = &peer_spec.user else {
+                panic!("Expected user name '{}'", name);
+            };
+            assert_eq!(actual_name.as_ref(), name);
+        }
+        ExpectedUser::Uid(uid) => {
+            let Identifier::ID(actual_uid) = &peer_spec.user else {
+                panic!("Expected user ID {}", uid);
+            };
+            assert_eq!(*actual_uid, uid);
+        }
+    }
+
+    match expected_group {
+        ExpectedGroup::Name(name) => {
+            let Some(Identifier::Name(actual_name)) = &peer_spec.group else {
+                panic!("Expected group name '{}'", name);
+            };
+            assert_eq!(actual_name.as_ref(), name);
+        }
+        ExpectedGroup::Gid(gid) => {
+            let Some(Identifier::ID(actual_gid)) = &peer_spec.group else {
+                panic!("Expected group ID {}", gid);
+            };
+            assert_eq!(*actual_gid, gid);
+        }
+        ExpectedGroup::None => {
+            assert!(peer_spec.group.is_none(), "Expected no group");
+        }
+    }
+}
+
+#[test]
+#[cfg(feature = "unstable-remote-sudoers")]
+fn remote_parsing() {
+    assert_remote(
+        "@socket (user1:group1) /var/run/fake-1.socket",
+        "/var/run/fake-1.socket",
+        ExpectedUser::Name("user1"),
+        ExpectedGroup::Name("group1"),
+    );
+
+    assert_remote(
+        "@socket (#2000:#2000) /var/run/fake-2.socket",
+        "/var/run/fake-2.socket",
+        ExpectedUser::Uid(2000),
+        ExpectedGroup::Gid(2000),
+    );
+
+    assert_remote(
+        "@socket (user3:#3000) /var/run/fake-3.socket",
+        "/var/run/fake-3.socket",
+        ExpectedUser::Name("user3"),
+        ExpectedGroup::Gid(3000),
+    );
+
+    assert_remote(
+        "@socket (user4) /var/run/fake-4.socket",
+        "/var/run/fake-4.socket",
+        ExpectedUser::Name("user4"),
+        ExpectedGroup::None,
+    );
+
+    assert_remote_failure("@socket", "expected user credentials in parentheses");
+    assert_remote_failure(
+        "@socket /path/socket.5",
+        "expected user credentials in parentheses",
+    );
+    assert_remote_failure("@socket () /var/run/fake-6.socket", "expected elem");
+    assert_remote_failure("@socket (:#7000) /var/run/fake-7.socket", "expected elem");
+    assert_remote_failure("@socket (:user8) /var/run/fake-8.socket", "expected elem");
 }
 
 fn test_topo_sort(n: usize) {

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -793,14 +793,14 @@ fn assert_remote(
 #[cfg(feature = "unstable-remote-sudoers")]
 fn remote_parsing() {
     assert_remote(
-        "@socket (user1:group1) /var/run/fake-1.socket",
+        "@socket ( user1:group1) /var/run/fake-1.socket",
         "/var/run/fake-1.socket",
         Identifier::Name("user1".into()),
         Some(Identifier::Name("group1".into())),
     );
 
     assert_remote(
-        "@socket (#2000:#2000) /var/run/fake-2.socket",
+        "@socket (#2000: #2000) /var/run/fake-2.socket",
         "/var/run/fake-2.socket",
         Identifier::ID(2000),
         Some(Identifier::ID(2000)),
@@ -820,11 +820,8 @@ fn remote_parsing() {
         None,
     );
 
-    assert_remote_failure("@socket", "expected user credentials in parentheses");
-    assert_remote_failure(
-        "@socket /path/socket.5",
-        "expected user credentials in parentheses",
-    );
+    assert_remote_failure("@socket", "expected elem");
+    assert_remote_failure("@socket /path/socket.5", "expected elem");
     assert_remote_failure("@socket () /var/run/fake-6.socket", "expected elem");
     assert_remote_failure("@socket (:#7000) /var/run/fake-7.socket", "expected elem");
     assert_remote_failure("@socket (:user8) /var/run/fake-8.socket", "expected elem");

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -122,14 +122,6 @@ macro_rules! sudoer {
     }
 }
 
-#[cfg(feature = "unstable-remote-sudoers")]
-macro_rules! sudoer_err {
-    ($($e:expr),*) => {
-        parse_lines(&mut CharStream::new(&[$($e),*, ""].join("\n")))
-            .into_iter()
-    }
-}
-
 // alternative to parse_eval, but goes through sudoer! directly
 #[must_use]
 fn parse_line(s: &str) -> Sudo {
@@ -785,16 +777,11 @@ enum ExpectedGroup<'a> {
 
 #[cfg(feature = "unstable-remote-sudoers")]
 fn assert_remote_failure(line: &str, expected_msg: &str) {
-    let option: Option<Result<Sudo, Status>> = sudoer_err![line].next();
-    let result = option.expect("Expected Some");
-
-    let Err(status) = result else {
-        panic!("Expected Err");
+    let [Err(Status::Fatal(_, msg)), ..] = &parse_lines::<Sudo>(&mut CharStream::new(line))[..]
+    else {
+        panic!("Expected Fatal error");
     };
 
-    let Status::Fatal(_, msg) = status else {
-        panic!("Expected Fatal status");
-    };
     assert_eq!(msg, expected_msg);
 }
 

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -17,6 +17,8 @@ use super::{
     Group, GroupId, User, UserId, cerr, inject_group, interface::UnixUser, set_supplementary_groups,
 };
 use crate::common::resolve::CurrentUser;
+#[cfg(feature = "unstable-remote-sudoers")]
+use crate::sudoers::{Identifier, PeerSpec};
 
 #[cfg(target_os = "linux")]
 pub(crate) fn no_new_privs_enabled() -> io::Result<bool> {
@@ -98,6 +100,31 @@ pub(crate) fn sudo_call<T>(
     Ok(result)
 }
 
+#[cfg(feature = "unstable-remote-sudoers")]
+/// Get the credentials of the peer at the other side of the socket
+fn get_peer_credentials(stream: &UnixStream) -> io::Result<libc::ucred> {
+    let mut ucred = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut ucred_size = size_of::<libc::ucred>() as libc::socklen_t;
+
+    // SAFETY: An out pointer for the correct type and length are passed.
+    // FIXME use UnixStream::peer_cred() once stable in our MSRV.
+    unsafe {
+        cerr(libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            &mut ucred as *mut _ as *mut libc::c_void,
+            &mut ucred_size,
+        ))?;
+    }
+
+    Ok(ucred)
+}
+
 /// Drop root privileges by setting effective user id equal to the real user id.
 /// This routine will panic if the process is not privileged.
 pub fn irrevocably_drop_privileges() {
@@ -141,8 +168,11 @@ pub fn secure_open_sudoers(path: impl AsRef<Path>) -> io::Result<File> {
 }
 
 #[cfg(feature = "unstable-remote-sudoers")]
-pub fn secure_open_remote_sudoers(path: impl AsRef<Path>) -> io::Result<BufReader<UnixStream>> {
-    secure_open_socket_impl(path.as_ref())
+pub fn secure_open_remote_sudoers(
+    path: impl AsRef<Path>,
+    peer_spec: &PeerSpec,
+) -> io::Result<BufReader<UnixStream>> {
+    secure_open_socket_impl(path.as_ref(), peer_spec)
 }
 
 /// Open a timestamp cookie file using various security checks
@@ -237,10 +267,84 @@ fn secure_open_impl(
     Ok(file)
 }
 
+#[cfg(feature = "unstable-remote-sudoers")]
+fn check_user(peer_uid: libc::uid_t, user_id: &Identifier) -> io::Result<()> {
+    match user_id {
+        Identifier::Name(name) => {
+            let name_cstr = CString::new(name.as_ref()).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidInput, "user name contains null byte")
+            })?;
+            let expected_user = User::from_name(&name_cstr)
+                .map_err(|e| io::Error::other(e.to_string()))?
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, format!("user '{name}' not found"))
+                })?;
+            if peer_uid != expected_user.uid.inner() {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!(
+                        "peer process must run as user '{name}' (uid {}) but runs as {peer_uid}",
+                        expected_user.uid.inner()
+                    ),
+                ));
+            }
+        }
+        Identifier::ID(uid) => {
+            if peer_uid != *uid {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!("peer process must run as uid {uid} but runs as {peer_uid}"),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "unstable-remote-sudoers")]
+fn check_group(peer_gid: libc::gid_t, group_id: Option<&Identifier>) -> io::Result<()> {
+    let Some(group_id) = group_id else {
+        return Ok(());
+    };
+
+    match group_id {
+        Identifier::Name(name) => {
+            let name_cstr = CString::new(name.as_ref()).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidInput, "group name contains null byte")
+            })?;
+            let expected_group = Group::from_name(&name_cstr)
+                .map_err(|e| io::Error::other(e.to_string()))?
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, format!("group '{name}' not found"))
+                })?;
+            if peer_gid != expected_group.gid.inner() {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!(
+                        "peer process must run as group '{name}' (gid {}) but runs as gid {peer_gid}",
+                        expected_group.gid.inner()
+                    ),
+                ));
+            }
+        }
+        Identifier::ID(gid) => {
+            if peer_gid != *gid {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!("peer process must run as gid {gid} but runs as {peer_gid}"),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 // Open the socket at path, provided that it is "secure".
 // "Secure" means that it passes the `checks` function above.
 #[cfg(feature = "unstable-remote-sudoers")]
-fn secure_open_socket_impl(path: &Path) -> io::Result<BufReader<UnixStream>> {
+fn secure_open_socket_impl(path: &Path, peer_spec: &PeerSpec) -> io::Result<BufReader<UnixStream>> {
+    // Check the metadata on the filesystem as extra security,
+    // even knowing that it produces a TOCTOU.
     let meta = fs::metadata(path)?;
     checks(path, meta)?;
     if let Some(parent_dir) = path.parent() {
@@ -256,6 +360,15 @@ fn secure_open_socket_impl(path: &Path) -> io::Result<BufReader<UnixStream>> {
     }
 
     let stream = UnixStream::connect(path)?;
+
+    // Check the peer's credentials to avoid the TOCTOU.
+    let peer_creds = get_peer_credentials(&stream)?;
+
+    // If there is an error in these checks, the function returns immediately
+    // leaving `stream` out of scope and forcing the closing of the socket.
+    check_user(peer_creds.uid, &peer_spec.user)?;
+    check_group(peer_creds.gid, peer_spec.group.as_ref())?;
+
     stream.shutdown(Shutdown::Write)?;
     let reader = BufReader::new(stream);
 

--- a/test-framework/e2e-tests/src/sudoers.rs
+++ b/test-framework/e2e-tests/src/sudoers.rs
@@ -18,7 +18,7 @@ fn test_remote_sudoers_check() {
     let include_dir = format!("{}/conf.d", base_dir);
     let include_file = format!("{}/01-conf", include_dir);
 
-    let env = Env(format!("@socket {}", socket_path))
+    let env = Env(format!("@socket (root:root) {}", socket_path))
         .directory(sudo_test::Directory(base_dir).chmod("700"))
         .directory(sudo_test::Directory(&include_dir).chmod("700"))
         .file(&include_file, TextFile("garbage").chmod("600"))
@@ -27,7 +27,7 @@ fn test_remote_sudoers_check() {
 
     // Launch the server
     let rules = format!(
-        "{} ALL=(ALL) NOPASSWD: /usr/bin/true\n@include {}\n@includedir {}\n@socket /fake/socket",
+        "{} ALL=(ALL) NOPASSWD: /usr/bin/true\n@include {}\n@includedir {}\n@socket (root:root) /fake/socket",
         user, include_file, include_dir
     );
     let server = launch_server(socket_path, rules, &env);
@@ -74,7 +74,7 @@ fn remote_sudoers_run(should_succeed: bool) {
     let user = "user1";
     let base_dir = "/secret";
 
-    let env = Env(format!("@socket {}", socket_path))
+    let env = Env(format!("@socket (root:root) {}", socket_path))
         .directory(sudo_test::Directory(base_dir).chmod("700"))
         .user(User(user))
         .build();
@@ -120,7 +120,7 @@ fn test_relative_remote_sudoers_fail() {
     let user = "user1";
     let machine = "local";
 
-    let env = Env(format!("@socket {}", socket_path))
+    let env = Env(format!("@socket (root:root) {}", socket_path))
         .user(User(user))
         .hostname(machine)
         .build();


### PR DESCRIPTION
The PR fixes the TOCTOU introduced with the socket reading by checking the credentials of the peer process at the other side of the socket.

The directive is now:

```
@socket (user:group) /path/to/socket
```

These changes are introduced in the **second commit**. Tests and man pages are updated and a new unit test was added. Please see the commit message for more details.

The **first commit** makes remote sudoers 2e2 tests use the `unstable-remote-sudoers` feature that was previously introduced. [Edit: This commit was removed]

The **third commit** is an add-on to the second one. Because the second commit added an 8th parameter to the `include()` function, `cargo clippy` complains about having too many parameters. This commit is my proposition to fix this, but I'm not sure you agree with it. Basically it introduces a new `IncludeContext` structure where the parameters are stored and this context is passed as the second parameter (the first one being the configuration). If you agree with this solution, I will merge both commits into a single one as it is useless to have them separate.
[Edit: The third commit was merged into the second one]

Resolves: https://github.com/trifectatechfoundation/sudo-rs/issues/1549
