### PR TITLE
Fix bug where sudo-rs refuse to work in proot termux Android

### DIFF
--- a/src/sudo/mod.rs
+++ b/src/sudo/mod.rs
@@ -128,12 +128,12 @@ fn sudo_process() -> Result<(), Error> {
 }
 
 fn self_check() -> Result<(), Error> {
-    #[cfg(target_os = "linux")]
-    if crate::system::audit::no_new_privs_enabled()? {
-        return Err(Error::SelfCheckNoNewPrivs);
-    }
-
     if User::effective_uid() != UserId::ROOT {
+        #[cfg(target_os = "linux")]
+        if crate::system::audit::no_new_privs_enabled()? {
+            return Err(Error::SelfCheckNoNewPrivs);
+        }
+
         return Err(Error::SelfCheckSetuid);
     }
 


### PR DESCRIPTION
In Ubuntu 26.04 running on proot-distro on Termux on Android 14 Linux kernel 4.19 sudo-rs would say:
```
sudo: The "no new privileges" flag is set, which prevents sudo from running as root.
sudo: If sudo is running in a container, you may need to adjust the container configuration to disable the flag.
```
but sudo (the old one) would just run fine.
https://bugs.launchpad.net/bugs/2150695

This fix follows the logic of the old sudo to make it run on the said system.