### PR TITLE
Remove codecov/codecov-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -214,12 +214,7 @@ jobs:
         run: cargo build --workspace --all-targets --release
 
       - name: Run tests
-        run: cargo llvm-cov --workspace --all-targets --release --lcov --output-path lcov.info
-
-      - name: Upload code coverage
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        with:
-          files: lcov.info
+        run: cargo test --workspace --all-targets --release
 
   build-and-test-minimal:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We no longer measure code coverage in our CI; our testing framework is necessary for getting a proper code coverage measurement and it needs to run on a slightly modified sudo-rs source code for LLVM-related reasons. So there is no point in running codecov-action.

Supersedes #1575 