### PR TITLE
Use flexible array sizes for the results of getgrnam_r / getgrgid_r

### DIFF
--- a/src/cutils/mod.rs
+++ b/src/cutils/mod.rs
@@ -109,11 +109,38 @@ pub fn is_fifo_or_sock(fildes: BorrowedFd) -> bool {
     fstat_mode_any::<{ libc::S_IFIFO | libc::S_IFSOCK }>(&fildes)
 }
 
+/// Dynamically obtain the correct buffer size (within boundds)
+pub fn dynamic_fill<T: Default + Clone, E>(
+    range: std::ops::Range<usize>,
+    mut fill: impl FnMut(&mut [T]) -> Result<Option<usize>, E>,
+) -> Result<Option<Vec<T>>, E> {
+    let mut buffer = vec![T::default(); range.start];
+    loop {
+        match fill(&mut buffer)? {
+            Some(len) => {
+                buffer.resize_with(len, || {
+                    panic!("closure returned a buffer size that was larger than the input, this should not happen")
+                });
+
+                return Ok(Some(buffer));
+            }
+
+            None => {
+                if buffer.len() >= range.end {
+                    return Ok(None);
+                } else {
+                    buffer.resize_with(std::cmp::max(buffer.len() * 2, range.end), T::default)
+                }
+            }
+        }
+    }
+}
+
 #[allow(clippy::undocumented_unsafe_blocks)]
 #[cfg(test)]
 mod test {
 
-    use super::{os_string_from_ptr, string_from_ptr};
+    use super::{dynamic_fill, os_string_from_ptr, string_from_ptr};
 
     #[test]
     fn miri_test_str_to_ptr() {
@@ -143,5 +170,44 @@ mod test {
         let pty = Pty::open().unwrap();
         assert!(super::safe_isatty(pty.leader.as_fd()));
         assert!(super::safe_isatty(pty.follower.as_fd()));
+    }
+
+    #[test]
+    fn test_dynamic_fill() {
+        assert_eq!(
+            dynamic_fill(1..50, |buf: &mut [u8]| Ok::<_, ()>(
+                (buf.len() >= 23).then_some(23)
+            ))
+            .unwrap()
+            .unwrap()
+            .len(),
+            23
+        );
+
+        assert_eq!(
+            dynamic_fill(1..50, |buf: &mut [u8]| Ok::<_, ()>(
+                (buf.len() >= 50).then_some(23)
+            ))
+            .unwrap()
+            .unwrap()
+            .len(),
+            23
+        );
+
+        assert!(
+            dynamic_fill(1..50, |buf: &mut [u8]| Ok::<_, ()>(
+                (buf.len() > 50).then_some(23)
+            ))
+            .unwrap()
+            .is_none()
+        );
+
+        assert!(
+            dynamic_fill(1..50, |buf: &mut [u8]| {
+                assert!(buf.len() == 1);
+                Err(())
+            })
+            .is_err()
+        );
     }
 }

--- a/src/cutils/mod.rs
+++ b/src/cutils/mod.rs
@@ -129,7 +129,7 @@ pub fn dynamic_fill<T: Default + Copy, E>(
                 if buffer.len() >= range.end {
                     return Ok(None);
                 } else {
-                    buffer.resize_with(std::cmp::max(buffer.len() * 2, range.end), T::default)
+                    buffer.resize_with(std::cmp::min(buffer.len() * 2, range.end), T::default)
                 }
             }
         }
@@ -175,9 +175,10 @@ mod test {
     #[test]
     fn test_dynamic_fill() {
         assert_eq!(
-            dynamic_fill(1..50, |buf: &mut [u8]| Ok::<_, ()>(
+            dynamic_fill(1..50, |buf: &mut [u8]| Ok::<_, ()>({
+                assert!(buf.len() < 50);
                 (buf.len() >= 23).then_some(23)
-            ))
+            }))
             .unwrap()
             .unwrap()
             .len(),
@@ -185,9 +186,10 @@ mod test {
         );
 
         assert_eq!(
-            dynamic_fill(1..50, |buf: &mut [u8]| Ok::<_, ()>(
+            dynamic_fill(1..50, |buf: &mut [u8]| Ok::<_, ()>({
+                assert!(buf.len() <= 50);
                 (buf.len() >= 50).then_some(23)
-            ))
+            }))
             .unwrap()
             .unwrap()
             .len(),
@@ -195,9 +197,10 @@ mod test {
         );
 
         assert!(
-            dynamic_fill(1..50, |buf: &mut [u8]| Ok::<_, ()>(
-                (buf.len() > 50).then_some(23)
-            ))
+            dynamic_fill(1..50, |buf: &mut [u8]| Ok::<_, ()>({
+                assert!(buf.len() <= 50);
+                None
+            }))
             .unwrap()
             .is_none()
         );

--- a/src/cutils/mod.rs
+++ b/src/cutils/mod.rs
@@ -109,8 +109,8 @@ pub fn is_fifo_or_sock(fildes: BorrowedFd) -> bool {
     fstat_mode_any::<{ libc::S_IFIFO | libc::S_IFSOCK }>(&fildes)
 }
 
-/// Dynamically obtain the correct buffer size (within boundds)
-pub fn dynamic_fill<T: Default + Clone, E>(
+/// Dynamically obtain the correct buffer size (within bounds)
+pub fn dynamic_fill<T: Default + Copy, E>(
     range: std::ops::Range<usize>,
     mut fill: impl FnMut(&mut [T]) -> Result<Option<usize>, E>,
 ) -> Result<Option<Vec<T>>, E> {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -371,34 +371,33 @@ impl User {
     /// This function expects `pwd` to be a result from a successful call to `getpwXXX_r`.
     /// (It can cause UB if any of `pwd`'s pointed-to strings does not have a null-terminator.)
     unsafe fn from_libc(pwd: &libc::passwd) -> Result<User, Error> {
-        let mut buf_len: c_int = 32;
-        let mut groups_buffer: Vec<libc::gid_t>;
+        //NOTE: on Linux, getgrouplist could be used to simply inquire as to the size needed;
+        //but on FreeBSD, getgrouplist does not specify this in its function contract, so a
+        //blind allocation loop is needed.
+        let Some(groups_buffer) =
+            dynamic_fill::<libc::gid_t, std::num::TryFromIntError>(32..65536, |groups_buffer| {
+                let mut buf_len: c_int = groups_buffer.len() as c_int;
+                // SAFETY: getgrouplist is passed valid pointers
+                // in particular `groups_buffer` is an array of `buf.len()` bytes, as required
+                let result = cerr(unsafe {
+                    libc::getgrouplist(
+                        pwd.pw_name,
+                        pwd.pw_gid,
+                        groups_buffer.as_mut_ptr(),
+                        &mut buf_len,
+                    )
+                });
 
-        while {
-            groups_buffer = vec![0; buf_len as usize];
-            // SAFETY: getgrouplist is passed valid pointers
-            // in particular `groups_buffer` is an array of `buf.len()` bytes, as required
-            let result = unsafe {
-                libc::getgrouplist(
-                    pwd.pw_name,
-                    pwd.pw_gid,
-                    groups_buffer.as_mut_ptr(),
-                    &mut buf_len,
-                )
-            };
-
-            result == -1
-        } {
-            if buf_len >= 65536 {
-                panic!("user has too many groups (> 65536), this should not happen");
-            }
-
-            buf_len *= 2;
-        }
-
-        groups_buffer.resize_with(buf_len as usize, || {
-            panic!("invalid groups count returned from getgrouplist, this should not happen")
-        });
+                Ok(if result.is_ok() {
+                    Some(buf_len.try_into()?)
+                } else {
+                    None
+                })
+            })
+            .expect("negative group size, this should not happen")
+        else {
+            panic!("user has too many groups (> 65536), this should not happen");
+        };
 
         // SAFETY: All pointers were initialized by a successful call to `getpwXXX_r` as per the
         // safety invariant of this function.

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -527,20 +527,33 @@ impl Group {
 
     /// Lookup group for gid without returning an error when a /etc/group entry is missing.
     fn from_gid_unchecked(gid: GroupId) -> std::io::Result<Group> {
-        let max_gr_size = sysconf(libc::_SC_GETGR_R_SIZE_MAX).unwrap_or(16_384);
-        let mut buf = vec![0; max_gr_size as usize];
+        // Set an arbitrary upper limit of two terabytes/two gigabytes for the temporary buffer
+        let initial_gr_size = sysconf(libc::_SC_GETGR_R_SIZE_MAX).unwrap_or(16_384) as usize;
+        let max_gr_size = std::cmp::max(i32::MAX as usize, usize::MAX >> 24);
+
         let mut grp = MaybeUninit::uninit();
         let mut grp_ptr = std::ptr::null_mut();
-        // SAFETY: analogous to getpwuid_r above
-        cerr(unsafe {
-            libc::getgrgid_r(
-                gid.inner(),
-                grp.as_mut_ptr(),
-                buf.as_mut_ptr(),
-                buf.len(),
-                &mut grp_ptr,
-            )
-        })?;
+        let Some(_buf) = dynamic_fill(initial_gr_size..max_gr_size, |buf| {
+            // SAFETY: analogous to getpwuid_r above
+            let result = unsafe {
+                libc::getgrgid_r(
+                    gid.inner(),
+                    grp.as_mut_ptr(),
+                    buf.as_mut_ptr(),
+                    buf.len(),
+                    &mut grp_ptr,
+                )
+            };
+            match result {
+                0 => Ok(Some(buf.len())),
+                libc::ERANGE => Ok(None),
+                _ => Err(io::Error::from_raw_os_error(result)),
+            }
+        })?
+        else {
+            panic!("group buffer size exceeds limit (>{max_gr_size})");
+        };
+
         if grp_ptr.is_null() {
             Ok(Group { gid, name: None })
         } else {
@@ -563,20 +576,32 @@ impl Group {
     }
 
     pub fn from_name(name_c: &CStr) -> std::io::Result<Option<Group>> {
-        let max_gr_size = sysconf(libc::_SC_GETGR_R_SIZE_MAX).unwrap_or(16_384);
-        let mut buf = vec![0; max_gr_size as usize];
+        // Set an arbitrary upper limit of two terabytes/two gigabytes for the temporary buffer
+        let initial_gr_size = sysconf(libc::_SC_GETGR_R_SIZE_MAX).unwrap_or(16_384) as usize;
+        let max_gr_size = std::cmp::max(i32::MAX as usize, usize::MAX >> 24);
         let mut grp = MaybeUninit::uninit();
         let mut grp_ptr = std::ptr::null_mut();
-        // SAFETY: analogous to getpwuid_r above
-        cerr(unsafe {
-            libc::getgrnam_r(
-                name_c.as_ptr(),
-                grp.as_mut_ptr(),
-                buf.as_mut_ptr(),
-                buf.len(),
-                &mut grp_ptr,
-            )
-        })?;
+        let Some(_buf) = dynamic_fill(initial_gr_size..max_gr_size, |buf| {
+            // SAFETY: analogous to getpwuid_r above
+            let result = unsafe {
+                libc::getgrnam_r(
+                    name_c.as_ptr(),
+                    grp.as_mut_ptr(),
+                    buf.as_mut_ptr(),
+                    buf.len(),
+                    &mut grp_ptr,
+                )
+            };
+            match result {
+                0 => Ok(Some(buf.len())),
+                libc::ERANGE => Ok(None),
+                _ => Err(io::Error::from_raw_os_error(result)),
+            }
+        })?
+        else {
+            panic!("group buffer size exceeds limit (>{max_gr_size})");
+        };
+
         if grp_ptr.is_null() {
             Ok(None)
         } else {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -371,24 +371,24 @@ impl User {
     /// This function expects `pwd` to be a result from a successful call to `getpwXXX_r`.
     /// (It can cause UB if any of `pwd`'s pointed-to strings does not have a null-terminator.)
     unsafe fn from_libc(pwd: &libc::passwd) -> Result<User, Error> {
-        //NOTE: on Linux, getgrouplist could be used to simply inquire as to the size needed;
-        //but on FreeBSD, getgrouplist does not specify this in its function contract, so a
-        //blind allocation loop is needed.
+        // NOTE: on Linux, getgrouplist could be used to simply inquire as to the size needed;
+        // but on FreeBSD, getgrouplist does not specify this in its function contract, so a
+        // blind allocation loop is needed.
         let Some(groups_buffer) =
             dynamic_fill::<libc::gid_t, std::num::TryFromIntError>(32..65536, |groups_buffer| {
                 let mut buf_len: c_int = groups_buffer.len() as c_int;
                 // SAFETY: getgrouplist is passed valid pointers
                 // in particular `groups_buffer` is an array of `buf.len()` bytes, as required
-                let result = cerr(unsafe {
+                let result = unsafe {
                     libc::getgrouplist(
                         pwd.pw_name,
                         pwd.pw_gid,
                         groups_buffer.as_mut_ptr(),
                         &mut buf_len,
                     )
-                });
+                };
 
-                Ok(if result.is_ok() {
+                Ok(if result != -1 {
                     Some(buf_len.try_into()?)
                 } else {
                     None


### PR DESCRIPTION
This imposes an artificial upper limit. If this is breached, a `panic!` is forced.