### PR TITLE
pam: expose sudo prompt to PAM via SUDO_PROMPT env

### DIFF
--- a/src/pam/mod.rs
+++ b/src/pam/mod.rs
@@ -7,6 +7,7 @@ use std::{
     time::Duration,
 };
 
+use crate::log::dev_info;
 use crate::system::signal::{self, SignalSet};
 
 use converse::ConverserData;
@@ -33,6 +34,11 @@ const PAM_DATA_SILENT: std::ffi::c_int = 0;
 
 pub use converse::CLIConverser;
 
+#[inline]
+fn default_auth_prompt() -> &'static str {
+    xlat!("authenticate")
+}
+
 pub struct PamContext {
     data_ptr: *mut ConverserData<CLIConverser>,
     pamh: *mut pam_handle_t,
@@ -43,6 +49,8 @@ pub struct PamContext {
 }
 
 impl PamContext {
+    const SUDO_PROMPT_ENV: &'static str = "SUDO_PROMPT";
+
     /// Build the PamContext with the CLI conversation function.
     ///
     /// The target user is optional and may also be set after the context was
@@ -83,7 +91,7 @@ impl PamContext {
             converser,
             converser_name: converser_name.to_owned(),
             no_interact,
-            auth_prompt: Some(xlat!("authenticate").to_owned()),
+            auth_prompt: Some(default_auth_prompt().to_owned()),
             error: None,
             panicked: false,
         }));
@@ -150,11 +158,50 @@ impl PamContext {
         }
     }
 
+    fn put_env(&mut self, pam_env: &CStr) -> PamResult<()> {
+        // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`) and
+        // `pam_env` is a valid null-terminated string.
+        pam_err(unsafe { pam_putenv(self.pamh, pam_env.as_ptr()) })
+    }
+
+    fn clear_sudo_prompt(&mut self) -> PamResult<()> {
+        let prompt_name =
+            CString::new(Self::SUDO_PROMPT_ENV).expect("SUDO_PROMPT literal must not contain NUL");
+        self.put_env(&prompt_name)
+    }
+
+    fn set_sudo_prompt_for_auth(&mut self) {
+        // SAFETY: self.data_ptr was created by Box::into_raw
+        let auth_prompt = unsafe { (*self.data_ptr).auth_prompt.clone() };
+        let Some(auth_prompt) = auth_prompt else {
+            return;
+        };
+        if auth_prompt == default_auth_prompt() {
+            return;
+        }
+
+        let Ok(prompt_env) = CString::new(format!("{}={auth_prompt}", Self::SUDO_PROMPT_ENV))
+        else {
+            dev_info!("could not set SUDO_PROMPT in PAM env: prompt contains a null byte");
+            return;
+        };
+
+        if let Err(err) = self.put_env(&prompt_env) {
+            dev_info!("pam_putenv(SUDO_PROMPT=...) failed before auth: {}", err);
+        }
+    }
+
     /// Run authentication for the account
     pub fn authenticate(&mut self, for_user: &str) -> PamResult<()> {
         let mut flags = 0;
         flags |= self.silent_flag();
         flags |= self.disallow_null_auth_token_flag();
+
+        match self.clear_sudo_prompt() {
+            Ok(()) | Err(PamError::Pam(PamErrorType::BadItem)) => {}
+            Err(err) => return Err(err),
+        }
+        self.set_sudo_prompt_for_auth();
 
         // Temporarily mask SIGINT and SIGQUIT.
         let cur_signals = SignalSet::empty().and_then(|mut set| {
@@ -165,6 +212,10 @@ impl PamContext {
 
         // SAFETY: `self.pamh` contains a correct handle (obtained from `pam_start`)
         let auth_res = pam_err(unsafe { pam_authenticate(self.pamh, flags) });
+
+        if let Err(err) = self.clear_sudo_prompt() {
+            dev_info!("pam_putenv(SUDO_PROMPT) failed after auth: {}", err);
+        }
 
         // Restore signals
         if let Ok(set) = cur_signals {

--- a/src/pam/sys_linuxpam.rs
+++ b/src/pam/sys_linuxpam.rs
@@ -121,3 +121,9 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn pam_chauthtok(pamh: *mut pam_handle_t, flags: std::ffi::c_int) -> std::ffi::c_int;
 }
+unsafe extern "C" {
+    pub fn pam_putenv(
+        pamh: *mut pam_handle_t,
+        name_value: *const std::ffi::c_char,
+    ) -> std::ffi::c_int;
+}

--- a/src/pam/sys_linuxpam.rs
+++ b/src/pam/sys_linuxpam.rs
@@ -90,6 +90,12 @@ unsafe extern "C" {
     ) -> *const std::ffi::c_char;
 }
 unsafe extern "C" {
+    pub fn pam_putenv(
+        pamh: *mut pam_handle_t,
+        name_value: *const std::ffi::c_char,
+    ) -> std::ffi::c_int;
+}
+unsafe extern "C" {
     pub fn pam_getenvlist(pamh: *mut pam_handle_t) -> *mut *mut std::ffi::c_char;
 }
 unsafe extern "C" {
@@ -120,10 +126,4 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn pam_chauthtok(pamh: *mut pam_handle_t, flags: std::ffi::c_int) -> std::ffi::c_int;
-}
-unsafe extern "C" {
-    pub fn pam_putenv(
-        pamh: *mut pam_handle_t,
-        name_value: *const std::ffi::c_char,
-    ) -> std::ffi::c_int;
 }

--- a/src/pam/sys_openpam.rs
+++ b/src/pam/sys_openpam.rs
@@ -95,6 +95,12 @@ unsafe extern "C" {
     ) -> std::ffi::c_int;
 }
 unsafe extern "C" {
+    pub fn pam_putenv(
+        pamh: *mut pam_handle_t,
+        name_value: *const std::ffi::c_char,
+    ) -> std::ffi::c_int;
+}
+unsafe extern "C" {
     pub fn pam_getenvlist(_pamh: *mut pam_handle_t) -> *mut *mut std::ffi::c_char;
 }
 unsafe extern "C" {
@@ -123,10 +129,4 @@ unsafe extern "C" {
         _pamh: *const pam_handle_t,
         _error_number: std::ffi::c_int,
     ) -> *const std::ffi::c_char;
-}
-unsafe extern "C" {
-    pub fn pam_putenv(
-        _pamh: *mut pam_handle_t,
-        _name_value: *const std::ffi::c_char,
-    ) -> std::ffi::c_int;
 }

--- a/src/pam/sys_openpam.rs
+++ b/src/pam/sys_openpam.rs
@@ -124,3 +124,9 @@ unsafe extern "C" {
         _error_number: std::ffi::c_int,
     ) -> *const std::ffi::c_char;
 }
+unsafe extern "C" {
+    pub fn pam_putenv(
+        _pamh: *mut pam_handle_t,
+        _name_value: *const std::ffi::c_char,
+    ) -> std::ffi::c_int;
+}

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -1,10 +1,50 @@
 //! PAM integration tests
 
-use sudo_test::{Command, Env, User};
+use std::collections::HashMap;
+
+use sudo_test::{Command, Directory, Env, User};
 
 use crate::{PASSWORD, USERNAME};
 
 mod env;
+
+fn test_temp_paths(test_name: &str) -> (String, String, String) {
+    let base = std::env::temp_dir().join(format!("sudo-rs-pam-{test_name}-{}", std::process::id()));
+    let value = base.join("pam_env_value");
+    let log = base.join("repro.log");
+
+    (
+        base.to_string_lossy().into_owned(),
+        value.to_string_lossy().into_owned(),
+        log.to_string_lossy().into_owned(),
+    )
+}
+
+fn build_pam_capture_env(tmp_dir: &str, pam_env_value: &str) -> sudo_test::Env {
+    Env("ALL ALL=(ALL:ALL) ALL")
+        .user(USERNAME)
+        .directory(Directory(tmp_dir).chmod("777"))
+        .file(
+            "/etc/pam.d/sudo",
+            format!(
+                r#"auth optional pam_exec.so log={pam_env_value} /usr/bin/env
+auth sufficient pam_permit.so"#
+            ),
+        )
+        .build()
+}
+
+fn parse_pam_env(stdout: &str) -> HashMap<String, String> {
+    let mut pam_env = HashMap::new();
+
+    for line in stdout.lines() {
+        if let Some((key, value)) = line.split_once('=') {
+            pam_env.insert(key.to_string(), value.to_string());
+        }
+    }
+
+    pam_env
+}
 
 #[test]
 fn given_pam_permit_then_no_password_auth_required() {
@@ -101,4 +141,101 @@ fn sudo_dash_i_uses_correct_service_file() {
         .as_user(USERNAME)
         .output(&env)
         .assert_success();
+}
+
+#[test]
+#[cfg_attr(target_os = "freebsd", ignore = "pam_exec wiring differs on FreeBSD")]
+fn sudo_prompt_is_not_set_without_dash_p() {
+    if sudo_test::is_original_sudo() {
+        eprintln!(
+            "skipping: requires sudo behavior from https://github.com/sudo-project/sudo/pull/539"
+        );
+        // Remove this guard once https://github.com/sudo-project/sudo/pull/539 is merged.
+        return;
+    }
+
+    let (tmp_dir, pam_env_value, repro_log) = test_temp_paths("sudo-prompt-default");
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"sudo true >{repro_log} 2>&1
+cat {pam_env_value}"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let pam_env = parse_pam_env(&stdout);
+    assert!(
+        !pam_env.contains_key("SUDO_PROMPT"),
+        "SUDO_PROMPT must not be set when -p is not specified"
+    );
+}
+
+#[test]
+#[cfg_attr(target_os = "freebsd", ignore = "pam_exec wiring differs on FreeBSD")]
+fn sudo_prompt_is_not_set_when_dash_p_uses_default_value() {
+    if sudo_test::is_original_sudo() {
+        eprintln!(
+            "skipping: requires sudo behavior from https://github.com/sudo-project/sudo/pull/539"
+        );
+        // Remove this guard once https://github.com/sudo-project/sudo/pull/539 is merged.
+        return;
+    }
+
+    let (tmp_dir, pam_env_value, repro_log) = test_temp_paths("sudo-prompt-default-value");
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"LC_ALL=C LANG=C sudo -p 'authenticate' true >{repro_log} 2>&1
+cat {pam_env_value}"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let pam_env = parse_pam_env(&stdout);
+    assert!(
+        !pam_env.contains_key("SUDO_PROMPT"),
+        "SUDO_PROMPT must not be set when -p uses default prompt value"
+    );
+}
+
+#[test]
+#[cfg_attr(target_os = "freebsd", ignore = "pam_exec wiring differs on FreeBSD")]
+fn sudo_prompt_is_set_when_dash_p_is_specified() {
+    if sudo_test::is_original_sudo() {
+        eprintln!(
+            "skipping: requires sudo behavior from https://github.com/sudo-project/sudo/pull/539"
+        );
+        // Remove this guard once https://github.com/sudo-project/sudo/pull/539 is merged.
+        return;
+    }
+
+    let (tmp_dir, pam_env_value, repro_log) = test_temp_paths("sudo-prompt-custom");
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"sudo -p 'CUSTOM_PROMPT' true >{repro_log} 2>&1
+cat {pam_env_value}"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let pam_env = parse_pam_env(&stdout);
+    let actual = pam_env
+        .get("SUDO_PROMPT")
+        .map(String::as_str)
+        .unwrap_or_default();
+    assert_eq!("CUSTOM_PROMPT", actual, "SUDO_PROMPT should match -p value");
 }


### PR DESCRIPTION
Some PAM modules implementations do not use PAM conversations and
instead present their own native client UI when they have access to
the terminal.
In those cases, modules cannot infer sudo's custom prompt text from
the conversation callback path.

Set SUDO_PROMPT in the PAM environment before pam_authenticate(),
so modules that render their own UI can combine:
 - PAM service identity (from the PAM transaction)
 - sudo's resolved prompt string (SUDO_PROMPT)

to display a consistent, context-aware prompt.

To avoid stale state, clear SUDO_PROMPT before authentication starts
and clear it again after pam_authenticate() returns.

Allowing PAM modules in the stack to read (and potentially change)
SUDO_PROMPT does not introduce a new trust boundary concern:
PAM modules already control the conversation flow and can provide
their own prompt text/messages through the standard PAM conversation
mechanism.

This has been also proposed to regular sudo as https://github.com/sudo-project/sudo/pull/539

Closes: #1594