### PR TITLE
system/term: Improve resolution for setting a valid PAM_TTY

### DIFF
--- a/src/system/term/find_tty.rs
+++ b/src/system/term/find_tty.rs
@@ -19,6 +19,10 @@ pub(super) fn ttyname_from_dev() -> Option<OsString> {
         .or_else(|| find_tty_in_dir(Path::new("/dev"), tty_dev))
 }
 
+fn is_our_tty(metadata: fs::Metadata, tty_dev: libc::dev_t) -> bool {
+    metadata.file_type().is_char_device() && metadata.rdev() == tty_dev
+}
+
 fn ttyname_from_proc_self_fd(tty_dev: libc::dev_t) -> Option<OsString> {
     for fd in libc::STDIN_FILENO..=libc::STDERR_FILENO {
         let mut st = std::mem::MaybeUninit::<libc::stat>::uninit();
@@ -42,8 +46,8 @@ fn ttyname_from_proc_self_fd(tty_dev: libc::dev_t) -> Option<OsString> {
 fn dev_check(path: &Path, tty_dev: libc::dev_t) -> Option<OsString> {
     let metadata = fs::metadata(path).ok()?;
 
-    if metadata.file_type().is_char_device() && metadata.rdev() == tty_dev {
-        Some(path.as_os_str().to_os_string())
+    if is_our_tty(metadata, tty_dev) {
+        Some(path.into())
     } else {
         None
     }
@@ -52,8 +56,8 @@ fn dev_check(path: &Path, tty_dev: libc::dev_t) -> Option<OsString> {
 fn find_tty_in_dir(dir: &Path, tty_dev: libc::dev_t) -> Option<OsString> {
     for entry in fs::read_dir(dir).ok()?.flatten() {
         if let Ok(metadata) = entry.metadata() {
-            if metadata.file_type().is_char_device() && metadata.rdev() == tty_dev {
-                return Some(entry.path().into_os_string());
+            if is_our_tty(metadata, tty_dev) {
+                return Some(entry.path().into());
             }
         }
     }

--- a/src/system/term/find_tty.rs
+++ b/src/system/term/find_tty.rs
@@ -1,31 +1,32 @@
 use std::{
     ffi::OsString,
-    fs, io,
+    fs,
     os::unix::fs::{FileTypeExt, MetadataExt},
     path::{Path, PathBuf},
 };
 
 use crate::system::{Process, WithProcess};
 
-pub(super) fn ttyname_from_dev() -> io::Result<Option<OsString>> {
+pub(super) fn ttyname_from_dev() -> Option<OsString> {
     let Ok(Some(tty_dev)) = Process::tty_device_id(WithProcess::Current) else {
-        return Ok(None);
+        return None;
     };
 
     let tty_dev = tty_dev.inner();
-    if let Some(tty_name) = ttyname_from_proc_self_fd(tty_dev)? {
-        return Ok(Some(tty_name));
+    if let Some(tty_name) = ttyname_from_proc_self_fd(tty_dev) {
+        return Some(tty_name);
     }
-    if let Some(tty_name) = dev_check(Path::new("/dev/console"), tty_dev)? {
-        return Ok(Some(tty_name));
+    if let Some(tty_name) = dev_check(Path::new("/dev/console"), tty_dev) {
+        return Some(tty_name);
     }
-    if let Some(tty_name) = find_tty_in_dir(Path::new("/dev/pts"), tty_dev)? {
-        return Ok(Some(tty_name));
+    if let Some(tty_name) = find_tty_in_dir(Path::new("/dev/pts"), tty_dev) {
+        return Some(tty_name);
     }
+
     find_tty_in_dir(Path::new("/dev"), tty_dev)
 }
 
-fn ttyname_from_proc_self_fd(tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
+fn ttyname_from_proc_self_fd(tty_dev: libc::dev_t) -> Option<OsString> {
     for fd in libc::STDIN_FILENO..=libc::STDERR_FILENO {
         let mut st = std::mem::MaybeUninit::<libc::stat>::uninit();
         // SAFETY: `st` points to uninitialized memory for libc to write the stat struct.
@@ -39,32 +40,24 @@ fn ttyname_from_proc_self_fd(tty_dev: libc::dev_t) -> io::Result<Option<OsString
         }
         let link = PathBuf::from(format!("/proc/self/fd/{fd}"));
         if let Ok(path) = fs::read_link(link) {
-            return Ok(Some(path.into_os_string()));
+            return Some(path.into_os_string());
         }
     }
-    Ok(None)
+    None
 }
 
-fn dev_check(path: &Path, tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
-    let metadata = match fs::metadata(path) {
-        Ok(metadata) => metadata,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => return Err(err),
-    };
+fn dev_check(path: &Path, tty_dev: libc::dev_t) -> Option<OsString> {
+    let metadata = fs::metadata(path).ok()?;
+
     if metadata.file_type().is_char_device() && metadata.rdev() == tty_dev {
-        return Ok(Some(path.as_os_str().to_os_string()));
+        Some(path.as_os_str().to_os_string())
+    } else {
+        None
     }
-    Ok(None)
 }
 
-fn find_tty_in_dir(dir: &Path, tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
-    let entries = match fs::read_dir(dir) {
-        Ok(entries) => entries,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => return Err(err),
-    };
-
-    for entry in entries {
+fn find_tty_in_dir(dir: &Path, tty_dev: libc::dev_t) -> Option<OsString> {
+    for entry in fs::read_dir(dir).ok()? {
         let entry = match entry {
             Ok(entry) => entry,
             Err(_) => continue,
@@ -74,9 +67,9 @@ fn find_tty_in_dir(dir: &Path, tty_dev: libc::dev_t) -> io::Result<Option<OsStri
             Err(_) => continue,
         };
         if metadata.file_type().is_char_device() && metadata.rdev() == tty_dev {
-            return Ok(Some(entry.path().into_os_string()));
+            return Some(entry.path().into_os_string());
         }
     }
 
-    Ok(None)
+    None
 }

--- a/src/system/term/find_tty.rs
+++ b/src/system/term/find_tty.rs
@@ -5,14 +5,12 @@ use std::{
     path::Path,
 };
 
-use crate::system::{Process, WithProcess, term::Terminal};
+use crate::system::{DeviceId, Process, WithProcess, term::Terminal};
 
 pub(super) fn ttyname_from_dev() -> io::Result<Option<OsString>> {
     let Ok(Some(tty_dev)) = Process::tty_device_id(WithProcess::Current) else {
         return Ok(None);
     };
-
-    let tty_dev = tty_dev.inner();
 
     let tty_name = dev_check(Path::new("/dev/console"), tty_dev)
         .or_else(|| ttyname_from_stdioe(tty_dev))
@@ -26,11 +24,11 @@ pub(super) fn ttyname_from_dev() -> io::Result<Option<OsString>> {
     }
 }
 
-fn is_our_tty(metadata: fs::Metadata, tty_dev: libc::dev_t) -> bool {
-    metadata.file_type().is_char_device() && metadata.rdev() == tty_dev
+fn is_our_tty(metadata: fs::Metadata, tty_dev: DeviceId) -> bool {
+    metadata.file_type().is_char_device() && metadata.rdev() == tty_dev.inner()
 }
 
-fn ttyname_from_stdioe(tty_dev: libc::dev_t) -> Option<OsString> {
+fn ttyname_from_stdioe(tty_dev: DeviceId) -> Option<OsString> {
     [
         io::stdin().ttyname(),
         io::stdout().ttyname(),
@@ -41,18 +39,14 @@ fn ttyname_from_stdioe(tty_dev: libc::dev_t) -> Option<OsString> {
     .find_map(|ttyname| dev_check(ttyname.as_ref(), tty_dev))
 }
 
-fn dev_check(path: &Path, tty_dev: libc::dev_t) -> Option<OsString> {
+fn dev_check(path: &Path, tty_dev: DeviceId) -> Option<OsString> {
     let metadata = fs::metadata(path).ok()?;
 
-    if is_our_tty(metadata, tty_dev) {
-        Some(path.into())
-    } else {
-        None
-    }
+    is_our_tty(metadata, tty_dev).then(|| path.into())
 }
 
-fn find_tty_in_dir(dir: &Path, tty_dev: libc::dev_t) -> Option<OsString> {
-    for entry in fs::read_dir(dir).ok()?.flatten() {
+fn find_tty_in_dir(dir: &Path, tty_dev: DeviceId) -> Option<OsString> {
+    for entry in fs::read_dir(dir).ok()?.filter_map(|entry| entry.ok()) {
         if let Ok(metadata) = entry.metadata() {
             if is_our_tty(metadata, tty_dev) {
                 return Some(entry.path().into());

--- a/src/system/term/find_tty.rs
+++ b/src/system/term/find_tty.rs
@@ -8,22 +8,15 @@ use std::{
 use crate::system::{Process, WithProcess};
 
 pub(super) fn ttyname_from_dev() -> Option<OsString> {
-    let Ok(Some(tty_dev)) = Process::tty_device_id(WithProcess::Current) else {
-        return None;
-    };
+    let tty_dev = Process::tty_device_id(WithProcess::Current)
+        .ok()
+        .flatten()?
+        .inner();
 
-    let tty_dev = tty_dev.inner();
-    if let Some(tty_name) = ttyname_from_proc_self_fd(tty_dev) {
-        return Some(tty_name);
-    }
-    if let Some(tty_name) = dev_check(Path::new("/dev/console"), tty_dev) {
-        return Some(tty_name);
-    }
-    if let Some(tty_name) = find_tty_in_dir(Path::new("/dev/pts"), tty_dev) {
-        return Some(tty_name);
-    }
-
-    find_tty_in_dir(Path::new("/dev"), tty_dev)
+    dev_check(Path::new("/dev/console"), tty_dev)
+        .or_else(|| ttyname_from_proc_self_fd(tty_dev))
+        .or_else(|| find_tty_in_dir(Path::new("/dev/pts"), tty_dev))
+        .or_else(|| find_tty_in_dir(Path::new("/dev"), tty_dev))
 }
 
 fn ttyname_from_proc_self_fd(tty_dev: libc::dev_t) -> Option<OsString> {
@@ -57,17 +50,11 @@ fn dev_check(path: &Path, tty_dev: libc::dev_t) -> Option<OsString> {
 }
 
 fn find_tty_in_dir(dir: &Path, tty_dev: libc::dev_t) -> Option<OsString> {
-    for entry in fs::read_dir(dir).ok()? {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(_) => continue,
-        };
-        let metadata = match entry.metadata() {
-            Ok(metadata) => metadata,
-            Err(_) => continue,
-        };
-        if metadata.file_type().is_char_device() && metadata.rdev() == tty_dev {
-            return Some(entry.path().into_os_string());
+    for entry in fs::read_dir(dir).ok()?.flatten() {
+        if let Ok(metadata) = entry.metadata() {
+            if metadata.file_type().is_char_device() && metadata.rdev() == tty_dev {
+                return Some(entry.path().into_os_string());
+            }
         }
     }
 

--- a/src/system/term/find_tty.rs
+++ b/src/system/term/find_tty.rs
@@ -1,0 +1,82 @@
+use std::{
+    ffi::OsString,
+    fs, io,
+    os::unix::fs::{FileTypeExt, MetadataExt},
+    path::{Path, PathBuf},
+};
+
+use crate::system::{Process, WithProcess};
+
+pub(super) fn ttyname_from_dev() -> io::Result<Option<OsString>> {
+    let Ok(Some(tty_dev)) = Process::tty_device_id(WithProcess::Current) else {
+        return Ok(None);
+    };
+
+    let tty_dev = tty_dev.inner();
+    if let Some(tty_name) = ttyname_from_proc_self_fd(tty_dev)? {
+        return Ok(Some(tty_name));
+    }
+    if let Some(tty_name) = dev_check(Path::new("/dev/console"), tty_dev)? {
+        return Ok(Some(tty_name));
+    }
+    if let Some(tty_name) = find_tty_in_dir(Path::new("/dev/pts"), tty_dev)? {
+        return Ok(Some(tty_name));
+    }
+    find_tty_in_dir(Path::new("/dev"), tty_dev)
+}
+
+fn ttyname_from_proc_self_fd(tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
+    for fd in libc::STDIN_FILENO..=libc::STDERR_FILENO {
+        let mut st = std::mem::MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: `st` points to uninitialized memory for libc to write the stat struct.
+        if unsafe { libc::fstat(fd, st.as_mut_ptr()) } != 0 {
+            continue;
+        }
+        // SAFETY: fstat() succeeded.
+        let st = unsafe { st.assume_init() };
+        if (st.st_mode & libc::S_IFMT) != libc::S_IFCHR || st.st_rdev != tty_dev {
+            continue;
+        }
+        let link = PathBuf::from(format!("/proc/self/fd/{fd}"));
+        if let Ok(path) = fs::read_link(link) {
+            return Ok(Some(path.into_os_string()));
+        }
+    }
+    Ok(None)
+}
+
+fn dev_check(path: &Path, tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    if metadata.file_type().is_char_device() && metadata.rdev() == tty_dev {
+        return Ok(Some(path.as_os_str().to_os_string()));
+    }
+    Ok(None)
+}
+
+fn find_tty_in_dir(dir: &Path, tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        let metadata = match entry.metadata() {
+            Ok(metadata) => metadata,
+            Err(_) => continue,
+        };
+        if metadata.file_type().is_char_device() && metadata.rdev() == tty_dev {
+            return Ok(Some(entry.path().into_os_string()));
+        }
+    }
+
+    Ok(None)
+}

--- a/src/system/term/find_tty.rs
+++ b/src/system/term/find_tty.rs
@@ -7,16 +7,23 @@ use std::{
 
 use crate::system::{Process, WithProcess, term::Terminal};
 
-pub(super) fn ttyname_from_dev() -> Option<OsString> {
-    let tty_dev = Process::tty_device_id(WithProcess::Current)
-        .ok()
-        .flatten()?
-        .inner();
+pub(super) fn ttyname_from_dev() -> io::Result<Option<OsString>> {
+    let Ok(Some(tty_dev)) = Process::tty_device_id(WithProcess::Current) else {
+        return Ok(None);
+    };
 
-    dev_check(Path::new("/dev/console"), tty_dev)
+    let tty_dev = tty_dev.inner();
+
+    let tty_name = dev_check(Path::new("/dev/console"), tty_dev)
         .or_else(|| ttyname_from_stdioe(tty_dev))
         .or_else(|| find_tty_in_dir(Path::new("/dev/pts"), tty_dev))
-        .or_else(|| find_tty_in_dir(Path::new("/dev"), tty_dev))
+        .or_else(|| find_tty_in_dir(Path::new("/dev"), tty_dev));
+
+    if tty_name.is_some() {
+        Ok(tty_name)
+    } else {
+        Err(io::ErrorKind::NotFound.into())
+    }
 }
 
 fn is_our_tty(metadata: fs::Metadata, tty_dev: libc::dev_t) -> bool {

--- a/src/system/term/find_tty.rs
+++ b/src/system/term/find_tty.rs
@@ -1,11 +1,11 @@
 use std::{
     ffi::OsString,
-    fs,
+    fs, io,
     os::unix::fs::{FileTypeExt, MetadataExt},
-    path::{Path, PathBuf},
+    path::Path,
 };
 
-use crate::system::{Process, WithProcess};
+use crate::system::{Process, WithProcess, term::Terminal};
 
 pub(super) fn ttyname_from_dev() -> Option<OsString> {
     let tty_dev = Process::tty_device_id(WithProcess::Current)
@@ -14,7 +14,7 @@ pub(super) fn ttyname_from_dev() -> Option<OsString> {
         .inner();
 
     dev_check(Path::new("/dev/console"), tty_dev)
-        .or_else(|| ttyname_from_proc_self_fd(tty_dev))
+        .or_else(|| ttyname_from_stdioe(tty_dev))
         .or_else(|| find_tty_in_dir(Path::new("/dev/pts"), tty_dev))
         .or_else(|| find_tty_in_dir(Path::new("/dev"), tty_dev))
 }
@@ -23,24 +23,15 @@ fn is_our_tty(metadata: fs::Metadata, tty_dev: libc::dev_t) -> bool {
     metadata.file_type().is_char_device() && metadata.rdev() == tty_dev
 }
 
-fn ttyname_from_proc_self_fd(tty_dev: libc::dev_t) -> Option<OsString> {
-    for fd in libc::STDIN_FILENO..=libc::STDERR_FILENO {
-        let mut st = std::mem::MaybeUninit::<libc::stat>::uninit();
-        // SAFETY: `st` points to uninitialized memory for libc to write the stat struct.
-        if unsafe { libc::fstat(fd, st.as_mut_ptr()) } != 0 {
-            continue;
-        }
-        // SAFETY: fstat() succeeded.
-        let st = unsafe { st.assume_init() };
-        if (st.st_mode & libc::S_IFMT) != libc::S_IFCHR || st.st_rdev != tty_dev {
-            continue;
-        }
-        let link = PathBuf::from(format!("/proc/self/fd/{fd}"));
-        if let Ok(path) = fs::read_link(link) {
-            return Some(path.into_os_string());
-        }
-    }
-    None
+fn ttyname_from_stdioe(tty_dev: libc::dev_t) -> Option<OsString> {
+    [
+        io::stdin().ttyname(),
+        io::stdout().ttyname(),
+        io::stderr().ttyname(),
+    ]
+    .iter()
+    .flatten()
+    .find_map(|ttyname| dev_check(ttyname.as_ref(), tty_dev))
 }
 
 fn dev_check(path: &Path, tty_dev: libc::dev_t) -> Option<OsString> {

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -15,7 +15,6 @@ use crate::cutils::{cerr, is_fifo_or_sock, os_string_from_ptr, safe_isatty};
 
 use super::interface::ProcessId;
 
-#[cfg(target_os = "linux")]
 mod find_tty;
 
 pub(crate) use user_term::UserTerm;
@@ -257,7 +256,6 @@ impl<F: AsFd> Terminal for F {
 
 /// Try to get the path of the current TTY
 pub fn current_tty_name() -> io::Result<OsString> {
-    #[cfg(target_os = "linux")]
     if let Some(tty) = find_tty::ttyname_from_dev()? {
         return Ok(tty);
     }

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -258,8 +258,8 @@ impl<F: AsFd> Terminal for F {
 /// Try to get the path of the current TTY
 pub fn current_tty_name() -> io::Result<OsString> {
     #[cfg(target_os = "linux")]
-    if let Some(tty_name) = find_tty::ttyname_from_dev() {
-        return Ok(tty_name);
+    if let Some(tty) = find_tty::ttyname_from_dev()? {
+        return Ok(tty);
     }
 
     io::stdin()

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -254,7 +254,19 @@ impl<F: AsFd> Terminal for F {
 
 /// Try to get the path of the current TTY
 pub fn current_tty_name() -> io::Result<OsString> {
-    std::io::stdin().ttyname()
+    if let Some(tty_name) = [
+        std::io::stdin().ttyname(),
+        std::io::stdout().ttyname(),
+        std::io::stderr().ttyname(),
+    ]
+    .into_iter()
+    .flatten()
+    .next()
+    {
+        return Ok(tty_name);
+    }
+
+    Err(io::ErrorKind::Unsupported.into())
 }
 
 #[repr(transparent)]

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -269,19 +269,10 @@ pub fn current_tty_name() -> io::Result<OsString> {
         }
     }
 
-    if let Some(tty_name) = [
-        std::io::stdin().ttyname(),
-        std::io::stdout().ttyname(),
-        std::io::stderr().ttyname(),
-    ]
-    .into_iter()
-    .flatten()
-    .next()
-    {
-        return Ok(tty_name);
-    }
-
-    Err(io::ErrorKind::Unsupported.into())
+    io::stdin()
+        .ttyname()
+        .or_else(|_| io::stdout().ttyname())
+        .or_else(|_| io::stderr().ttyname())
 }
 
 #[cfg(target_os = "linux")]

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -258,7 +258,7 @@ impl<F: AsFd> Terminal for F {
 /// Try to get the path of the current TTY
 pub fn current_tty_name() -> io::Result<OsString> {
     #[cfg(target_os = "linux")]
-    if let Ok(Some(tty_name)) = find_tty::ttyname_from_dev() {
+    if let Some(tty_name) = find_tty::ttyname_from_dev() {
         return Ok(tty_name);
     }
 

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -8,20 +8,15 @@ use std::{
     os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd},
     ptr::null_mut,
 };
-#[cfg(target_os = "linux")]
-use std::{
-    fs,
-    os::unix::fs::{FileTypeExt, MetadataExt},
-    path::{Path, PathBuf},
-};
 
 use libc::{TIOCSWINSZ, ioctl, winsize};
 
 use crate::cutils::{cerr, is_fifo_or_sock, os_string_from_ptr, safe_isatty};
 
 use super::interface::ProcessId;
+
 #[cfg(target_os = "linux")]
-use super::{Process, WithProcess};
+mod find_tty;
 
 pub(crate) use user_term::UserTerm;
 
@@ -263,89 +258,14 @@ impl<F: AsFd> Terminal for F {
 /// Try to get the path of the current TTY
 pub fn current_tty_name() -> io::Result<OsString> {
     #[cfg(target_os = "linux")]
-    if let Ok(Some(tty_dev)) = Process::tty_device_id(WithProcess::Current) {
-        if let Ok(Some(tty_name)) = ttyname_from_dev_linux(tty_dev.inner()) {
-            return Ok(tty_name);
-        }
+    if let Ok(Some(tty_name)) = find_tty::ttyname_from_dev() {
+        return Ok(tty_name);
     }
 
     io::stdin()
         .ttyname()
         .or_else(|_| io::stdout().ttyname())
         .or_else(|_| io::stderr().ttyname())
-}
-
-#[cfg(target_os = "linux")]
-fn ttyname_from_dev_linux(tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
-    if let Some(tty_name) = ttyname_from_proc_self_fd(tty_dev)? {
-        return Ok(Some(tty_name));
-    }
-    if let Some(tty_name) = dev_check(Path::new("/dev/console"), tty_dev)? {
-        return Ok(Some(tty_name));
-    }
-    if let Some(tty_name) = find_tty_in_dir(Path::new("/dev/pts"), tty_dev)? {
-        return Ok(Some(tty_name));
-    }
-    find_tty_in_dir(Path::new("/dev"), tty_dev)
-}
-
-#[cfg(target_os = "linux")]
-fn ttyname_from_proc_self_fd(tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
-    for fd in libc::STDIN_FILENO..=libc::STDERR_FILENO {
-        let mut st = std::mem::MaybeUninit::<libc::stat>::uninit();
-        // SAFETY: `st` points to uninitialized memory for libc to write the stat struct.
-        if unsafe { libc::fstat(fd, st.as_mut_ptr()) } != 0 {
-            continue;
-        }
-        // SAFETY: fstat() succeeded.
-        let st = unsafe { st.assume_init() };
-        if (st.st_mode & libc::S_IFMT) != libc::S_IFCHR || st.st_rdev != tty_dev {
-            continue;
-        }
-        let link = PathBuf::from(format!("/proc/self/fd/{fd}"));
-        if let Ok(path) = fs::read_link(link) {
-            return Ok(Some(path.into_os_string()));
-        }
-    }
-    Ok(None)
-}
-
-#[cfg(target_os = "linux")]
-fn dev_check(path: &Path, tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
-    let metadata = match fs::metadata(path) {
-        Ok(metadata) => metadata,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => return Err(err),
-    };
-    if metadata.file_type().is_char_device() && metadata.rdev() == tty_dev {
-        return Ok(Some(path.as_os_str().to_os_string()));
-    }
-    Ok(None)
-}
-
-#[cfg(target_os = "linux")]
-fn find_tty_in_dir(dir: &Path, tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
-    let entries = match fs::read_dir(dir) {
-        Ok(entries) => entries,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => return Err(err),
-    };
-
-    for entry in entries {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(_) => continue,
-        };
-        let metadata = match entry.metadata() {
-            Ok(metadata) => metadata,
-            Err(_) => continue,
-        };
-        if metadata.file_type().is_char_device() && metadata.rdev() == tty_dev {
-            return Ok(Some(entry.path().into_os_string()));
-        }
-    }
-
-    Ok(None)
 }
 
 #[repr(transparent)]

--- a/src/system/term/mod.rs
+++ b/src/system/term/mod.rs
@@ -8,12 +8,20 @@ use std::{
     os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd},
     ptr::null_mut,
 };
+#[cfg(target_os = "linux")]
+use std::{
+    fs,
+    os::unix::fs::{FileTypeExt, MetadataExt},
+    path::{Path, PathBuf},
+};
 
 use libc::{TIOCSWINSZ, ioctl, winsize};
 
 use crate::cutils::{cerr, is_fifo_or_sock, os_string_from_ptr, safe_isatty};
 
 use super::interface::ProcessId;
+#[cfg(target_os = "linux")]
+use super::{Process, WithProcess};
 
 pub(crate) use user_term::UserTerm;
 
@@ -254,6 +262,13 @@ impl<F: AsFd> Terminal for F {
 
 /// Try to get the path of the current TTY
 pub fn current_tty_name() -> io::Result<OsString> {
+    #[cfg(target_os = "linux")]
+    if let Ok(Some(tty_dev)) = Process::tty_device_id(WithProcess::Current) {
+        if let Ok(Some(tty_name)) = ttyname_from_dev_linux(tty_dev.inner()) {
+            return Ok(tty_name);
+        }
+    }
+
     if let Some(tty_name) = [
         std::io::stdin().ttyname(),
         std::io::stdout().ttyname(),
@@ -267,6 +282,79 @@ pub fn current_tty_name() -> io::Result<OsString> {
     }
 
     Err(io::ErrorKind::Unsupported.into())
+}
+
+#[cfg(target_os = "linux")]
+fn ttyname_from_dev_linux(tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
+    if let Some(tty_name) = ttyname_from_proc_self_fd(tty_dev)? {
+        return Ok(Some(tty_name));
+    }
+    if let Some(tty_name) = dev_check(Path::new("/dev/console"), tty_dev)? {
+        return Ok(Some(tty_name));
+    }
+    if let Some(tty_name) = find_tty_in_dir(Path::new("/dev/pts"), tty_dev)? {
+        return Ok(Some(tty_name));
+    }
+    find_tty_in_dir(Path::new("/dev"), tty_dev)
+}
+
+#[cfg(target_os = "linux")]
+fn ttyname_from_proc_self_fd(tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
+    for fd in libc::STDIN_FILENO..=libc::STDERR_FILENO {
+        let mut st = std::mem::MaybeUninit::<libc::stat>::uninit();
+        // SAFETY: `st` points to uninitialized memory for libc to write the stat struct.
+        if unsafe { libc::fstat(fd, st.as_mut_ptr()) } != 0 {
+            continue;
+        }
+        // SAFETY: fstat() succeeded.
+        let st = unsafe { st.assume_init() };
+        if (st.st_mode & libc::S_IFMT) != libc::S_IFCHR || st.st_rdev != tty_dev {
+            continue;
+        }
+        let link = PathBuf::from(format!("/proc/self/fd/{fd}"));
+        if let Ok(path) = fs::read_link(link) {
+            return Ok(Some(path.into_os_string()));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(target_os = "linux")]
+fn dev_check(path: &Path, tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    if metadata.file_type().is_char_device() && metadata.rdev() == tty_dev {
+        return Ok(Some(path.as_os_str().to_os_string()));
+    }
+    Ok(None)
+}
+
+#[cfg(target_os = "linux")]
+fn find_tty_in_dir(dir: &Path, tty_dev: libc::dev_t) -> io::Result<Option<OsString>> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        let metadata = match entry.metadata() {
+            Ok(metadata) => metadata,
+            Err(_) => continue,
+        };
+        if metadata.file_type().is_char_device() && metadata.rdev() == tty_dev {
+            return Ok(Some(entry.path().into_os_string()));
+        }
+    }
+
+    Ok(None)
 }
 
 #[repr(transparent)]

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -16,9 +16,16 @@ fn build_pam_capture_env() -> sudo_test::Env {
     Env("ALL ALL=(ALL:ALL) ALL")
         .user(USERNAME)
         .file(
+            "/tmp/env",
+            r#"#! /bin/sh
+umask a+r
+/usr/bin/env > "$1"
+"#,
+        )
+        .file(
             "/etc/pam.d/sudo",
             format!(
-                r#"auth optional pam_exec.so log={PAM_ENV_VALUE} /usr/bin/env
+                r#"auth optional pam_exec.so /bin/sh /tmp/env {PAM_ENV_VALUE}
 auth sufficient pam_permit.so"#
             ),
         )

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -1,11 +1,86 @@
 //! PAM integration tests
 
-use sudo_test::{Command, Env, User};
+use std::collections::HashMap;
+
+use sudo_test::{Command, Directory, Env, User};
 
 use crate::{PASSWORD, USERNAME};
 
 #[cfg(target_os = "linux")]
 mod env;
+
+const TEST_ENV_EXPECTED_TTY: &str = "SUDO_RS_TEST_ENV_EXPECTED_TTY";
+
+fn test_temp_paths(test_name: &str) -> (String, String) {
+    let base = std::env::temp_dir().join(format!("sudo-rs-pam-{test_name}"));
+    let value = base.join("pam_env_value");
+
+    (
+        base.to_string_lossy().into_owned(),
+        value.to_string_lossy().into_owned(),
+    )
+}
+
+fn build_pam_capture_env(tmp_dir: &str, pam_env_value: &str) -> sudo_test::Env {
+    Env("ALL ALL=(ALL:ALL) ALL")
+        .user(USERNAME)
+        .directory(Directory(tmp_dir).chmod("777"))
+        .file(
+            "/etc/pam.d/sudo",
+            format!(
+                r#"auth optional pam_exec.so log={pam_env_value} /usr/bin/env
+auth sufficient pam_permit.so"#
+            ),
+        )
+        .build()
+}
+
+fn parse_pam_env(stdout: &str) -> HashMap<String, String> {
+    let mut pam_env = HashMap::new();
+
+    for line in stdout.lines() {
+        if let Some((key, value)) = line.split_once('=') {
+            pam_env.insert(key.to_string(), value.to_string());
+        }
+    }
+
+    pam_env
+}
+
+fn assert_pam_tty_is_valid(actual: &str) {
+    assert!(!actual.is_empty(), "PAM_TTY must not be empty");
+    assert_ne!(actual, "/dev/null", "PAM_TTY must not be /dev/null");
+    assert!(
+        actual.starts_with("/dev/"),
+        "PAM_TTY must be a /dev path, got: {actual}"
+    );
+}
+
+fn assert_pam_tty_matches_expected(expected: &str, pam_env: &HashMap<String, String>) {
+    let actual = pam_env
+        .get("PAM_TTY")
+        .map(String::as_str)
+        .unwrap_or_default();
+
+    if expected.is_empty() {
+        assert!(
+            actual.is_empty(),
+            "PAM_TTY should be empty when command has no tty"
+        );
+        return;
+    }
+
+    assert_pam_tty_is_valid(actual);
+    assert_eq!(expected, actual, "PAM_TTY should match controlling TTY");
+}
+
+fn parse_expected_tty_and_pam_env(stdout: &str) -> (String, HashMap<String, String>) {
+    let mut env = parse_pam_env(stdout);
+    let expected = env
+        .remove(TEST_ENV_EXPECTED_TTY)
+        .expect("expected tty value not found");
+    (expected, env)
+}
 
 #[test]
 fn given_pam_permit_then_no_password_auth_required() {
@@ -102,4 +177,150 @@ fn sudo_dash_i_uses_correct_service_file() {
         .as_user(USERNAME)
         .output(&env)
         .assert_success();
+}
+
+#[test]
+fn pam_tty_with_stdout_redirect_uses_stdin_tty() {
+    let (tmp_dir, pam_env_value) = test_temp_paths("stdout-not-a-tty");
+
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"exec 3>&1
+expected_tty=$(tty <&3)
+exec >/dev/null
+sudo true
+printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
+cat {pam_env_value} >&3"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
+    assert_pam_tty_matches_expected(&expected, &pam_env);
+}
+
+#[test]
+fn pam_tty_with_stderr_redirect_uses_stdin_tty() {
+    let (tmp_dir, pam_env_value) = test_temp_paths("stderr-not-a-tty");
+
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"exec 3>&1
+expected_tty=$(tty <&3)
+sudo true 2>/dev/null
+printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
+cat {pam_env_value} >&3"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
+    assert_pam_tty_matches_expected(&expected, &pam_env);
+}
+
+#[test]
+fn pam_tty_with_stdout_and_stderr_redirect_uses_stdin_tty() {
+    let (tmp_dir, pam_env_value) = test_temp_paths("stdout-and-stderr-not-ttys");
+
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"exec 3>&1
+expected_tty=$(tty <&3)
+sudo true >/dev/null 2>&1
+printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
+cat {pam_env_value} >&3"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
+    assert_pam_tty_matches_expected(&expected, &pam_env);
+}
+
+#[test]
+fn pam_tty_is_set_when_stdin_is_closed_even_if_stdout_stderr_are_ttys() {
+    let (tmp_dir, pam_env_value) = test_temp_paths("stdin-closed-stdout-stderr-ttys");
+
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"exec 3>&1
+expected_tty=$(tty <&3)
+exec 0<&-
+sudo true
+printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
+cat {pam_env_value} >&3"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
+    assert_pam_tty_matches_expected(&expected, &pam_env);
+}
+
+#[test]
+fn pam_tty_is_set_when_stdin_is_devnull_even_if_stdout_stderr_are_ttys() {
+    let (tmp_dir, pam_env_value) = test_temp_paths("stdin-devnull-stdout-stderr-ttys");
+
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"exec 3>&1
+expected_tty=$(tty <&3)
+exec </dev/null
+sudo true
+printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
+cat {pam_env_value} >&3"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
+    assert_pam_tty_matches_expected(&expected, &pam_env);
+}
+
+#[test]
+fn pam_tty_is_not_pts_when_command_has_no_tty() {
+    let (tmp_dir, pam_env_value) = test_temp_paths("no-tty");
+
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"expected_tty=$(tty -s || echo '')
+sudo true
+printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty"
+cat {pam_env_value}"#
+        ))
+        .as_user(USERNAME)
+        .output(&env)
+        .stdout();
+
+    println!("stdout: {stdout}");
+    let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
+    assert_pam_tty_matches_expected(&expected, &pam_env);
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -181,7 +181,7 @@ fn sudo_dash_i_uses_correct_service_file() {
 
 #[test]
 fn pam_tty_is_set_when_stdio_fds_are_not_ttys() {
-    let (tmp_dir, pam_env_value, repro_log) = test_temp_paths("stdio-fds-not-ttys");
+    let (tmp_dir, pam_env_value) = test_temp_paths("stdio-fds-not-ttys");
 
     let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
 
@@ -190,7 +190,7 @@ fn pam_tty_is_set_when_stdio_fds_are_not_ttys() {
         .arg(format!(
             r#"exec 3>&1
 expected_tty=$(tty <&3)
-exec </dev/null >{repro_log} 2>&1
+exec </dev/null >/dev/null 2>&1
 sudo true
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
 cat {pam_env_value} >&3"#
@@ -279,7 +279,7 @@ cat {pam_env_value} >&3"#
 
 #[test]
 fn pam_tty_is_set_when_stdin_is_closed_and_stdio_fds_are_not_ttys() {
-    let (tmp_dir, pam_env_value, repro_log) = test_temp_paths("stdin-closed-stdio-not-ttys");
+    let (tmp_dir, pam_env_value) = test_temp_paths("stdin-closed-stdio-not-ttys");
 
     let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
 
@@ -288,7 +288,7 @@ fn pam_tty_is_set_when_stdin_is_closed_and_stdio_fds_are_not_ttys() {
         .arg(format!(
             r#"exec 3>&1
 expected_tty=$(tty <&3)
-exec 0<&- >{repro_log} 2>&1
+exec 0<&- >/dev/null 2>&1
 sudo true
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
 cat {pam_env_value} >&3"#
@@ -371,6 +371,30 @@ cat {pam_env_value}"#
         .stdout();
 
     println!("stdout: {stdout}");
+    let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
+    assert_pam_tty_matches_expected(&expected, &pam_env);
+}
+
+#[test]
+fn pam_tty_with_stdin_pipe_uses_controlling_tty() {
+    let (tmp_dir, pam_env_value) = test_temp_paths("stdin-pipe");
+
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"exec 3>&1
+expected_tty=$(tty <&3)
+printf 'through-a-pipe\n' | sudo true >/dev/null 2>&1
+printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
+cat {pam_env_value} >&3"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
     let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
     assert_pam_tty_matches_expected(&expected, &pam_env);
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -422,3 +422,27 @@ cat {pam_env_value} >&3"#
     let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
     assert_pam_tty_matches_expected(&expected, &pam_env);
 }
+
+#[test]
+fn pam_tty_with_stdin_here_string_uses_controlling_tty() {
+    let (tmp_dir, pam_env_value) = test_temp_paths("stdin-here-string");
+
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            r#"exec 3>&1
+expected_tty=$(tty <&3)
+sudo -S -p '' true <<< '{PASSWORD}'
+printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
+cat {pam_env_value} >&3"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
+    assert_pam_tty_matches_expected(&expected, &pam_env);
+}

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -398,3 +398,27 @@ cat {pam_env_value} >&3"#
     let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
     assert_pam_tty_matches_expected(&expected, &pam_env);
 }
+
+#[test]
+fn pam_tty_is_set_when_stdout_is_closed_even_if_stdin_stderr_are_ttys() {
+    let (tmp_dir, pam_env_value) = test_temp_paths("stdout-closed-stdin-stderr-ttys");
+
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"exec 3>&1
+expected_tty=$(tty <&3)
+sudo true >&-
+printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
+cat {pam_env_value} >&3"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
+    assert_pam_tty_matches_expected(&expected, &pam_env);
+}

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -446,3 +446,30 @@ cat {pam_env_value} >&3"#
     let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
     assert_pam_tty_matches_expected(&expected, &pam_env);
 }
+
+#[test]
+fn pam_tty_with_background_stdin_here_string_uses_controlling_tty() {
+    let (tmp_dir, pam_env_value) = test_temp_paths("background-stdin-here-string");
+
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            r#"exec 3>&1
+expected_tty=$(tty <&3)
+set -m
+sudo -S -p '' true <<< '{PASSWORD}' >/dev/null 2>&1 &
+sudo_pid=$!
+wait "$sudo_pid"
+printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
+cat {pam_env_value} >&3"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
+    assert_pam_tty_matches_expected(&expected, &pam_env);
+}

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -180,6 +180,31 @@ fn sudo_dash_i_uses_correct_service_file() {
 }
 
 #[test]
+fn pam_tty_is_set_when_stdio_fds_are_not_ttys() {
+    let (tmp_dir, pam_env_value, repro_log) = test_temp_paths("stdio-fds-not-ttys");
+
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"exec 3>&1
+expected_tty=$(tty <&3)
+exec </dev/null >{repro_log} 2>&1
+sudo true
+printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
+cat {pam_env_value} >&3"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
+    assert_pam_tty_matches_expected(&expected, &pam_env);
+}
+
+#[test]
 fn pam_tty_with_stdout_redirect_uses_stdin_tty() {
     let (tmp_dir, pam_env_value) = test_temp_paths("stdout-not-a-tty");
 
@@ -240,6 +265,31 @@ fn pam_tty_with_stdout_and_stderr_redirect_uses_stdin_tty() {
             r#"exec 3>&1
 expected_tty=$(tty <&3)
 sudo true >/dev/null 2>&1
+printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
+cat {pam_env_value} >&3"#
+        ))
+        .as_user(USERNAME)
+        .tty(true)
+        .output(&env)
+        .stdout();
+
+    let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
+    assert_pam_tty_matches_expected(&expected, &pam_env);
+}
+
+#[test]
+fn pam_tty_is_set_when_stdin_is_closed_and_stdio_fds_are_not_ttys() {
+    let (tmp_dir, pam_env_value, repro_log) = test_temp_paths("stdin-closed-stdio-not-ttys");
+
+    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+
+    let stdout = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"exec 3>&1
+expected_tty=$(tty <&3)
+exec 0<&- >{repro_log} 2>&1
+sudo true
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
 cat {pam_env_value} >&3"#
         ))

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use sudo_test::{Command, Directory, Env, User};
+use sudo_test::{Command, Env, User};
 
 use crate::{PASSWORD, USERNAME};
 
@@ -10,25 +10,15 @@ use crate::{PASSWORD, USERNAME};
 mod env;
 
 const TEST_ENV_EXPECTED_TTY: &str = "SUDO_RS_TEST_ENV_EXPECTED_TTY";
+const PAM_ENV_VALUE: &str = "/tmp/PAM_ENV_VALUE";
 
-fn test_temp_paths(test_name: &str) -> (String, String) {
-    let base = std::env::temp_dir().join(format!("sudo-rs-pam-{test_name}"));
-    let value = base.join("pam_env_value");
-
-    (
-        base.to_string_lossy().into_owned(),
-        value.to_string_lossy().into_owned(),
-    )
-}
-
-fn build_pam_capture_env(tmp_dir: &str, pam_env_value: &str) -> sudo_test::Env {
+fn build_pam_capture_env() -> sudo_test::Env {
     Env("ALL ALL=(ALL:ALL) ALL")
         .user(USERNAME)
-        .directory(Directory(tmp_dir).chmod("777"))
         .file(
             "/etc/pam.d/sudo",
             format!(
-                r#"auth optional pam_exec.so log={pam_env_value} /usr/bin/env
+                r#"auth optional pam_exec.so log={PAM_ENV_VALUE} /usr/bin/env
 auth sufficient pam_permit.so"#
             ),
         )
@@ -181,9 +171,7 @@ fn sudo_dash_i_uses_correct_service_file() {
 
 #[test]
 fn pam_tty_is_set_when_stdio_fds_are_not_ttys() {
-    let (tmp_dir, pam_env_value) = test_temp_paths("stdio-fds-not-ttys");
-
-    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+    let env = build_pam_capture_env();
 
     let stdout = Command::new("sh")
         .arg("-c")
@@ -193,7 +181,7 @@ expected_tty=$(tty <&3)
 exec </dev/null >/dev/null 2>&1
 sudo true
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
-cat {pam_env_value} >&3"#
+cat {PAM_ENV_VALUE} >&3"#
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -206,9 +194,7 @@ cat {pam_env_value} >&3"#
 
 #[test]
 fn pam_tty_with_stdout_redirect_uses_stdin_tty() {
-    let (tmp_dir, pam_env_value) = test_temp_paths("stdout-not-a-tty");
-
-    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+    let env = build_pam_capture_env();
 
     let stdout = Command::new("sh")
         .arg("-c")
@@ -218,7 +204,7 @@ expected_tty=$(tty <&3)
 exec >/dev/null
 sudo true
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
-cat {pam_env_value} >&3"#
+cat {PAM_ENV_VALUE} >&3"#
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -231,9 +217,7 @@ cat {pam_env_value} >&3"#
 
 #[test]
 fn pam_tty_with_stderr_redirect_uses_stdin_tty() {
-    let (tmp_dir, pam_env_value) = test_temp_paths("stderr-not-a-tty");
-
-    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+    let env = build_pam_capture_env();
 
     let stdout = Command::new("sh")
         .arg("-c")
@@ -242,7 +226,7 @@ fn pam_tty_with_stderr_redirect_uses_stdin_tty() {
 expected_tty=$(tty <&3)
 sudo true 2>/dev/null
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
-cat {pam_env_value} >&3"#
+cat {PAM_ENV_VALUE} >&3"#
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -255,9 +239,7 @@ cat {pam_env_value} >&3"#
 
 #[test]
 fn pam_tty_with_stdout_and_stderr_redirect_uses_stdin_tty() {
-    let (tmp_dir, pam_env_value) = test_temp_paths("stdout-and-stderr-not-ttys");
-
-    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+    let env = build_pam_capture_env();
 
     let stdout = Command::new("sh")
         .arg("-c")
@@ -266,7 +248,7 @@ fn pam_tty_with_stdout_and_stderr_redirect_uses_stdin_tty() {
 expected_tty=$(tty <&3)
 sudo true >/dev/null 2>&1
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
-cat {pam_env_value} >&3"#
+cat {PAM_ENV_VALUE} >&3"#
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -279,9 +261,7 @@ cat {pam_env_value} >&3"#
 
 #[test]
 fn pam_tty_is_set_when_stdin_is_closed_and_stdio_fds_are_not_ttys() {
-    let (tmp_dir, pam_env_value) = test_temp_paths("stdin-closed-stdio-not-ttys");
-
-    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+    let env = build_pam_capture_env();
 
     let stdout = Command::new("sh")
         .arg("-c")
@@ -291,7 +271,7 @@ expected_tty=$(tty <&3)
 exec 0<&- >/dev/null 2>&1
 sudo true
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
-cat {pam_env_value} >&3"#
+cat {PAM_ENV_VALUE} >&3"#
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -304,9 +284,7 @@ cat {pam_env_value} >&3"#
 
 #[test]
 fn pam_tty_is_set_when_stdin_is_closed_even_if_stdout_stderr_are_ttys() {
-    let (tmp_dir, pam_env_value) = test_temp_paths("stdin-closed-stdout-stderr-ttys");
-
-    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+    let env = build_pam_capture_env();
 
     let stdout = Command::new("sh")
         .arg("-c")
@@ -316,7 +294,7 @@ expected_tty=$(tty <&3)
 exec 0<&-
 sudo true
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
-cat {pam_env_value} >&3"#
+cat {PAM_ENV_VALUE} >&3"#
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -329,9 +307,7 @@ cat {pam_env_value} >&3"#
 
 #[test]
 fn pam_tty_is_set_when_stdin_is_devnull_even_if_stdout_stderr_are_ttys() {
-    let (tmp_dir, pam_env_value) = test_temp_paths("stdin-devnull-stdout-stderr-ttys");
-
-    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+    let env = build_pam_capture_env();
 
     let stdout = Command::new("sh")
         .arg("-c")
@@ -341,7 +317,7 @@ expected_tty=$(tty <&3)
 exec </dev/null
 sudo true
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
-cat {pam_env_value} >&3"#
+cat {PAM_ENV_VALUE} >&3"#
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -354,9 +330,7 @@ cat {pam_env_value} >&3"#
 
 #[test]
 fn pam_tty_is_not_pts_when_command_has_no_tty() {
-    let (tmp_dir, pam_env_value) = test_temp_paths("no-tty");
-
-    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+    let env = build_pam_capture_env();
 
     let stdout = Command::new("sh")
         .arg("-c")
@@ -364,7 +338,7 @@ fn pam_tty_is_not_pts_when_command_has_no_tty() {
             r#"expected_tty=$(tty -s || echo '')
 sudo true
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty"
-cat {pam_env_value}"#
+cat {PAM_ENV_VALUE}"#
         ))
         .as_user(USERNAME)
         .output(&env)
@@ -377,9 +351,7 @@ cat {pam_env_value}"#
 
 #[test]
 fn pam_tty_with_stdin_pipe_uses_controlling_tty() {
-    let (tmp_dir, pam_env_value) = test_temp_paths("stdin-pipe");
-
-    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+    let env = build_pam_capture_env();
 
     let stdout = Command::new("sh")
         .arg("-c")
@@ -388,7 +360,7 @@ fn pam_tty_with_stdin_pipe_uses_controlling_tty() {
 expected_tty=$(tty <&3)
 printf 'through-a-pipe\n' | sudo true >/dev/null 2>&1
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
-cat {pam_env_value} >&3"#
+cat {PAM_ENV_VALUE} >&3"#
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -401,9 +373,7 @@ cat {pam_env_value} >&3"#
 
 #[test]
 fn pam_tty_is_set_when_stdout_is_closed_even_if_stdin_stderr_are_ttys() {
-    let (tmp_dir, pam_env_value) = test_temp_paths("stdout-closed-stdin-stderr-ttys");
-
-    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+    let env = build_pam_capture_env();
 
     let stdout = Command::new("sh")
         .arg("-c")
@@ -412,7 +382,7 @@ fn pam_tty_is_set_when_stdout_is_closed_even_if_stdin_stderr_are_ttys() {
 expected_tty=$(tty <&3)
 sudo true >&-
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
-cat {pam_env_value} >&3"#
+cat {PAM_ENV_VALUE} >&3"#
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -425,9 +395,7 @@ cat {pam_env_value} >&3"#
 
 #[test]
 fn pam_tty_with_stdin_here_string_uses_controlling_tty() {
-    let (tmp_dir, pam_env_value) = test_temp_paths("stdin-here-string");
-
-    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+    let env = build_pam_capture_env();
 
     let stdout = Command::new("bash")
         .arg("-c")
@@ -436,7 +404,7 @@ fn pam_tty_with_stdin_here_string_uses_controlling_tty() {
 expected_tty=$(tty <&3)
 sudo -S -p '' true <<< '{PASSWORD}'
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
-cat {pam_env_value} >&3"#
+cat {PAM_ENV_VALUE} >&3"#
         ))
         .as_user(USERNAME)
         .tty(true)
@@ -449,9 +417,7 @@ cat {pam_env_value} >&3"#
 
 #[test]
 fn pam_tty_with_background_stdin_here_string_uses_controlling_tty() {
-    let (tmp_dir, pam_env_value) = test_temp_paths("background-stdin-here-string");
-
-    let env = build_pam_capture_env(tmp_dir.as_str(), pam_env_value.as_str());
+    let env = build_pam_capture_env();
 
     let stdout = Command::new("bash")
         .arg("-c")
@@ -463,7 +429,7 @@ sudo -S -p '' true <<< '{PASSWORD}' >/dev/null 2>&1 &
 sudo_pid=$!
 wait "$sudo_pid"
 printf '%s=%s\n' '{TEST_ENV_EXPECTED_TTY}' "$expected_tty" >&3
-cat {pam_env_value} >&3"#
+cat {PAM_ENV_VALUE} >&3"#
         ))
         .as_user(USERNAME)
         .tty(true)


### PR DESCRIPTION
In sudo-rs we're just trying to use stdin as `PAM_TTY`, but this may not be available if some input is redirected.

For example, using tools such as `sshuttle` with `sudo-rs`, `PAM_TTY`, is currently unset while it's `/dev/pts/3` with sudo.ws

Now, the first commit would be enough to handle this in a simple way, but I also implemented a logic (for linux only, although BSDs can be added too), to follow the same logic that sudo is using to pick the TTY in a follow-up commit. Not sure if we have to go that deep though.

A simpler reproducer is (bug visible when uising `--close-stdin` or `--stdin-devnull`):

```python
#!/usr/bin/env python3
"""Minimal reproducer for sshuttle-style sudo launch."""

import argparse
import os
import shutil
import socket
import subprocess
import sys


def enable_sshuttle_syslog_fd_mode() -> subprocess.Popen[bytes]:
    """Mimic cmdline.py + ssyslog.py fd setup used by sshuttle --syslog."""
    sink = subprocess.Popen(
        ["cat"],
        stdin=subprocess.PIPE,
        stdout=subprocess.DEVNULL,
        stderr=subprocess.DEVNULL,
    )
    assert sink.stdin is not None
    # ssyslog.close_stdin()
    os.close(0)
    # ssyslog.stdout_to_syslog() + stderr_to_syslog()
    os.dup2(sink.stdin.fileno(), 1)
    os.dup2(sink.stdin.fileno(), 2)
    return sink


def main() -> int:
    parser = argparse.ArgumentParser()
    parser.add_argument(
        "--close-stdin",
        action="store_true",
        help="close stdin before launching sudo (mimics sshuttle --syslog path)",
    )
    parser.add_argument(
        "--stdin-devnull",
        action="store_true",
        help="launch sudo with stdin from /dev/null",
    )
    parser.add_argument(
        "--sshuttle-syslog-fds",
        action="store_true",
        help="mimic sshuttle --syslog fd wiring before spawning sudo",
    )
    args = parser.parse_args()

    if args.sshuttle_syslog_fds and (args.close_stdin or args.stdin_devnull):
        parser.error("--sshuttle-syslog-fds cannot be combined with stdin flags")
    if args.close_stdin and args.stdin_devnull:
        parser.error("--close-stdin and --stdin-devnull are mutually exclusive")

    sudo = shutil.which("sudo") or "sudo"
    argv = [sudo, "-p", "[local sudo] Password: ", "id"]

    s1, s2 = socket.socketpair()

    def setup() -> None:
        # Run in child process.
        s2.close()

    stdin_obj = None
    syslog_sink = None
    if args.sshuttle_syslog_fds:
        syslog_sink = enable_sshuttle_syslog_fd_mode()
    elif args.close_stdin:
        os.close(0)
    elif args.stdin_devnull:
        stdin_obj = open(os.devnull, "rb")

    # We can't rely on stderr being tty-writable in syslog-fd mode.
    debug_fd = open("/dev/tty", "w", buffering=1) if os.path.exists("/dev/tty") else sys.__stderr__
    print(f"Starting command: {argv!r}", file=debug_fd)
    print(
        f"parent isatty: stdin={os.isatty(0)} stdout={os.isatty(1)} stderr={os.isatty(2)}",
        file=debug_fd,
    )
    proc = subprocess.Popen(
        argv,
        stdin=stdin_obj,
        stdout=s1,
        preexec_fn=setup,
    )
    s1.close()
    if stdin_obj is not None:
        stdin_obj.close()

    pfile = s2.makefile("rwb")
    output = pfile.read()
    if output:
        sys.stdout.buffer.write(output)
        sys.stdout.buffer.flush()

    rc = proc.wait()
    pfile.close()
    s2.close()
    if syslog_sink is not None:
        if syslog_sink.stdin is not None:
            syslog_sink.stdin.close()
        syslog_sink.wait()
    if debug_fd is not sys.__stderr__:
        debug_fd.close()
    return rc


if __name__ == "__main__":
    raise SystemExit(main())
```

Closes: #1593