### PR TITLE
PAM: Improve error messages and align them with sudo.ws when no tty is available

### DIFF
--- a/src/pam/converse.rs
+++ b/src/pam/converse.rs
@@ -199,7 +199,9 @@ struct AskpassEnv {
 impl AskpassEnv {
     fn from_env() -> Self {
         Self {
-            has_display: std::env::var_os("DISPLAY").is_some(),
+            has_display: std::env::var_os("DISPLAY").is_some()
+                || std::env::var_os("WAYLAND_DISPLAY").is_some()
+                || std::env::var_os("WAYLAND_SOCKET").is_some(),
             has_askpass: std::env::var_os("SUDO_ASKPASS").is_some(),
         }
     }

--- a/src/pam/converse.rs
+++ b/src/pam/converse.rs
@@ -129,27 +129,89 @@ impl Drop for SignalGuard {
 }
 
 impl CLIConverser {
-    fn open(&self) -> PamResult<(Terminal<'_>, SignalGuard)> {
-        let term = if self.use_askpass {
-            Terminal::open_askpass()?
-        } else if self.use_stdin {
-            Terminal::open_stdie()?
-        } else {
-            let mut tty = Terminal::open_tty()?;
-            if self.bell.replace(false) {
-                tty.bell()?;
-            }
+    fn open(&self, style: PamMessageStyle) -> PamResult<(Terminal<'_>, SignalGuard)> {
+        let term = match style {
+            PamMessageStyle::PromptEchoOff if self.use_askpass => Terminal::open_askpass()?,
+            PamMessageStyle::PromptEchoOff if self.use_stdin => Terminal::open_stdie()?,
+            PamMessageStyle::PromptEchoOff => match Terminal::open_tty() {
+                Ok(mut tty) => {
+                    if self.bell.replace(false) {
+                        tty.bell()?;
+                    }
 
-            tty
+                    tty
+                }
+                Err(PamError::TtyRequired) => {
+                    match Self::tty_unavailable_fallback(style, AskpassEnv::from_env()) {
+                        TtyUnavailableFallback::Askpass => Terminal::open_askpass()?,
+                        TtyUnavailableFallback::Stdie => Terminal::open_stdie()?,
+                        TtyUnavailableFallback::Error => return Err(PamError::TtyRequired),
+                    }
+                }
+                Err(err) => return Err(err),
+            },
+            _ if self.use_stdin => Terminal::open_stdie()?,
+            _ => match Terminal::open_tty() {
+                Ok(mut tty) => {
+                    if self.bell.replace(false) {
+                        tty.bell()?;
+                    }
+
+                    tty
+                }
+                Err(PamError::TtyRequired) => Terminal::open_stdie()?,
+                Err(err) => return Err(err),
+            },
         };
 
         Ok((term, SignalGuard::unblock_interrupts()))
+    }
+
+    fn tty_unavailable_fallback(
+        style: PamMessageStyle,
+        askpass_env: AskpassEnv,
+    ) -> TtyUnavailableFallback {
+        match style {
+            PamMessageStyle::PromptEchoOff if askpass_env.can_use_askpass() => {
+                TtyUnavailableFallback::Askpass
+            }
+            PamMessageStyle::PromptEchoOff => TtyUnavailableFallback::Error,
+            PamMessageStyle::PromptEchoOn
+            | PamMessageStyle::ErrorMessage
+            | PamMessageStyle::TextInfo => TtyUnavailableFallback::Stdie,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TtyUnavailableFallback {
+    Askpass,
+    Stdie,
+    Error,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct AskpassEnv {
+    has_display: bool,
+    has_askpass: bool,
+}
+
+impl AskpassEnv {
+    fn from_env() -> Self {
+        Self {
+            has_display: std::env::var_os("DISPLAY").is_some(),
+            has_askpass: std::env::var_os("SUDO_ASKPASS").is_some(),
+        }
+    }
+
+    fn can_use_askpass(self) -> bool {
+        self.has_display && self.has_askpass
     }
 }
 
 impl Converser for CLIConverser {
     fn handle_normal_prompt(&self, msg: &str) -> PamResult<PamBuffer> {
-        let (mut tty, _guard) = self.open()?;
+        let (mut tty, _guard) = self.open(PamMessageStyle::PromptEchoOn)?;
         let input_needed = xlat!("input needed");
         tty.read_input(
             &format!("[{}: {input_needed} {msg} ", self.name),
@@ -159,7 +221,7 @@ impl Converser for CLIConverser {
     }
 
     fn handle_hidden_prompt(&self, msg: &str) -> PamResult<PamBuffer> {
-        let (mut tty, _guard) = self.open()?;
+        let (mut tty, _guard) = self.open(PamMessageStyle::PromptEchoOff)?;
         tty.read_input(
             msg,
             self.password_timeout,
@@ -172,12 +234,12 @@ impl Converser for CLIConverser {
     }
 
     fn handle_error(&self, msg: &str) -> PamResult<()> {
-        let (mut tty, _) = self.open()?;
+        let (mut tty, _) = self.open(PamMessageStyle::ErrorMessage)?;
         Ok(tty.prompt(&format!("[{} error] {msg}\n", self.name))?)
     }
 
     fn handle_info(&self, msg: &str) -> PamResult<()> {
-        let (mut tty, _) = self.open()?;
+        let (mut tty, _) = self.open(PamMessageStyle::TextInfo)?;
         Ok(tty.prompt(&format!("[{}] {msg}\n", self.name))?)
     }
 }
@@ -472,5 +534,93 @@ mod test {
         assert_eq!(dummy_pam(&[msg(ErrorMessage, "oops")], pam_conv), vec![]);
 
         assert!(hello.panicked); // allowed now
+    }
+
+    #[test]
+    fn tty_unavailable_fallback_for_hidden_prompt_uses_askpass_only_with_display_and_askpass() {
+        assert_eq!(
+            CLIConverser::tty_unavailable_fallback(
+                PamMessageStyle::PromptEchoOff,
+                AskpassEnv {
+                    has_display: true,
+                    has_askpass: true,
+                },
+            ),
+            TtyUnavailableFallback::Askpass
+        );
+        assert_eq!(
+            CLIConverser::tty_unavailable_fallback(
+                PamMessageStyle::PromptEchoOff,
+                AskpassEnv {
+                    has_display: true,
+                    has_askpass: false,
+                },
+            ),
+            TtyUnavailableFallback::Error
+        );
+        assert_eq!(
+            CLIConverser::tty_unavailable_fallback(
+                PamMessageStyle::PromptEchoOff,
+                AskpassEnv {
+                    has_display: false,
+                    has_askpass: true,
+                },
+            ),
+            TtyUnavailableFallback::Error
+        );
+        assert_eq!(
+            CLIConverser::tty_unavailable_fallback(
+                PamMessageStyle::PromptEchoOff,
+                AskpassEnv {
+                    has_display: false,
+                    has_askpass: false,
+                },
+            ),
+            TtyUnavailableFallback::Error
+        );
+    }
+
+    #[test]
+    fn tty_unavailable_fallback_for_non_hidden_prompt_uses_stdio() {
+        assert_eq!(
+            CLIConverser::tty_unavailable_fallback(
+                PamMessageStyle::PromptEchoOn,
+                AskpassEnv {
+                    has_display: true,
+                    has_askpass: true,
+                },
+            ),
+            TtyUnavailableFallback::Stdie
+        );
+        assert_eq!(
+            CLIConverser::tty_unavailable_fallback(
+                PamMessageStyle::PromptEchoOn,
+                AskpassEnv {
+                    has_display: true,
+                    has_askpass: false,
+                },
+            ),
+            TtyUnavailableFallback::Stdie
+        );
+        assert_eq!(
+            CLIConverser::tty_unavailable_fallback(
+                PamMessageStyle::PromptEchoOn,
+                AskpassEnv {
+                    has_display: false,
+                    has_askpass: true,
+                },
+            ),
+            TtyUnavailableFallback::Stdie
+        );
+        assert_eq!(
+            CLIConverser::tty_unavailable_fallback(
+                PamMessageStyle::PromptEchoOn,
+                AskpassEnv {
+                    has_display: false,
+                    has_askpass: false,
+                },
+            ),
+            TtyUnavailableFallback::Stdie
+        );
     }
 }

--- a/src/pam/converse.rs
+++ b/src/pam/converse.rs
@@ -145,7 +145,9 @@ impl CLIConverser {
                     match Self::tty_unavailable_fallback(style, AskpassEnv::from_env()) {
                         TtyUnavailableFallback::Askpass => Terminal::open_askpass()?,
                         TtyUnavailableFallback::Stdie => Terminal::open_stdie()?,
-                        TtyUnavailableFallback::Error => return Err(PamError::TtyRequired),
+                        TtyUnavailableFallback::Error => {
+                            return Err(Self::tty_required_error());
+                        }
                     }
                 }
                 Err(err) => return Err(err),
@@ -180,6 +182,10 @@ impl CLIConverser {
             | PamMessageStyle::ErrorMessage
             | PamMessageStyle::TextInfo => TtyUnavailableFallback::Stdie,
         }
+    }
+
+    fn tty_required_error() -> PamError {
+        PamError::TtyRequiredNoTtyPrompt
     }
 }
 
@@ -624,5 +630,13 @@ mod test {
             ),
             TtyUnavailableFallback::Stdie
         );
+    }
+
+    #[test]
+    fn tty_required_error_is_no_tty_prompt() {
+        assert!(matches!(
+            CLIConverser::tty_required_error(),
+            PamError::TtyRequiredNoTtyPrompt
+        ));
     }
 }

--- a/src/pam/converse.rs
+++ b/src/pam/converse.rs
@@ -185,7 +185,19 @@ impl CLIConverser {
     }
 
     fn tty_required_error() -> PamError {
+        if std::env::var_os("SSH_CONNECTION").is_some() && std::env::var_os("SSH_TTY").is_none() {
+            Self::tty_required_error_ssh()
+        } else {
+            Self::tty_required_error_no_tty_prompt()
+        }
+    }
+
+    fn tty_required_error_no_tty_prompt() -> PamError {
         PamError::TtyRequiredNoTtyPrompt
+    }
+
+    fn tty_required_error_ssh() -> PamError {
+        PamError::TtyRequiredSsh
     }
 }
 
@@ -633,10 +645,18 @@ mod test {
     }
 
     #[test]
-    fn tty_required_error_is_no_tty_prompt() {
+    fn tty_required_error_no_tty_prompt_uses_s_hint() {
         assert!(matches!(
-            CLIConverser::tty_required_error(),
+            CLIConverser::tty_required_error_no_tty_prompt(),
             PamError::TtyRequiredNoTtyPrompt
+        ));
+    }
+
+    #[test]
+    fn tty_required_error_ssh_uses_ssh_t_hint() {
+        assert!(matches!(
+            CLIConverser::tty_required_error_ssh(),
+            PamError::TtyRequiredSsh
         ));
     }
 }

--- a/src/pam/error.rs
+++ b/src/pam/error.rs
@@ -177,6 +177,7 @@ pub enum PamError {
     Pam(PamErrorType),
     IoError(std::io::Error),
     TtyRequired,
+    TtyRequiredNoTtyPrompt,
     EnvListFailure,
     InteractionRequired,
     NoPasswordProvided,
@@ -225,6 +226,10 @@ impl fmt::Display for PamError {
             PamError::Pam(tp) => xlat_write!(f, "PAM error: {error}", error = tp.get_err_msg()),
             PamError::IoError(e) => xlat_write!(f, "IO error: {error}", error = e),
             PamError::TtyRequired => xlat_write!(f, "A terminal is required to authenticate"),
+            PamError::TtyRequiredNoTtyPrompt => xlat_write!(
+                f,
+                "A terminal is required to authenticate; either use the -S option to read the password from standard input or configure an askpass helper"
+            ),
             PamError::EnvListFailure => {
                 xlat_write!(
                     f,

--- a/src/pam/error.rs
+++ b/src/pam/error.rs
@@ -178,6 +178,7 @@ pub enum PamError {
     IoError(std::io::Error),
     TtyRequired,
     TtyRequiredNoTtyPrompt,
+    TtyRequiredSsh,
     EnvListFailure,
     InteractionRequired,
     NoPasswordProvided,
@@ -229,6 +230,10 @@ impl fmt::Display for PamError {
             PamError::TtyRequiredNoTtyPrompt => xlat_write!(
                 f,
                 "A terminal is required to authenticate; either use the -S option to read the password from standard input or configure an askpass helper"
+            ),
+            PamError::TtyRequiredSsh => xlat_write!(
+                f,
+                "A terminal is required to authenticate; either use ssh's -t option or configure an askpass helper"
             ),
             PamError::EnvListFailure => {
                 xlat_write!(

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -102,3 +102,49 @@ fn sudo_dash_i_uses_correct_service_file() {
         .output(&env)
         .assert_success();
 }
+
+#[test]
+#[cfg_attr(target_os = "freebsd", ignore = "pam_echo behavior differs on FreeBSD")]
+fn no_tty_pam_text_info_falls_back_to_stdio() {
+    let env = Env("ALL ALL=(ALL:ALL) ALL")
+        .user(USERNAME)
+        .file(
+            "/etc/pam.d/sudo",
+            [
+                "auth optional pam_echo.so Hello sudo-rs, I am PAM",
+                "auth sufficient pam_permit.so",
+            ]
+            .join("\n"),
+        )
+        .build();
+
+    Command::new("sh")
+        .args(["-c", "sudo true </dev/null >/tmp/repro.log 2>&1"])
+        .as_user(USERNAME)
+        .output(&env)
+        .assert_success();
+}
+
+#[test]
+#[cfg_attr(target_os = "freebsd", ignore = "pam_echo behavior differs on FreeBSD")]
+fn no_tty_pam_text_info_uses_stdio_fallback() {
+    let env = Env("ALL ALL=(ALL:ALL) NOPASSWD: ALL")
+        .file(
+            "/etc/pam.d/sudo",
+            [
+                "auth sufficient pam_permit.so",
+                "account sufficient pam_permit.so",
+                "session optional pam_echo.so Hello sudo-rs, I am PAM",
+                "session sufficient pam_permit.so",
+            ]
+            .join("\n"),
+        )
+        .user(USERNAME)
+        .build();
+
+    Command::new("sh")
+        .args(["-c", "sudo true </dev/null"])
+        .as_user(USERNAME)
+        .output(&env)
+        .assert_success();
+}

--- a/test-framework/sudo-compliance-tests/src/sudo/pass_auth/askpass.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pass_auth/askpass.rs
@@ -25,6 +25,93 @@ fn correct_password() {
 }
 
 #[test]
+fn no_tty_uses_askpass_when_display_is_set() {
+    let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) ALL"))
+        .file("/bin/askpass", generate_askpass(PASSWORD))
+        .user(User(USERNAME).password(PASSWORD))
+        .build();
+
+    Command::new("sh")
+        .args([
+            "-c",
+            "SUDO_ASKPASS=/bin/askpass DISPLAY=:0 sudo true </dev/null >/tmp/repro.log 2>&1",
+        ])
+        .as_user(USERNAME)
+        .output(&env)
+        .assert_success();
+}
+
+#[test]
+fn no_tty_uses_askpass_with_custom_prompt_when_display_is_set() {
+    let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) ALL"))
+        .file(
+            "/bin/askpass",
+            TextFile(format!(
+                "#!/bin/sh\necho \"$1\" > /tmp/prompt\necho {PASSWORD}"
+            ))
+            .chmod(CHMOD_EXEC),
+        )
+        .user(User(USERNAME).password(PASSWORD))
+        .build();
+
+    Command::new("sh")
+        .args([
+            "-c",
+            "SUDO_ASKPASS=/bin/askpass DISPLAY=:0 sudo -p 'my fancy prompt' true </dev/null >/tmp/repro.log 2>&1",
+        ])
+        .as_user(USERNAME)
+        .output(&env)
+        .assert_success();
+
+    let output = Command::new("cat").arg("/tmp/prompt").output(&env);
+    assert_contains!(output.stdout(), "my fancy prompt");
+}
+
+#[test]
+fn no_tty_does_not_use_askpass_without_display() {
+    let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) ALL"))
+        .file("/bin/askpass", generate_askpass(PASSWORD))
+        .user(User(USERNAME).password(PASSWORD))
+        .build();
+
+    let output = Command::new("sh")
+        .args([
+            "-c",
+            "SUDO_ASKPASS=/bin/askpass sudo true </dev/null >/tmp/repro.log",
+        ])
+        .as_user(USERNAME)
+        .output(&env);
+
+    output.assert_exit_code(1);
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "a terminal is required to read the password"
+    } else {
+        "A terminal is required to authenticate"
+    };
+    assert_contains!(output.stderr(), diagnostic);
+}
+
+#[test]
+fn no_tty_with_display_but_without_askpass_still_fails() {
+    let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) ALL"))
+        .user(User(USERNAME).password(PASSWORD))
+        .build();
+
+    let output = Command::new("sh")
+        .args(["-c", "DISPLAY=:0 sudo true </dev/null >/tmp/repro.log"])
+        .as_user(USERNAME)
+        .output(&env);
+
+    output.assert_exit_code(1);
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "a terminal is required to read the password"
+    } else {
+        "A terminal is required to authenticate"
+    };
+    assert_contains!(output.stderr(), diagnostic);
+}
+
+#[test]
 fn incorrect_password() {
     let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) ALL"))
         .file("/bin/askpass", generate_askpass("incorrect-password"))

--- a/test-framework/sudo-compliance-tests/src/sudo/pass_auth/askpass.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pass_auth/askpass.rs
@@ -128,9 +128,9 @@ fn no_tty_does_not_use_askpass_without_display() {
 
     output.assert_exit_code(1);
     let diagnostic = if sudo_test::is_original_sudo() {
-        "a terminal is required to read the password"
+        "a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper"
     } else {
-        "A terminal is required to authenticate"
+        "A terminal is required to authenticate; either use the -S option to read the password from standard input or configure an askpass helper"
     };
     assert_contains!(output.stderr(), diagnostic);
 }
@@ -148,9 +148,9 @@ fn no_tty_with_display_but_without_askpass_still_fails() {
 
     output.assert_exit_code(1);
     let diagnostic = if sudo_test::is_original_sudo() {
-        "a terminal is required to read the password"
+        "a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper"
     } else {
-        "A terminal is required to authenticate"
+        "A terminal is required to authenticate; either use the -S option to read the password from standard input or configure an askpass helper"
     };
     assert_contains!(output.stderr(), diagnostic);
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/pass_auth/askpass.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pass_auth/askpass.rs
@@ -68,6 +68,50 @@ fn no_tty_uses_askpass_with_custom_prompt_when_display_is_set() {
 }
 
 #[test]
+fn no_tty_uses_askpass_when_wayland_display_is_set() {
+    if sudo_test::is_original_sudo() {
+        // Upstream sudo behavior is pending https://github.com/sudo-project/sudo/pull/540
+        return;
+    }
+
+    let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) ALL"))
+        .file("/bin/askpass", generate_askpass(PASSWORD))
+        .user(User(USERNAME).password(PASSWORD))
+        .build();
+
+    Command::new("sh")
+        .args([
+            "-c",
+            "SUDO_ASKPASS=/bin/askpass WAYLAND_DISPLAY=wayland-0 sudo true </dev/null >/tmp/repro.log 2>&1",
+        ])
+        .as_user(USERNAME)
+        .output(&env)
+        .assert_success();
+}
+
+#[test]
+fn no_tty_uses_askpass_when_wayland_socket_is_set() {
+    if sudo_test::is_original_sudo() {
+        // Upstream sudo behavior is pending https://github.com/sudo-project/sudo/pull/540
+        return;
+    }
+
+    let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) ALL"))
+        .file("/bin/askpass", generate_askpass(PASSWORD))
+        .user(User(USERNAME).password(PASSWORD))
+        .build();
+
+    Command::new("sh")
+        .args([
+            "-c",
+            "SUDO_ASKPASS=/bin/askpass WAYLAND_SOCKET=7 sudo true </dev/null >/tmp/repro.log 2>&1",
+        ])
+        .as_user(USERNAME)
+        .output(&env)
+        .assert_success();
+}
+
+#[test]
 fn no_tty_does_not_use_askpass_without_display() {
     let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) ALL"))
         .file("/bin/askpass", generate_askpass(PASSWORD))

--- a/test-framework/sudo-compliance-tests/src/sudo/pass_auth/tty.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pass_auth/tty.rs
@@ -50,9 +50,9 @@ fn no_tty() {
     output.assert_exit_code(1);
 
     let diagnostic = if sudo_test::is_original_sudo() {
-        "a terminal is required to read the password"
+        "a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper"
     } else {
-        "A terminal is required to authenticate"
+        "A terminal is required to authenticate; either use the -S option to read the password from standard input or configure an askpass helper"
     };
     assert_contains!(output.stderr(), diagnostic);
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/pass_auth/tty.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pass_auth/tty.rs
@@ -58,6 +58,35 @@ fn no_tty() {
 }
 
 #[test]
+fn no_tty_over_ssh_suggests_ssh_t() {
+    let env = Env(format!("{USERNAME}    ALL=(ALL:ALL) ALL"))
+        .user(User(USERNAME).password(PASSWORD))
+        .build();
+
+    let output = Command::new("sh")
+        .args([
+            "-c",
+            "LANG=C LC_ALL=C SSH_CONNECTION='127.0.0.1 33860 127.0.0.1 22' sudo true </dev/null >/tmp/repro.log",
+        ])
+        .as_user(USERNAME)
+        .output(&env);
+    output.assert_exit_code(1);
+
+    if sudo_test::is_original_sudo() {
+        // TODO: Remove this once sudo-project/sudo commit 516f72960 (sudo v1.9.17)
+        // is broadly available in the test container.
+        return;
+    }
+
+    let diagnostic = if sudo_test::is_original_sudo() {
+        "a terminal is required to read the password; either use ssh's -t option or configure an askpass helper"
+    } else {
+        "A terminal is required to authenticate; either use ssh's -t option or configure an askpass helper"
+    };
+    assert_contains!(output.stderr(), diagnostic);
+}
+
+#[test]
 fn longest_possible_password_works() {
     let password = "a".repeat(MAX_PASSWORD_SIZE);
 


### PR DESCRIPTION
Adjust the logic to pick a TTY and to warn if none is found with sudo.ws

See each commits for details.

Closes: #1595