### PR TITLE
Make `Digits` tokenizer more precise

### DIFF
--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -171,7 +171,7 @@ pub enum Sudo {
 impl Parse for Identifier {
     fn parse(stream: &mut CharStream) -> Parsed<Self> {
         if stream.eat_char('#') {
-            let Digits(guid) = expect_nonterminal(stream)?;
+            let DigitsU32(guid) = expect_nonterminal(stream)?;
             make(Identifier::ID(guid))
         } else {
             let Username(name) = try_nonterminal(stream)?;

--- a/src/sudoers/ast_names.rs
+++ b/src/sudoers/ast_names.rs
@@ -12,7 +12,7 @@ mod names {
     use crate::sudoers::ast::*;
     use crate::sudoers::tokens;
 
-    impl UserFriendly for tokens::Digits {
+    impl UserFriendly for tokens::DigitsU32 {
         const DESCRIPTION: &'static str = "number";
     }
 

--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -597,6 +597,16 @@ fn defaults_regression() {
 }
 
 #[test]
+fn user_id_regression() {
+    assert!(parse_line("#499999999999 ALL=ALL").is_line_comment());
+    assert!(parse_line("#49999999999 ALL=ALL").is_line_comment());
+    assert!(try_parse_line("Defaults:#49999999999 use_pty").is_none());
+    assert!(try_parse_line("Defaults:#4999999999 use_pty").is_none());
+    assert!(parse_line("#1999999999 ALL=ALL").is_spec());
+    assert!(parse_line("Defaults:#1999999999 use_pty").is_decl());
+}
+
+#[test]
 fn specific_defaults() {
     assert!(parse_line("Defaults !use_pty").is_decl());
     assert!(try_parse_line("Defaults!use_pty").is_none());

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -40,13 +40,15 @@ impl Token for Username {
 
 impl Many for Username {}
 
-pub struct Digits(pub u32);
+pub struct DigitsU32(pub u32);
 
-impl Token for Digits {
-    const MAX_LEN: usize = 9;
+impl Token for DigitsU32 {
+    const MAX_LEN: usize = 10;
 
     fn construct(s: String) -> Result<Self, String> {
-        Ok(Digits(s.parse().unwrap()))
+        s.parse()
+            .map(Self)
+            .map_err(|_| "value too large".to_string())
     }
 
     fn accept(c: char) -> bool {


### PR DESCRIPTION
We use to cap this at `10e9` so the `str::parse` method would always succeed; now we cap it at 10 digits and simply listen to the result of `str::parse`.

Closes #1602 