### PR TITLE
Ignore zizmor on warnings about Fedora/Alpine containers

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   zizmor:
-    name: Run zizmor 🌈
+    name: Run zizmor
     runs-on: ubuntu-latest
     permissions:
       security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
@@ -20,5 +20,5 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run zizmor 🌈
+      - name: Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-images:
+    ignore:
+      - ci.yaml:285
+      - ci.yaml:312


### PR DESCRIPTION
We deliberately pin these on the latest containers.