### PR TITLE
Move PAM account check upwards so it also applies to `sudo -l` and `sudo -e`.

### DIFF
--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -142,9 +142,6 @@ pub(super) fn pre_exec(
     pam: &mut PamContext,
     target_user: &str,
 ) -> Result<Vec<(OsString, OsString)>, Error> {
-    // make sure that the user that needed to authenticate has a valid token
-    pam.validate_account_or_change_auth_token()?;
-
     // check what the current user in PAM is
     let user = pam.get_user()?;
     if user != target_user {

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -11,7 +11,7 @@ use crate::sudo::env::environment;
 use crate::sudo::pam::{InitPamArgs, attempt_authenticate, init_pam, pre_exec};
 use crate::sudoers::{AuthenticatingUser, Authentication, Authorization, Judgement, Sudoers};
 use crate::system::term::current_tty_name;
-use crate::system::timestamp::{RecordScope, SessionRecordFile, TouchResult};
+use crate::system::timestamp::{LookupResult, RecordScope, SessionRecordFile};
 use crate::system::{Process, escape_os_str_lossy};
 
 mod list;
@@ -198,12 +198,15 @@ fn auth_and_update_record_file(
             context.non_interactive,
             allowed_attempts,
         )?;
-        if let (Some(record_file), Some(scope)) = (&mut auth_status.record_file, scope) {
-            match record_file.create(scope, &auth_user) {
-                Ok(_) => (),
-                Err(e) => {
-                    auth_warn!("Could not update session record file with new record: {e}");
-                }
+    }
+
+    pam_context.validate_account_or_change_auth_token()?;
+
+    if let (Some(record_file), Some(scope)) = (&mut auth_status.record_file, scope) {
+        match record_file.create(scope, &auth_user) {
+            Ok(_) => (),
+            Err(e) => {
+                auth_warn!("Could not update session record file with new record: {e}");
             }
         }
     }
@@ -226,10 +229,10 @@ fn determine_auth_status(
     } else if let (true, Some(record_for)) = (use_session_records, record_for) {
         match SessionRecordFile::open_for_user(current_user, prior_validity) {
             Ok(mut sr) => {
-                match sr.touch(record_for, auth_user) {
-                    // if a record was found and updated within the timeout, we do not need to authenticate
-                    Ok(TouchResult::Updated { .. }) => AuthStatus::new(false, Some(sr)),
-                    Ok(TouchResult::NotFound | TouchResult::Outdated { .. }) => {
+                match sr.lookup(record_for, auth_user) {
+                    // if a record was found within the timeout, we do not need to authenticate
+                    Ok(LookupResult::Valid { .. }) => AuthStatus::new(false, Some(sr)),
+                    Ok(LookupResult::NotFound | LookupResult::Outdated { .. }) => {
                         AuthStatus::new(true, Some(sr))
                     }
                     Err(e) => {

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -11,7 +11,7 @@ use crate::sudo::env::environment;
 use crate::sudo::pam::{InitPamArgs, attempt_authenticate, init_pam, pre_exec};
 use crate::sudoers::{AuthenticatingUser, Authentication, Authorization, Judgement, Sudoers};
 use crate::system::term::current_tty_name;
-use crate::system::timestamp::{LookupResult, RecordScope, SessionRecordFile};
+use crate::system::timestamp::{RecordScope, SessionRecordFile, TouchResult};
 use crate::system::{Process, escape_os_str_lossy};
 
 mod list;
@@ -198,18 +198,17 @@ fn auth_and_update_record_file(
             context.non_interactive,
             allowed_attempts,
         )?;
-    }
-
-    pam_context.validate_account_or_change_auth_token()?;
-
-    if let (Some(record_file), Some(scope)) = (&mut auth_status.record_file, scope) {
-        match record_file.create(scope, &auth_user) {
-            Ok(_) => (),
-            Err(e) => {
-                auth_warn!("Could not update session record file with new record: {e}");
+        if let (Some(record_file), Some(scope)) = (&mut auth_status.record_file, scope) {
+            match record_file.create(scope, &auth_user) {
+                Ok(_) => (),
+                Err(e) => {
+                    auth_warn!("Could not update session record file with new record: {e}");
+                }
             }
         }
     }
+
+    pam_context.validate_account_or_change_auth_token()?;
 
     Ok(pam_context)
 }
@@ -229,10 +228,10 @@ fn determine_auth_status(
     } else if let (true, Some(record_for)) = (use_session_records, record_for) {
         match SessionRecordFile::open_for_user(current_user, prior_validity) {
             Ok(mut sr) => {
-                match sr.lookup(record_for, auth_user) {
-                    // if a record was found within the timeout, we do not need to authenticate
-                    Ok(LookupResult::Valid { .. }) => AuthStatus::new(false, Some(sr)),
-                    Ok(LookupResult::NotFound | LookupResult::Outdated { .. }) => {
+                match sr.touch(record_for, auth_user) {
+                    // if a record was found and updated within the timeout, we do not need to authenticate
+                    Ok(TouchResult::Updated { .. }) => AuthStatus::new(false, Some(sr)),
+                    Ok(TouchResult::NotFound | TouchResult::Outdated { .. }) => {
                         AuthStatus::new(true, Some(sr))
                     }
                     Err(e) => {

--- a/src/system/timestamp.rs
+++ b/src/system/timestamp.rs
@@ -190,6 +190,7 @@ impl SessionRecordFile {
     /// that record time to the current time. This will not create a new record
     /// when one is not found. A record will only be updated if it is still
     /// valid at this time.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn touch(&mut self, scope: RecordScope, auth_user: &AuthUser) -> io::Result<TouchResult> {
         // lock the file to indicate that we are currently in a writing operation
         let lock = FileLock::exclusive(&self.file, false)?;
@@ -224,6 +225,32 @@ impl SessionRecordFile {
 
         lock.unlock()?;
         Ok(TouchResult::NotFound)
+    }
+
+    /// Try and find a valid record for the given scope and auth user id without
+    /// updating the record timestamp.
+    pub fn lookup(&mut self, scope: RecordScope, auth_user: &AuthUser) -> io::Result<LookupResult> {
+        let lock = FileLock::exclusive(&self.file, false)?;
+        self.seek_to_first_record()?;
+        while let Some(record) = self.next_record()? {
+            if record.enabled && record.matches(&scope, auth_user) {
+                let now = SystemTime::now()?;
+                let result = if record.written_between(now - self.timeout, now) {
+                    LookupResult::Valid {
+                        time: record.timestamp,
+                    }
+                } else {
+                    LookupResult::Outdated {
+                        time: record.timestamp,
+                    }
+                };
+                lock.unlock()?;
+                return Ok(result);
+            }
+        }
+
+        lock.unlock()?;
+        Ok(LookupResult::NotFound)
     }
 
     /// Disable all records that match the given scope.
@@ -308,6 +335,7 @@ impl SessionRecordFile {
     }
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TouchResult {
     /// The record was found and within the timeout, and it was refreshed
@@ -318,6 +346,16 @@ pub enum TouchResult {
     /// A record was found, but it was no longer valid
     Outdated { time: SystemTime },
     /// A record was not found that matches the input
+    NotFound,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum LookupResult {
+    /// The record was found and is within the timeout.
+    Valid { time: SystemTime },
+    /// A record was found, but it was no longer valid.
+    Outdated { time: SystemTime },
+    /// A record was not found that matches the input.
     NotFound,
 }
 

--- a/src/system/timestamp.rs
+++ b/src/system/timestamp.rs
@@ -190,7 +190,6 @@ impl SessionRecordFile {
     /// that record time to the current time. This will not create a new record
     /// when one is not found. A record will only be updated if it is still
     /// valid at this time.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub fn touch(&mut self, scope: RecordScope, auth_user: &AuthUser) -> io::Result<TouchResult> {
         // lock the file to indicate that we are currently in a writing operation
         let lock = FileLock::exclusive(&self.file, false)?;
@@ -225,32 +224,6 @@ impl SessionRecordFile {
 
         lock.unlock()?;
         Ok(TouchResult::NotFound)
-    }
-
-    /// Try and find a valid record for the given scope and auth user id without
-    /// updating the record timestamp.
-    pub fn lookup(&mut self, scope: RecordScope, auth_user: &AuthUser) -> io::Result<LookupResult> {
-        let lock = FileLock::exclusive(&self.file, false)?;
-        self.seek_to_first_record()?;
-        while let Some(record) = self.next_record()? {
-            if record.enabled && record.matches(&scope, auth_user) {
-                let now = SystemTime::now()?;
-                let result = if record.written_between(now - self.timeout, now) {
-                    LookupResult::Valid {
-                        time: record.timestamp,
-                    }
-                } else {
-                    LookupResult::Outdated {
-                        time: record.timestamp,
-                    }
-                };
-                lock.unlock()?;
-                return Ok(result);
-            }
-        }
-
-        lock.unlock()?;
-        Ok(LookupResult::NotFound)
     }
 
     /// Disable all records that match the given scope.
@@ -335,7 +308,6 @@ impl SessionRecordFile {
     }
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TouchResult {
     /// The record was found and within the timeout, and it was refreshed
@@ -346,16 +318,6 @@ pub enum TouchResult {
     /// A record was found, but it was no longer valid
     Outdated { time: SystemTime },
     /// A record was not found that matches the input
-    NotFound,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum LookupResult {
-    /// The record was found and is within the timeout.
-    Valid { time: SystemTime },
-    /// A record was found, but it was no longer valid.
-    Outdated { time: SystemTime },
-    /// A record was not found that matches the input.
     NotFound,
 }
 

--- a/test-framework/sudo-compliance-tests/src/lib.rs
+++ b/test-framework/sudo-compliance-tests/src/lib.rs
@@ -33,6 +33,12 @@ const SUDOERS_ALWAYS_LECTURE: &str = "Defaults lecture=\"always\"";
 const SUDOERS_NEW_LECTURE: &str = "Defaults lecture_file = \"/etc/sudo_lecture\"";
 const SUDOERS_NEW_LECTURE_USER: &str = "Defaults:ferris lecture_file = \"/etc/sudo_lecture\"";
 const PAMD_SUDO_PAM_PERMIT: &str = "auth sufficient pam_permit.so";
+const PAMD_SUDO_ACCOUNT_DENY: &str =
+    "auth sufficient pam_permit.so\naccount requisite pam_deny.so\nsession optional pam_permit.so";
+const PAMD_SUDO_ACCOUNT_PERMIT: &str =
+    "auth sufficient pam_permit.so\naccount sufficient pam_permit.so\nsession optional pam_permit.so";
+const PAMD_SUDO_AUTH_DENY_ACCOUNT_PERMIT: &str =
+    "auth requisite pam_deny.so\naccount sufficient pam_permit.so\nsession optional pam_permit.so";
 
 const OG_SUDO_STANDARD_LECTURE: &str = "\nWe trust you have received the usual lecture from the local System\nAdministrator. It usually boils down to these three things:\n\n    #1) Respect the privacy of others.\n    #2) Think before you type.\n    #3) With great power comes great responsibility.";
 

--- a/test-framework/sudo-compliance-tests/src/lib.rs
+++ b/test-framework/sudo-compliance-tests/src/lib.rs
@@ -35,8 +35,7 @@ const SUDOERS_NEW_LECTURE_USER: &str = "Defaults:ferris lecture_file = \"/etc/su
 const PAMD_SUDO_PAM_PERMIT: &str = "auth sufficient pam_permit.so";
 const PAMD_SUDO_ACCOUNT_DENY: &str =
     "auth sufficient pam_permit.so\naccount requisite pam_deny.so\nsession optional pam_permit.so";
-const PAMD_SUDO_ACCOUNT_PERMIT: &str =
-    "auth sufficient pam_permit.so\naccount sufficient pam_permit.so\nsession optional pam_permit.so";
+const PAMD_SUDO_ACCOUNT_PERMIT: &str = "auth sufficient pam_permit.so\naccount sufficient pam_permit.so\nsession optional pam_permit.so";
 
 const OG_SUDO_STANDARD_LECTURE: &str = "\nWe trust you have received the usual lecture from the local System\nAdministrator. It usually boils down to these three things:\n\n    #1) Respect the privacy of others.\n    #2) Think before you type.\n    #3) With great power comes great responsibility.";
 

--- a/test-framework/sudo-compliance-tests/src/lib.rs
+++ b/test-framework/sudo-compliance-tests/src/lib.rs
@@ -37,8 +37,6 @@ const PAMD_SUDO_ACCOUNT_DENY: &str =
     "auth sufficient pam_permit.so\naccount requisite pam_deny.so\nsession optional pam_permit.so";
 const PAMD_SUDO_ACCOUNT_PERMIT: &str =
     "auth sufficient pam_permit.so\naccount sufficient pam_permit.so\nsession optional pam_permit.so";
-const PAMD_SUDO_AUTH_DENY_ACCOUNT_PERMIT: &str =
-    "auth requisite pam_deny.so\naccount sufficient pam_permit.so\nsession optional pam_permit.so";
 
 const OG_SUDO_STANDARD_LECTURE: &str = "\nWe trust you have received the usual lecture from the local System\nAdministrator. It usually boils down to these three things:\n\n    #1) Respect the privacy of others.\n    #2) Think before you type.\n    #3) With great power comes great responsibility.";
 

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list.rs
@@ -1,6 +1,6 @@
 use sudo_test::{
-    BIN_FALSE, BIN_LS, BIN_PWD, BIN_SUDO, BIN_TRUE, Command, ETC_SUDOERS, Env,
-    PAM_D_SUDO_PATH, TextFile, User,
+    BIN_FALSE, BIN_LS, BIN_PWD, BIN_SUDO, BIN_TRUE, Command, ETC_SUDOERS, Env, PAM_D_SUDO_PATH,
+    TextFile, User,
 };
 
 use crate::{
@@ -142,10 +142,7 @@ fn pam_account_denial_blocks_list_output() {
         .output(&env);
 
     assert!(!output.status().success());
-    assert_contains!(
-        output.stderr().to_lowercase(),
-        "account validation failure"
-    );
+    assert_contains!(output.stderr().to_lowercase(), "account validation failure");
     assert!(!output.stdout_unchecked().contains("may run"));
 }
 

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list.rs
@@ -4,8 +4,7 @@ use sudo_test::{
 };
 
 use crate::{
-    HOSTNAME, PAMD_SUDO_ACCOUNT_DENY, PAMD_SUDO_ACCOUNT_PERMIT,
-    PAMD_SUDO_AUTH_DENY_ACCOUNT_PERMIT, PANIC_EXIT_CODE, PASSWORD, Result,
+    HOSTNAME, PAMD_SUDO_ACCOUNT_DENY, PAMD_SUDO_ACCOUNT_PERMIT, PANIC_EXIT_CODE, PASSWORD, Result,
     SUDOERS_ALL_ALL_NOPASSWD, USERNAME,
 };
 
@@ -169,44 +168,6 @@ fn pam_account_permit_allows_list_output() {
         format!("User {USERNAME} may run the following commands on {HOSTNAME}:")
     );
     assert_contains!(output.stdout_unchecked(), BIN_TRUE);
-}
-
-#[test]
-fn pam_account_denial_does_not_create_list_timestamp() {
-    if sudo_test::is_original_sudo() {
-        return;
-    }
-
-    let env = Env(format!("{USERNAME} ALL=(root) list, {BIN_TRUE}"))
-        .user(USERNAME)
-        .hostname(HOSTNAME)
-        .file(PAM_D_SUDO_PATH, PAMD_SUDO_ACCOUNT_DENY)
-        .build();
-
-    let output = Command::new("sudo")
-        .arg("-l")
-        .as_user(USERNAME)
-        .output(&env);
-
-    assert!(!output.status().success());
-    assert_contains!(
-        output.stderr().to_lowercase(),
-        "account validation failure"
-    );
-
-    Command::new("tee")
-        .arg(PAM_D_SUDO_PATH)
-        .stdin(PAMD_SUDO_AUTH_DENY_ACCOUNT_PERMIT)
-        .output(&env)
-        .assert_success();
-
-    let output = Command::new("sudo")
-        .args(["-n", "-l"])
-        .as_user(USERNAME)
-        .output(&env);
-
-    assert!(!output.status().success());
-    assert!(!output.stdout_unchecked().contains("may run"));
 }
 
 #[test]

--- a/test-framework/sudo-compliance-tests/src/sudo/flag_list.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/flag_list.rs
@@ -1,8 +1,13 @@
 use sudo_test::{
-    BIN_FALSE, BIN_LS, BIN_PWD, BIN_SUDO, BIN_TRUE, Command, ETC_SUDOERS, Env, TextFile, User,
+    BIN_FALSE, BIN_LS, BIN_PWD, BIN_SUDO, BIN_TRUE, Command, ETC_SUDOERS, Env,
+    PAM_D_SUDO_PATH, TextFile, User,
 };
 
-use crate::{PANIC_EXIT_CODE, PASSWORD, Result, SUDOERS_ALL_ALL_NOPASSWD, USERNAME};
+use crate::{
+    HOSTNAME, PAMD_SUDO_ACCOUNT_DENY, PAMD_SUDO_ACCOUNT_PERMIT,
+    PAMD_SUDO_AUTH_DENY_ACCOUNT_PERMIT, PANIC_EXIT_CODE, PASSWORD, Result,
+    SUDOERS_ALL_ALL_NOPASSWD, USERNAME,
+};
 
 mod credential_caching;
 mod flag_other_user;
@@ -122,6 +127,86 @@ fn works_with_long_form_list_flag() {
     );
     let actual = output.stdout();
     assert_eq!(strip_matching_defaults_message(&actual), expected);
+}
+
+#[test]
+fn pam_account_denial_blocks_list_output() {
+    let env = Env(format!("{USERNAME} ALL=(root) NOPASSWD: {BIN_TRUE}"))
+        .user(USERNAME)
+        .hostname(HOSTNAME)
+        .file(PAM_D_SUDO_PATH, PAMD_SUDO_ACCOUNT_DENY)
+        .build();
+
+    let output = Command::new("sudo")
+        .args(["-n", "-l"])
+        .as_user(USERNAME)
+        .output(&env);
+
+    assert!(!output.status().success());
+    assert_contains!(
+        output.stderr().to_lowercase(),
+        "account validation failure"
+    );
+    assert!(!output.stdout_unchecked().contains("may run"));
+}
+
+#[test]
+fn pam_account_permit_allows_list_output() {
+    let env = Env(format!("{USERNAME} ALL=(root) NOPASSWD: {BIN_TRUE}"))
+        .user(USERNAME)
+        .hostname(HOSTNAME)
+        .file(PAM_D_SUDO_PATH, PAMD_SUDO_ACCOUNT_PERMIT)
+        .build();
+
+    let output = Command::new("sudo")
+        .args(["-n", "-l"])
+        .as_user(USERNAME)
+        .output(&env);
+
+    output.assert_success();
+    assert_contains!(
+        output.stdout_unchecked(),
+        format!("User {USERNAME} may run the following commands on {HOSTNAME}:")
+    );
+    assert_contains!(output.stdout_unchecked(), BIN_TRUE);
+}
+
+#[test]
+fn pam_account_denial_does_not_create_list_timestamp() {
+    if sudo_test::is_original_sudo() {
+        return;
+    }
+
+    let env = Env(format!("{USERNAME} ALL=(root) list, {BIN_TRUE}"))
+        .user(USERNAME)
+        .hostname(HOSTNAME)
+        .file(PAM_D_SUDO_PATH, PAMD_SUDO_ACCOUNT_DENY)
+        .build();
+
+    let output = Command::new("sudo")
+        .arg("-l")
+        .as_user(USERNAME)
+        .output(&env);
+
+    assert!(!output.status().success());
+    assert_contains!(
+        output.stderr().to_lowercase(),
+        "account validation failure"
+    );
+
+    Command::new("tee")
+        .arg(PAM_D_SUDO_PATH)
+        .stdin(PAMD_SUDO_AUTH_DENY_ACCOUNT_PERMIT)
+        .output(&env)
+        .assert_success();
+
+    let output = Command::new("sudo")
+        .args(["-n", "-l"])
+        .as_user(USERNAME)
+        .output(&env);
+
+    assert!(!output.status().success());
+    assert!(!output.stdout_unchecked().contains("may run"));
 }
 
 #[test]

--- a/test-framework/sudo-compliance-tests/src/sudoedit.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoedit.rs
@@ -4,7 +4,7 @@ use sudo_test::{
 };
 
 use crate::{
-    DEFAULT_EDITOR, GROUPNAME, PANIC_EXIT_CODE, PAMD_SUDO_ACCOUNT_DENY, PAMD_SUDO_ACCOUNT_PERMIT,
+    DEFAULT_EDITOR, GROUPNAME, PAMD_SUDO_ACCOUNT_DENY, PAMD_SUDO_ACCOUNT_PERMIT, PANIC_EXIT_CODE,
     Result, SUDOERS_ALL_ALL_NOPASSWD, USERNAME,
 };
 
@@ -55,10 +55,7 @@ fn pam_account_denial_blocks_sudoedit_before_file_modification() {
     ))
     .user(USERNAME)
     .file(PAM_D_SUDO_PATH, PAMD_SUDO_ACCOUNT_DENY)
-    .file(
-        DEFAULT_EDITOR,
-        TextFile(EDITOR_OVERWRITE).chmod(CHMOD_EXEC),
-    )
+    .file(DEFAULT_EDITOR, TextFile(EDITOR_OVERWRITE).chmod(CHMOD_EXEC))
     .file(PAM_DENY_TARGET, TextFile("unchanged").chmod("644"))
     .build();
 
@@ -74,10 +71,7 @@ fn pam_account_denial_blocks_sudoedit_before_file_modification() {
         .output(&env);
 
     assert!(!output.status().success());
-    assert_contains!(
-        output.stderr().to_lowercase(),
-        "account validation failure"
-    );
+    assert_contains!(output.stderr().to_lowercase(), "account validation failure");
 
     let actual = Command::new("cat")
         .arg(PAM_DENY_TARGET)
@@ -94,10 +88,7 @@ fn pam_account_permit_allows_sudoedit() {
     ))
     .user(USERNAME)
     .file(PAM_D_SUDO_PATH, PAMD_SUDO_ACCOUNT_PERMIT)
-    .file(
-        DEFAULT_EDITOR,
-        TextFile(EDITOR_OVERWRITE).chmod(CHMOD_EXEC),
-    )
+    .file(DEFAULT_EDITOR, TextFile(EDITOR_OVERWRITE).chmod(CHMOD_EXEC))
     .file(PAM_DENY_TARGET, TextFile("unchanged").chmod("644"))
     .build();
 

--- a/test-framework/sudo-compliance-tests/src/sudoedit.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoedit.rs
@@ -4,9 +4,8 @@ use sudo_test::{
 };
 
 use crate::{
-    DEFAULT_EDITOR, GROUPNAME, PANIC_EXIT_CODE, PAMD_SUDO_ACCOUNT_DENY,
-    PAMD_SUDO_ACCOUNT_PERMIT, PAMD_SUDO_AUTH_DENY_ACCOUNT_PERMIT, Result,
-    SUDOERS_ALL_ALL_NOPASSWD, USERNAME,
+    DEFAULT_EDITOR, GROUPNAME, PANIC_EXIT_CODE, PAMD_SUDO_ACCOUNT_DENY, PAMD_SUDO_ACCOUNT_PERMIT,
+    Result, SUDOERS_ALL_ALL_NOPASSWD, USERNAME,
 };
 
 mod flag_help;
@@ -114,56 +113,6 @@ fn pam_account_permit_allows_sudoedit() {
         .stdout();
 
     assert_eq!("modified", actual);
-}
-
-#[test]
-fn pam_account_denial_does_not_create_sudoedit_timestamp() {
-    if sudo_test::is_original_sudo() {
-        return;
-    }
-
-    let env = Env(format!(
-        "{USERNAME} ALL=(root) sudoedit {PAM_DENY_TARGET}, /usr/bin/true"
-    ))
-    .user(USERNAME)
-    .file(PAM_D_SUDO_PATH, PAMD_SUDO_ACCOUNT_DENY)
-    .file(
-        DEFAULT_EDITOR,
-        TextFile(EDITOR_OVERWRITE).chmod(CHMOD_EXEC),
-    )
-    .file(PAM_DENY_TARGET, TextFile("unchanged").chmod("644"))
-    .build();
-
-    let output = Command::new("sudoedit")
-        .arg(PAM_DENY_TARGET)
-        .as_user(USERNAME)
-        .output(&env);
-
-    assert!(!output.status().success());
-    assert_contains!(
-        output.stderr().to_lowercase(),
-        "account validation failure"
-    );
-
-    Command::new("tee")
-        .arg(PAM_D_SUDO_PATH)
-        .stdin(PAMD_SUDO_AUTH_DENY_ACCOUNT_PERMIT)
-        .output(&env)
-        .assert_success();
-
-    let output = Command::new("sudo")
-        .args(["-n", "/usr/bin/true"])
-        .as_user(USERNAME)
-        .output(&env);
-
-    assert!(!output.status().success());
-
-    let actual = Command::new("cat")
-        .arg(PAM_DENY_TARGET)
-        .output(&env)
-        .stdout();
-
-    assert_eq!("unchanged", actual);
 }
 
 #[test]

--- a/test-framework/sudo-compliance-tests/src/sudoedit.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoedit.rs
@@ -1,9 +1,12 @@
 use sudo_test::{
-    Command, ETC_SUDOERS, Env, EnvNoImplicit, ROOT_GROUP, TextFile, helpers::assert_ls_output,
+    Command, ETC_SUDOERS, Env, EnvNoImplicit, PAM_D_SUDO_PATH, ROOT_GROUP, TextFile,
+    helpers::assert_ls_output,
 };
 
 use crate::{
-    DEFAULT_EDITOR, GROUPNAME, PANIC_EXIT_CODE, Result, SUDOERS_ALL_ALL_NOPASSWD, USERNAME,
+    DEFAULT_EDITOR, GROUPNAME, PANIC_EXIT_CODE, PAMD_SUDO_ACCOUNT_DENY,
+    PAMD_SUDO_ACCOUNT_PERMIT, PAMD_SUDO_AUTH_DENY_ACCOUNT_PERMIT, Result,
+    SUDOERS_ALL_ALL_NOPASSWD, USERNAME,
 };
 
 mod flag_help;
@@ -14,6 +17,10 @@ const LOGS_PATH: &str = "/tmp/logs.txt";
 const CHMOD_EXEC: &str = "555";
 const EDITOR_DUMMY: &str = "#!/bin/sh
 echo \"#\" >> \"$1\"";
+
+const PAM_DENY_TARGET: &str = "/etc/sudo-rs-pam-deny-target";
+const EDITOR_OVERWRITE: &str = "#!/bin/sh
+printf modified > \"$1\"";
 
 #[test]
 fn default_editor_is_usr_bin_editor() {
@@ -40,6 +47,123 @@ echo '{expected}' > {LOGS_PATH}"
     let actual = Command::new("cat").arg(LOGS_PATH).output(&env).stdout();
 
     assert_eq!(expected, actual);
+}
+
+#[test]
+fn pam_account_denial_blocks_sudoedit_before_file_modification() {
+    let env = Env(format!(
+        "{USERNAME} ALL=(root) NOPASSWD: sudoedit {PAM_DENY_TARGET}"
+    ))
+    .user(USERNAME)
+    .file(PAM_D_SUDO_PATH, PAMD_SUDO_ACCOUNT_DENY)
+    .file(
+        DEFAULT_EDITOR,
+        TextFile(EDITOR_OVERWRITE).chmod(CHMOD_EXEC),
+    )
+    .file(PAM_DENY_TARGET, TextFile("unchanged").chmod("644"))
+    .build();
+
+    let direct_write = Command::new("sh")
+        .args(["-c", &format!("echo direct > {PAM_DENY_TARGET}")])
+        .as_user(USERNAME)
+        .output(&env);
+    assert!(!direct_write.status().success());
+
+    let output = Command::new("sudoedit")
+        .args(["-n", PAM_DENY_TARGET])
+        .as_user(USERNAME)
+        .output(&env);
+
+    assert!(!output.status().success());
+    assert_contains!(
+        output.stderr().to_lowercase(),
+        "account validation failure"
+    );
+
+    let actual = Command::new("cat")
+        .arg(PAM_DENY_TARGET)
+        .output(&env)
+        .stdout();
+
+    assert_eq!("unchanged", actual);
+}
+
+#[test]
+fn pam_account_permit_allows_sudoedit() {
+    let env = Env(format!(
+        "{USERNAME} ALL=(root) NOPASSWD: sudoedit {PAM_DENY_TARGET}"
+    ))
+    .user(USERNAME)
+    .file(PAM_D_SUDO_PATH, PAMD_SUDO_ACCOUNT_PERMIT)
+    .file(
+        DEFAULT_EDITOR,
+        TextFile(EDITOR_OVERWRITE).chmod(CHMOD_EXEC),
+    )
+    .file(PAM_DENY_TARGET, TextFile("unchanged").chmod("644"))
+    .build();
+
+    Command::new("sudoedit")
+        .args(["-n", PAM_DENY_TARGET])
+        .as_user(USERNAME)
+        .output(&env)
+        .assert_success();
+
+    let actual = Command::new("cat")
+        .arg(PAM_DENY_TARGET)
+        .output(&env)
+        .stdout();
+
+    assert_eq!("modified", actual);
+}
+
+#[test]
+fn pam_account_denial_does_not_create_sudoedit_timestamp() {
+    if sudo_test::is_original_sudo() {
+        return;
+    }
+
+    let env = Env(format!(
+        "{USERNAME} ALL=(root) sudoedit {PAM_DENY_TARGET}, /usr/bin/true"
+    ))
+    .user(USERNAME)
+    .file(PAM_D_SUDO_PATH, PAMD_SUDO_ACCOUNT_DENY)
+    .file(
+        DEFAULT_EDITOR,
+        TextFile(EDITOR_OVERWRITE).chmod(CHMOD_EXEC),
+    )
+    .file(PAM_DENY_TARGET, TextFile("unchanged").chmod("644"))
+    .build();
+
+    let output = Command::new("sudoedit")
+        .arg(PAM_DENY_TARGET)
+        .as_user(USERNAME)
+        .output(&env);
+
+    assert!(!output.status().success());
+    assert_contains!(
+        output.stderr().to_lowercase(),
+        "account validation failure"
+    );
+
+    Command::new("tee")
+        .arg(PAM_D_SUDO_PATH)
+        .stdin(PAMD_SUDO_AUTH_DENY_ACCOUNT_PERMIT)
+        .output(&env)
+        .assert_success();
+
+    let output = Command::new("sudo")
+        .args(["-n", "/usr/bin/true"])
+        .as_user(USERNAME)
+        .output(&env);
+
+    assert!(!output.status().success());
+
+    let actual = Command::new("cat")
+        .arg(PAM_DENY_TARGET)
+        .output(&env)
+        .stdout();
+
+    assert_eq!("unchanged", actual);
 }
 
 #[test]


### PR DESCRIPTION
Without this fix sudo-rs essentially behaves as if
```
Defaults!sudoedit,list !pam_acct_mgmt
```
was specified in the /etc/sudoers file.