### PR TITLE
Finetune `runcwd`

### DIFF
--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -248,7 +248,7 @@ impl Context {
         controls: &Restrictions,
     ) -> Result<RunOptions<'_>, Error> {
         // see if the chdir flag is permitted
-        let chdir = match controls.chdir {
+        let chdir = match &controls.chdir {
             DirChange::Any => self.chdir.as_ref(),
             DirChange::Strict(optdir) => {
                 if let Some(chdir) = &self.chdir {
@@ -257,7 +257,7 @@ impl Context {
                         command: self.command.command.clone(),
                     });
                 } else {
-                    optdir
+                    optdir.as_ref()
                 }
             }
         };

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -248,8 +248,8 @@ impl Context {
         controls: &Restrictions,
     ) -> Result<RunOptions<'_>, Error> {
         // see if the chdir flag is permitted
-        let mut chdir = match controls.chdir {
-            DirChange::Any => self.chdir.clone(),
+        let chdir = match controls.chdir {
+            DirChange::Any => self.chdir.as_ref(),
             DirChange::Strict(optdir) => {
                 if let Some(chdir) = &self.chdir {
                     return Err(Error::ChDirNotAllowed {
@@ -257,15 +257,15 @@ impl Context {
                         command: self.command.command.clone(),
                     });
                 } else {
-                    optdir.cloned()
+                    optdir
                 }
             }
         };
 
         // expand tildes in the path with the users home directory
-        if let Some(dir) = chdir.take() {
-            chdir = Some(dir.expand_tilde_in_path(&self.target_user.name)?);
-        }
+        let chdir = chdir
+            .map(|dir| dir.expand_tilde_in_path(&self.target_user.name))
+            .transpose()?;
 
         Ok(RunOptions {
             command: if self.command.resolved {

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -172,18 +172,9 @@ impl Sudoers {
             am_user.is_root() || (request.user == am_user && in_group(am_user, request.group));
 
         let mut flags = check_permission(self, am_user, on_host, request);
-        if let Some(tag) = flags.as_mut() {
+        if let Some(Tag { authenticate, .. }) = flags.as_mut() {
             if skip_passwd {
-                tag.authenticate = Authenticate::Nopasswd;
-            }
-
-            // a `runcwd` default acts as the working directory when no explicit CWD was set
-            if tag.cwd.is_none() {
-                use basic_parser::Token;
-                tag.cwd = self
-                    .settings
-                    .runcwd()
-                    .and_then(|s| tokens::ChDir::construct(s.to_string()).ok());
+                *authenticate = Authenticate::Nopasswd;
             }
         }
 

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -66,7 +66,7 @@ pub struct Restrictions<'a> {
     pub noexec: bool,
     pub env_keep: &'a HashSet<String>,
     pub env_check: &'a HashSet<String>,
-    pub chdir: DirChange<'a>,
+    pub chdir: DirChange,
     pub path: Option<&'a str>,
     pub umask: Umask,
     #[cfg(feature = "apparmor")]
@@ -76,8 +76,8 @@ pub struct Restrictions<'a> {
 #[must_use]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[repr(u32)]
-pub enum DirChange<'a> {
-    Strict(Option<&'a SudoPath>) = HARDENED_ENUM_VALUE_0,
+pub enum DirChange {
+    Strict(Option<SudoPath>) = HARDENED_ENUM_VALUE_0,
     Any = HARDENED_ENUM_VALUE_1,
 }
 
@@ -113,7 +113,12 @@ impl Judgement {
                     },
                     env_keep: self.settings.env_keep(),
                     env_check: self.settings.env_check(),
-                    chdir: match tag.cwd.as_ref() {
+                    chdir: match tag.cwd.clone().or_else(|| {
+                        // a `runcwd` default acts as the working directory when no explicit CWD was set
+                        self.settings
+                            .runcwd()
+                            .and_then(|s| super::basic_parser::Token::construct(s.to_string()).ok())
+                    }) {
                         None => DirChange::Strict(None),
                         Some(super::ChDir::Any) => DirChange::Any,
                         Some(super::ChDir::Path(path)) => DirChange::Strict(Some(path)),
@@ -230,7 +235,7 @@ mod test {
             flags: Some(Tag::default()),
             ..Default::default()
         };
-        fn chdir(judge: &mut Judgement) -> DirChange<'_> {
+        fn chdir(judge: &mut Judgement) -> DirChange {
             let Authorization::Allowed(_, ctl) = judge.authorization() else {
                 panic!()
             };
@@ -240,8 +245,8 @@ mod test {
         judge.mod_flag(|tag| tag.cwd = Some(ChDir::Any));
         assert_eq!(chdir(&mut judge), DirChange::Any);
         judge.mod_flag(|tag| tag.cwd = Some(ChDir::Path("/usr".into())));
-        assert_eq!(chdir(&mut judge), (DirChange::Strict(Some(&"/usr".into()))));
+        assert_eq!(chdir(&mut judge), (DirChange::Strict(Some("/usr".into()))));
         judge.mod_flag(|tag| tag.cwd = Some(ChDir::Path("/bin".into())));
-        assert_eq!(chdir(&mut judge), (DirChange::Strict(Some(&"/bin".into()))));
+        assert_eq!(chdir(&mut judge), (DirChange::Strict(Some("/bin".into()))));
     }
 }


### PR DESCRIPTION
Follow-up to #1542.

The implementation there exposed some of the logic of the sudoers config in the `fn check()` function, which is a bit high up the chain (ideally everything should be handled in the "Judgement" object and `fn check()` should only handle exceptions such as "the current user is root", which the Judgement object doesn't know about).

However, doing that required changing the lifetime in `DirChange`. This reverts `fn check()` to the form it had before #1542 was merged.