### PR TITLE
Remove PAM breakage for test-framework on FreeBSD

### DIFF
--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -4,6 +4,7 @@ use sudo_test::{Command, Env, User};
 
 use crate::{PASSWORD, USERNAME};
 
+#[cfg(target_os = "linux")]
 mod env;
 
 #[test]

--- a/test-framework/sudo-compliance-tests/src/sudo/pam/env.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam/env.rs
@@ -1,4 +1,5 @@
 // `pam_env` module integration
+// These tests only run on Linux since FreeBSD doesn't have pam_env.so
 // see 'Command execution' section in `man sudoers`
 
 use pretty_assertions::assert_eq;
@@ -28,7 +29,6 @@ fn remove_comments_and_whitespace(contents: &str) -> String {
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn stock_pam_d_sudo() {
     let env = EnvNoImplicit("").build();
 
@@ -94,7 +94,6 @@ fn stock_pam_d_sudo() {
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn preserves_pam_env() {
     let set_name = "SET_VAR";
     let set_value = "set";
@@ -124,7 +123,6 @@ fn preserves_pam_env() {
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn pam_env_has_precedence_over_callers_env() {
     let set_name = "SET_VAR";
     let set_value = "set";
@@ -200,19 +198,16 @@ fn env_list_has_precendece_over_pam_env(env_list: EnvList) {
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn env_keep_has_precedence_over_pam_env() {
     env_list_has_precendece_over_pam_env(EnvList::Keep)
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn env_check_has_precedence_over_pam_env() {
     env_list_has_precendece_over_pam_env(EnvList::Check)
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn var_rejected_by_env_check_falls_back_to_pam_env_value() {
     let set_name = "SET_VAR";
     let set_value = "set";
@@ -254,7 +249,6 @@ fn var_rejected_by_env_check_falls_back_to_pam_env_value() {
 }
 
 #[test]
-#[cfg_attr(target_os = "freebsd", ignore = "FreeBSD doesn't have pam_env.so")]
 fn pam_env_vars_are_not_env_checked() {
     let set_name = "SET_VAR";
     let set_value = "%set";

--- a/test-framework/sudo-test/src/constants.rs
+++ b/test-framework/sudo-test/src/constants.rs
@@ -67,3 +67,20 @@ pub const BIN_BASH: &str = "/usr/bin/bash";
 /// The path to the `bash` binary.
 #[cfg(target_os = "freebsd")]
 pub const BIN_BASH: &str = "/usr/local/bin/bash";
+
+/// Location of the sudo pam config
+#[cfg(target_os = "linux")]
+pub const PAM_D_SUDO_PATH: &str = "/etc/pam.d/sudo";
+
+/// Location of the sudo pam config
+#[cfg(target_os = "freebsd")]
+pub const PAM_D_SUDO_PATH: &str = "/usr/local/etc/pam.d/sudo";
+
+/// The default pam config on Debian
+pub const STOCK_PAM_D_SUDO: &str = "#%PAM-1.0\nsession    required   pam_limits.so\n@include common-auth\n@include common-account\n@include common-session-noninteractive";
+
+/// Location of the su pam config
+pub const PAM_D_SU_PATH: &str = "/etc/pam.d/su";
+
+/// The default `/etc/pam.d/su` on Debian
+pub const STOCK_PAM_D_SU: &str = "#%PAM-1.0\nauth       sufficient pam_rootok.so\nsession    optional   pam_mail.so nopen\nsession    required   pam_limits.so\n@include common-auth\n@include common-account\n@include common-session";

--- a/test-framework/sudo-test/src/lib.rs
+++ b/test-framework/sudo-test/src/lib.rs
@@ -77,15 +77,6 @@ pub fn sudo_version() -> SudoVersion {
     }
 }
 
-/// Location of the sudo pam config
-pub const PAM_D_SUDO_PATH: &str = "/etc/pam.d/sudo";
-/// The default `/etc/pam.d/sudo` on Debian
-pub const STOCK_PAM_D_SUDO: &str = "#%PAM-1.0\nsession    required   pam_limits.so\n@include common-auth\n@include common-account\n@include common-session-noninteractive";
-/// Location of the su pam config
-pub const PAM_D_SU_PATH: &str = "/etc/pam.d/su";
-/// The default `/etc/pam.d/su` on Debian
-pub const STOCK_PAM_D_SU: &str = "#%PAM-1.0\nauth       sufficient pam_rootok.so\nsession    optional   pam_mail.so nopen\nsession    required   pam_limits.so\n@include common-auth\n@include common-account\n@include common-session";
-
 enum SudoUnderTest {
     Ours,
     Theirs,
@@ -130,9 +121,11 @@ pub fn Env(sudoers: impl Into<TextFile>) -> EnvBuilder {
         .insert_str(0, "Defaults !fqdn, !lecture, !mailerpath\n");
     builder.file(ETC_SUDOERS, sudoers);
 
-    // Ubuntu uses pam_env to set a bunch of extra env vars that various tests don't expect to be set.
-    builder.default_file(PAM_D_SUDO_PATH, STOCK_PAM_D_SUDO);
-    builder.default_file(PAM_D_SU_PATH, STOCK_PAM_D_SU);
+    if cfg!(target_os = "linux") {
+        // Ubuntu uses pam_env to set a bunch of extra env vars that various tests don't expect to be set.
+        builder.default_file(PAM_D_SUDO_PATH, STOCK_PAM_D_SUDO);
+        builder.default_file(PAM_D_SU_PATH, STOCK_PAM_D_SU);
+    }
 
     if cfg!(target_os = "freebsd") {
         // Many tests expect the users group to exist, but FreeBSD doesn't actually use it.


### PR DESCRIPTION
Breakage has crept in due to the stock PAM config files being in the wrong format. Since they are only used for `pam_env.so` tests and those don't run on FreeBSD, I've disabled the lines that put them in.

To be able to also totally undefine them for FreeBSD, I've also gated the pam_env.so tests entirely instead of just conditionally ignoring them (which still forces the compiler to check for the symbols).