### PR TITLE
README: clarify that Alpine does package su

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ apk add sudo-rs
 
 This will install the `sudo`, `visudo` and `sudoedit` commands (but not replace `su`, which is still offered through BusyBox).
 
+To install the `sudo-rs` version of `su`, which is packaged separately, run:
+
+```sh
+apk add sudo-rs-su
+```
+
 ### Installing our pre-compiled x86-64 binaries
 
 You can also switch to sudo-rs manually by using our pre-compiled tarballs.


### PR DESCRIPTION
The version of su from sudo-rs is packaged in Alpine and installable, it is just not part of the main sudo-rs package, but is under sudo-rs-su. That package replaces the Busybox version with the sudo-rs one.