### PR TITLE
Show "group not found" messages on Linux

### DIFF
--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -545,7 +545,10 @@ impl Group {
                 )
             };
             match result {
-                0 => Ok(Some(buf.len())),
+                // These values signify the group doesn't exist, so send a "garbage" response
+                // that asks Rust to make no changes to the buffer size (since no actual group is filled in), triggering the
+                // `grp_ptr.is_null()` check and then cascading into a group not found message
+                0 | libc::ENOENT | libc::ESRCH | libc::EBADF | libc::EPERM => Ok(Some(buf.len())),
                 libc::ERANGE => Ok(None),
                 _ => Err(io::Error::from_raw_os_error(result)),
             }
@@ -593,7 +596,10 @@ impl Group {
                 )
             };
             match result {
-                0 => Ok(Some(buf.len())),
+                // These values signify the group doesn't exist, so send a "garbage" response
+                // that asks Rust to make no changes to the buffer size (since no actual group is filled in), triggering the
+                // `grp_ptr.is_null()` check and then cascading into a group not found message
+                0 | libc::ENOENT | libc::ESRCH | libc::EBADF | libc::EPERM => Ok(Some(buf.len())),
                 libc::ERANGE => Ok(None),
                 _ => Err(io::Error::from_raw_os_error(result)),
             }
@@ -932,6 +938,13 @@ mod tests {
             assert_eq!(root.gid, id);
             assert_eq!(root.name.unwrap(), name);
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_group_lookup_fails_gracefully() {
+        assert_eq!(Group::from_gid(GroupId::new(32767)).unwrap(), None);
+        assert_eq!(Group::from_name(c"nosuchgroupexists").unwrap(), None);
     }
 
     #[test]

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -938,7 +938,6 @@ mod tests {
         }
     }
 
-    #[cfg(target_os = "linux")]
     #[test]
     fn test_group_lookup_fails_gracefully() {
         assert_eq!(Group::from_gid(GroupId::new(32767)).unwrap(), None);

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -545,10 +545,10 @@ impl Group {
                 )
             };
             match result {
-                // These values signify the group doesn't exist, so send a "garbage" response
-                // that asks Rust to make no changes to the buffer size (since no actual group is filled in), triggering the
-                // `grp_ptr.is_null()` check and then cascading into a group not found message
-                0 | libc::ENOENT | libc::ESRCH | libc::EBADF | libc::EPERM => Ok(Some(buf.len())),
+                // These values signify the lookup could reach a conclusion (either the group exists,
+                // or it clearly doesn't). So don't try to increase the buffer size. If the group wasn't found,
+                // `grp_ptr` is set to NULL per the man page.
+                0 | libc::ENOENT => Ok(Some(buf.len())),
                 libc::ERANGE => Ok(None),
                 _ => Err(io::Error::from_raw_os_error(result)),
             }
@@ -596,10 +596,8 @@ impl Group {
                 )
             };
             match result {
-                // These values signify the group doesn't exist, so send a "garbage" response
-                // that asks Rust to make no changes to the buffer size (since no actual group is filled in), triggering the
-                // `grp_ptr.is_null()` check and then cascading into a group not found message
-                0 | libc::ENOENT | libc::ESRCH | libc::EBADF | libc::EPERM => Ok(Some(buf.len())),
+                // As above
+                0 | libc::ENOENT => Ok(Some(buf.len())),
                 libc::ERANGE => Ok(None),
                 _ => Err(io::Error::from_raw_os_error(result)),
             }


### PR DESCRIPTION
Previously, if an incorrect group was specified using a command like `./target/release/sudo -u#1 -g#555 id`, the user was shown the following error message on some Ubuntu Linux installations

```
sudo: IO error: No such file or directory (os error 2)
```

This occurred because we were only showing the existing group not found message when the `getgrgid_r()` and `getgrnam_r()` functions returned 0. However, per the docs, the functions can also return ENOENT, ESRCH, EBADF, or EPERM, among others.

This patch adds the other documented failure return values to the "return 0" case so that sudo-rs returns a more informative error message on some Ubuntu Linux installs when a group is not found.