### PR TITLE
chore: remove deprecated sudoedit feature from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,6 @@ dev = []
 # compilation using "cargo --all-features", which should not be used on sudo-rs
 do-not-use-all-features = []
 
-# sudoedit support is now always enabled. this feature only exists for back compat reasons
-sudoedit = []
-
 [profile.release]
 strip = "symbols"
 lto = true


### PR DESCRIPTION
Removes the `sudoedit` feature from `Cargo.toml` as requested in #1630.

Deprecated since 0.2.11 when sudoedit became permanently enabled, so
removing the flag has no functional consequences.

Closes #1630