### PR TITLE
Implement `log_allowed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Exceptions to the above, with respect to your `/etc/sudoers` configuration:
 * `timestamp_type` is always set at `tty`.
 * `sudoedit_checkdir` is always `on`, and `sudoedit_follow` is always `off`.
 * `logfile` is not supported --- logging is always done via syslog.
+* `log_denied` is ignored -- denied invocations are always logged.
 
 Some other notable restrictions to be aware of:
 

--- a/docs/man/sudoers.5.md
+++ b/docs/man/sudoers.5.md
@@ -379,11 +379,17 @@ sudo's behavior can be modified by Default_Entry lines, as explained earlier.  A
 
 ### Boolean Flags:
 
+* log_allowed
+
+  If set, sudoers will log commands allowed by the policy to the system log.
+  This flag is on by default.
+
 * noexec
 
   If set, all commands run via sudo will behave as if the NOEXEC tag has been set, unless overridden by an EXEC tag.  See the description of EXEC and NOEXEC as well as the *Preventing shell escapes* section at the end of this manual.  This flag is off by default.
 
 * noninteractive_auth
+
   If set, authentication will be attempted even in non-interactive mode (when sudo's -n option is specified).  This allows authentication methods that don't require user interaction to succeed.  Authentication methods that require input from the user's terminal will still fail.  If disabled, authentication will not be attempted in non-interactive mode.  This flag is off by default.
 
 * env_editor

--- a/src/defaults/mod.rs
+++ b/src/defaults/mod.rs
@@ -45,6 +45,9 @@ defaults! {
     noexec                    = false
     noninteractive_auth       = false
 
+    log_allowed               = true
+    log_denied                = true #ignored
+
     insults                   = false  #ignored
 
     setenv                    = false

--- a/src/defaults/settings_dsl.rs
+++ b/src/defaults/settings_dsl.rs
@@ -147,16 +147,16 @@ macro_rules! emit {
 macro_rules! defaults {
     ($($name:ident = $value:tt $((!= $negate:tt))? $([$($key:ident),*])? $([$first:literal ..= $last:literal$(; radix: $radix: expr)?])? $({$fn: expr})? $(#$attribute:ident)?)*) => {
         #[allow(non_camel_case_types)]
-        pub mod enums {
+        pub(crate) mod enums {
             $($(
                 #[derive(Clone,Copy,Debug,Default)]
                 #[cfg_attr(test, derive(PartialEq, Eq))]
-                pub enum $name { #[default] $($key),* }
+                pub(crate) enum $name { #[default] $($key),* }
             )?)*
         }
 
         #[derive(Clone)]
-        pub struct Settings {
+        pub(crate) struct Settings {
             $($name: storage_of!($name, $(=int $fn;)?$(=int $first;)?$($(=enum $key;)*)? $value)),*
         }
 
@@ -164,7 +164,7 @@ macro_rules! defaults {
         impl Settings {
             $(
             emit! { $($attribute)?;
-                pub fn $name(&self) -> referent_of!($name, $(=int $fn;)?$(=int $first;)?$($(=enum $key;)*)? $value) {
+                pub(crate) fn $name(&self) -> referent_of!($name, $(=int $fn;)?$(=int $first;)?$($(=enum $key;)*)? $value) {
                     result_of!(self.$name, $(=value $fn;)?$(=value $first;)?$($(=value $key;)*)? $value)
                 }
             }
@@ -179,7 +179,7 @@ macro_rules! defaults {
             }
         }
 
-        pub fn negate(name: &str) -> Option<SettingsModifier> {
+        pub(crate) fn negate(name: &str) -> Option<SettingsModifier> {
             match name {
                 $(
                 stringify!($name) if ifdef!($($negate)?; true; has_standard_negator!($value)) => {
@@ -196,7 +196,7 @@ macro_rules! defaults {
             }
         }
 
-        pub fn set(name: &str) -> Option<SettingKind> {
+        pub(crate) fn set(name: &str) -> Option<SettingKind> {
             match name {
             $(
                 stringify!($name) => Some(modifier_of!($name, $(=int $fn;)?$(=int $first ..= $last $(@ $radix)?;)?$($(=enum $key;)*)? $value)),

--- a/src/defaults/settings_dsl.rs
+++ b/src/defaults/settings_dsl.rs
@@ -147,7 +147,7 @@ macro_rules! emit {
 macro_rules! defaults {
     ($($name:ident = $value:tt $((!= $negate:tt))? $([$($key:ident),*])? $([$first:literal ..= $last:literal$(; radix: $radix: expr)?])? $({$fn: expr})? $(#$attribute:ident)?)*) => {
         #[allow(non_camel_case_types)]
-        mod enums {
+        pub mod enums {
             $($(
                 #[derive(Clone,Copy,Debug,Default)]
                 #[cfg_attr(test, derive(PartialEq, Eq))]

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -1,18 +1,21 @@
 use self::simple_logger::SimpleLogger;
 use self::syslog::Syslog;
 use std::fmt;
-use std::ops::Deref;
 use std::sync::OnceLock;
 
 mod simple_logger;
 mod syslog;
 
 macro_rules! logger_macro {
-    ($name:ident is $rule_level:ident to $target:literal with $filter:ident, $d:tt) => {
+    ($name:ident is $rule_level:ident to $target:ident with $filter:ident, $d:tt) => {
         macro_rules! $name {
             ($d($d arg:tt)+) => {
                 if let Some(logger) = $crate::log::LOGGER.get() {
-                    logger.log($crate::log::Level::$rule_level, $target, $filter!($d($d arg)+));
+                    logger.log(
+                        $crate::log::Level::$rule_level,
+                        $crate::log::Sink::$target,
+                        $filter!($d($d arg)+)
+                    );
                 }
             };
         }
@@ -20,30 +23,27 @@ macro_rules! logger_macro {
         pub(crate) use $name;
     };
 
-    ($name:ident is $rule_level:ident to $target:literal with $filter:ident) => {
+    ($name:ident is $rule_level:ident to $target:ident with $filter:ident) => {
         logger_macro!($name is $rule_level to $target with $filter, $);
     };
 }
 
-// logger_macro!(auth_error is Error to "sudo::auth");
-logger_macro!(auth_warn is Warn to "sudo::auth" with format_args);
-logger_macro!(auth_info is Info to "sudo::auth" with format_args);
-// logger_macro!(auth_debug is Debug to "sudo::auth" with format_args);
+logger_macro!(auth_warn is Warn to AuthLog with format_args);
+logger_macro!(auth_info is Info to AuthLog with format_args);
 
-logger_macro!(user_error is Error to "sudo::user" with xlat);
-logger_macro!(user_warn is Warn to "sudo::user" with xlat);
-logger_macro!(user_info is Info to "sudo::user" with xlat);
-// logger_macro!(user_debug is Debug to "sudo::user" with xlat);
+logger_macro!(user_error is Error to User with xlat);
+logger_macro!(user_warn is Warn to User with xlat);
+logger_macro!(user_info is Info to User with xlat);
 
 macro_rules! dev_logger_macro {
-    ($name:ident is $rule_level:ident to $target:expr, $d:tt) => {
+    ($name:ident is $rule_level:ident, $d:tt) => {
         macro_rules! $name {
             ($d($d arg:tt)+) => {
                 if std::cfg!(feature = "dev") {
                     if let Some(logger) = $crate::log::LOGGER.get() {
                         logger.log(
                             $crate::log::Level::$rule_level,
-                            $target,
+                            $crate::log::Sink::DevLog,
                             format_args!("{}: {}",
                                 std::panic::Location::caller(),
                                 format_args!($d($d arg)+)
@@ -56,29 +56,28 @@ macro_rules! dev_logger_macro {
 
         pub(crate) use $name;
     };
-    ($name:ident is $rule_level:ident to $target:expr) => {
-        dev_logger_macro!($name is $rule_level to $target, $);
+    ($name:ident is $rule_level:ident) => {
+        dev_logger_macro!($name is $rule_level, $);
     };
 }
 
-dev_logger_macro!(dev_error is Error to "sudo::dev");
-dev_logger_macro!(dev_warn is Warn to "sudo::dev");
-dev_logger_macro!(dev_info is Info to "sudo::dev");
-dev_logger_macro!(dev_debug is Debug to "sudo::dev");
-//dev_logger_macro!(dev_trace is Trace to "sudo::dev");
+dev_logger_macro!(dev_error is Error);
+dev_logger_macro!(dev_warn is Warn);
+dev_logger_macro!(dev_info is Info);
+dev_logger_macro!(dev_debug is Debug);
 
 pub static LOGGER: OnceLock<SudoLogger> = OnceLock::new();
 
 #[derive(Default)]
-pub struct SudoLogger(Vec<(String, Box<dyn Log>)>);
+pub struct SudoLogger(Vec<(Sink, Box<dyn Log>)>);
 
 impl SudoLogger {
     pub fn new(prefix: &'static str) -> Self {
         let mut logger: Self = Default::default();
 
-        logger.add_logger("sudo::auth", Syslog);
+        logger.add_logger(Sink::AuthLog, Syslog);
 
-        logger.add_logger("sudo::user", SimpleLogger::to_stderr(prefix));
+        logger.add_logger(Sink::User, SimpleLogger::to_stderr(prefix));
 
         #[cfg(feature = "dev")]
         {
@@ -87,7 +86,7 @@ impl SudoLogger {
                 .unwrap_or_else(|| {
                     std::env::temp_dir().join(format!("sudo-dev-{}.log", std::process::id()))
                 });
-            logger.add_logger("sudo::dev", SimpleLogger::to_file(path, "").unwrap());
+            logger.add_logger(Sink::DevLog, SimpleLogger::to_file(path, "").unwrap());
         }
 
         logger
@@ -100,38 +99,36 @@ impl SudoLogger {
     }
 
     /// Add a logger for a specific prefix to the stack
-    fn add_logger(
-        &mut self,
-        prefix: impl ToString + Deref<Target = str>,
-        logger: impl Log + 'static,
-    ) {
-        let prefix = if prefix.ends_with("::") {
-            prefix.to_string()
-        } else {
-            // given a prefix `my::prefix`, we want to match `my::prefix::somewhere`
-            // but not `my::prefix_to_somewhere`
-            format!("{}::", prefix.to_string())
-        };
-        self.0.push((prefix, Box::new(logger)))
+    fn add_logger(&mut self, sink: Sink, logger: impl Log + 'static) {
+        self.0.push((sink, Box::new(logger)))
     }
 }
 
 impl SudoLogger {
-    pub fn log(&self, level: Level, target: &str, args: impl fmt::Display) {
-        for (prefix, l) in self.0.iter() {
-            if target == &prefix[..prefix.len() - 2] || target.starts_with(prefix) {
+    pub fn log(&self, level: Level, target: Sink, args: impl fmt::Display) {
+        for (sink, l) in self.0.iter() {
+            if target == *sink {
                 l.log(level, &args);
             }
         }
     }
 }
 
+#[repr(u32)]
+#[derive(PartialEq)]
+pub enum Sink {
+    AuthLog = crate::common::HARDENED_ENUM_VALUE_0,
+    User = crate::common::HARDENED_ENUM_VALUE_1,
+    DevLog = crate::common::HARDENED_ENUM_VALUE_2,
+}
+
+#[repr(u32)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Level {
-    Error,
-    Warn,
-    Info,
-    Debug,
+    Error = crate::common::HARDENED_ENUM_VALUE_0,
+    Warn = crate::common::HARDENED_ENUM_VALUE_1,
+    Info = crate::common::HARDENED_ENUM_VALUE_2,
+    Debug = crate::common::HARDENED_ENUM_VALUE_3,
 }
 
 trait Log: Send + Sync {

--- a/src/sudo/env/environment.rs
+++ b/src/sudo/env/environment.rs
@@ -281,6 +281,7 @@ mod tests {
                         #[cfg(feature = "apparmor")]
                         apparmor_profile: None,
                         noexec: false,
+                        log: crate::sudoers::Logging::Auth,
                     }
                 ),
                 expected,

--- a/src/sudo/env/tests.rs
+++ b/src/sudo/env/tests.rs
@@ -174,6 +174,7 @@ fn test_environment_variable_filtering() {
                 #[cfg(feature = "apparmor")]
                 apparmor_profile: None,
                 noexec: false,
+                log: crate::sudoers::Logging::Auth,
             },
         )
         .unwrap();

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -9,7 +9,9 @@ use crate::log::{auth_info, auth_warn};
 use crate::pam::PamContext;
 use crate::sudo::env::environment;
 use crate::sudo::pam::{InitPamArgs, attempt_authenticate, init_pam, pre_exec};
-use crate::sudoers::{AuthenticatingUser, Authentication, Authorization, Judgement, Sudoers};
+use crate::sudoers::{
+    AuthenticatingUser, Authentication, Authorization, Judgement, Logging, Sudoers,
+};
 use crate::system::term::current_tty_name;
 use crate::system::timestamp::{RecordScope, SessionRecordFile, TouchResult};
 use crate::system::{Process, escape_os_str_lossy};
@@ -113,7 +115,7 @@ pub fn run(mut cmd_opts: SudoRunOptions) -> Result<(), Error> {
     let options = context.try_as_run_options(&controls)?;
 
     // Log after try_as_run_options to avoid logging if the command is not resolved
-    log_command_execution(&context);
+    log_command_execution(controls.log, &context);
 
     // run command and return corresponding exit code
     let command_exit_reason = crate::exec::run_command(options, target_env)
@@ -265,7 +267,10 @@ impl AuthStatus {
     }
 }
 
-fn log_command_execution(context: &Context) {
+fn log_command_execution(log: Logging, context: &Context) {
+    if matches!(log, Logging::Disabled) {
+        return;
+    }
     let tty_info = if let Ok(tty_name) = current_tty_name() {
         format!("TTY={} ;", escape_os_str_lossy(&tty_name))
     } else {

--- a/src/sudo/pipeline/edit.rs
+++ b/src/sudo/pipeline/edit.rs
@@ -11,7 +11,7 @@ pub fn run_edit(edit_opts: SudoEditOptions) -> Result<(), Error> {
 
     let policy = super::judge(policy, &context)?;
 
-    let Authorization::Allowed(auth, _controls) = policy.authorization() else {
+    let Authorization::Allowed(auth, controls) = policy.authorization() else {
         return Err(Error::Authorization(context.current_user.name.to_string()));
     };
 
@@ -54,7 +54,7 @@ pub fn run_edit(edit_opts: SudoEditOptions) -> Result<(), Error> {
 
     // run command and return corresponding exit code
     let command_exit_reason = {
-        super::log_command_execution(&context);
+        super::log_command_execution(controls.log, &context);
 
         let editor = policy.preferred_editor();
 

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -76,7 +76,9 @@ pub struct Judgement {
 
 mod policy;
 
-pub use policy::{AuthenticatingUser, Authentication, Authorization, DirChange, Restrictions};
+pub use policy::{
+    AuthenticatingUser, Authentication, Authorization, DirChange, Logging, Restrictions,
+};
 
 pub use self::entry::Entry;
 

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -9,7 +9,7 @@ use crate::common::{
     HARDENED_ENUM_VALUE_0, HARDENED_ENUM_VALUE_1, HARDENED_ENUM_VALUE_2, SudoPath,
 };
 use crate::exec::Umask;
-use crate::sudoers::ast::{ExecControl, Tag};
+use crate::sudoers::ast::{EnvironmentControl, ExecControl, Tag};
 use crate::system::{Hostname, User};
 use std::collections::HashSet;
 use std::time::Duration;
@@ -111,9 +111,9 @@ impl Judgement {
                 Restrictions {
                     use_pty: self.settings.use_pty(),
                     trust_environment: match tag.env {
-                        super::EnvironmentControl::Implicit => self.settings.setenv(),
-                        super::EnvironmentControl::Setenv => true,
-                        super::EnvironmentControl::Nosetenv => false,
+                        EnvironmentControl::Implicit => self.settings.setenv(),
+                        EnvironmentControl::Setenv => true,
+                        EnvironmentControl::Nosetenv => false,
                     },
                     noexec: match tag.noexec {
                         ExecControl::Implicit => self.settings.noexec(),

--- a/src/sudoers/policy.rs
+++ b/src/sudoers/policy.rs
@@ -69,6 +69,7 @@ pub struct Restrictions<'a> {
     pub chdir: DirChange,
     pub path: Option<&'a str>,
     pub umask: Umask,
+    pub log: Logging,
     #[cfg(feature = "apparmor")]
     pub apparmor_profile: Option<String>,
 }
@@ -79,6 +80,14 @@ pub struct Restrictions<'a> {
 pub enum DirChange {
     Strict(Option<SudoPath>) = HARDENED_ENUM_VALUE_0,
     Any = HARDENED_ENUM_VALUE_1,
+}
+
+#[must_use]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[repr(u32)]
+pub enum Logging {
+    Auth = HARDENED_ENUM_VALUE_0,
+    Disabled = HARDENED_ENUM_VALUE_1,
 }
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
@@ -137,6 +146,11 @@ impl Judgement {
                         } else {
                             Umask::Extend(mask)
                         }
+                    },
+                    log: if self.settings.log_allowed() {
+                        Logging::Auth
+                    } else {
+                        Logging::Disabled
                     },
                     #[cfg(feature = "apparmor")]
                     apparmor_profile: tag

--- a/test-framework/sudo-compliance-tests/src/sudo/syslog.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/syslog.rs
@@ -4,7 +4,26 @@ use crate::{SUDOERS_ALL_ALL_NOPASSWD, SUDOERS_USER_ALL_ALL, USERNAME, helpers::R
 
 #[test]
 fn sudo_logs_every_executed_command() {
-    let env = Env(SUDOERS_ALL_ALL_NOPASSWD).build();
+    for log_allowed in ["", "Defaults log_allowed"] {
+        let env = Env([log_allowed, SUDOERS_ALL_ALL_NOPASSWD]).build();
+        let rsyslog = Rsyslogd::start(&env);
+
+        let auth_log = rsyslog.auth_log();
+        assert_eq!("", auth_log);
+
+        Command::new("sudo")
+            .arg("true")
+            .output(&env)
+            .assert_success();
+
+        let auth_log = rsyslog.auth_log();
+        assert_contains!(auth_log, format!("COMMAND={BIN_TRUE}"));
+    }
+}
+
+#[test]
+fn sudo_respects_log_allowed() {
+    let env = Env(["Defaults !log_allowed", SUDOERS_ALL_ALL_NOPASSWD]).build();
     let rsyslog = Rsyslogd::start(&env);
 
     let auth_log = rsyslog.auth_log();
@@ -16,7 +35,7 @@ fn sudo_logs_every_executed_command() {
         .assert_success();
 
     let auth_log = rsyslog.auth_log();
-    assert_contains!(auth_log, format!("COMMAND={BIN_TRUE}"));
+    assert_not_contains!(auth_log, format!("COMMAND="));
 }
 
 #[test]


### PR DESCRIPTION
Closes #1181 

As discussed we only support `log_allowed`. The first few commits implement that.

While working on this I also saw that our logging infrastructure was a bit over-engineered so I simplified that as well.

The final commit were nitpicks discovered during this process which I'm going to leave in under the "boy scout rule".

(This work was done in April)