### PR TITLE
Enable clippy::uninlined_format_args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,4 @@ unsafe_op_in_unsafe_fn = { level = "deny" }
 
 [lints.clippy]
 undocumented_unsafe_blocks = "warn"
+uninlined_format_args = "warn"

--- a/src/log/syslog.rs
+++ b/src/log/syslog.rs
@@ -140,7 +140,7 @@ impl Log for Syslog {
         };
 
         let mut writer = SysLogMessageWriter::new(priority, FACILITY);
-        let _ = write!(writer, "{}", args);
+        let _ = write!(writer, "{args}");
     }
 }
 


### PR DESCRIPTION
While this is a pedantic lint, we were already following it and enabling the lint will enforce consistency for this.