### PR TITLE
Refactor check_user and check_group

### DIFF
--- a/src/sudoers/ast.rs
+++ b/src/sudoers/ast.rs
@@ -45,6 +45,15 @@ pub enum Identifier {
     ID(u32) = HARDENED_ENUM_VALUE_1,
 }
 
+impl std::fmt::Display for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            Self::Name(name) => write!(f, "{name}"),
+            Self::ID(id) => write!(f, "#{id}"),
+        }
+    }
+}
+
 /// A userspecifier is either a username, or a (non-unix) group name, or netgroup
 #[cfg_attr(test, derive(Clone, Debug, PartialEq, Eq))]
 #[repr(u32)]

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -421,12 +421,14 @@ fn open_remote_sudoers(
         class: &str,
         ident: &Identifier,
     ) -> io::Result<T> {
-        obj.ok().flatten().ok_or_else(|| {
-            io::Error::new(
+        if let Ok(Some(inner)) = obj {
+            Ok(inner)
+        } else {
+            Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!("{class} '{ident}' not found"),
-            )
-        })
+            ))
+        }
     }
 
     let user = match &peer.user {

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -25,8 +25,6 @@ use ast::*;
 use tokens::*;
 
 pub type Settings = defaults::Settings;
-#[cfg(feature = "unstable-remote-sudoers")]
-pub use ast::{Identifier, PeerSpec, UserSpecifier};
 pub use basic_parser::Span;
 
 /// How many nested include files do we allow?
@@ -414,9 +412,46 @@ fn open_sudoers(path: &Path) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
 #[cfg(feature = "unstable-remote-sudoers")]
 fn open_remote_sudoers(
     path: &Path,
-    peer_spec: &ast::PeerSpec,
+    peer: &PeerSpec,
 ) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
-    let source = audit::secure_open_remote_sudoers(path, peer_spec)?;
+    use system::{Group, User};
+
+    // these types deliberately don't have conversion traits defined to reduce
+    // the chance of mixing them up, but to keep things readable, let's define the common subset
+    let user_ctx = ("user", UserId::new, User::from_uid, User::from_name);
+    let group_ctx = ("group", GroupId::new, Group::from_gid, Group::from_name);
+
+    fn lookup<Id, T, E>(
+        ident: &Identifier,
+        (class, ctor, by_id, by_name): (
+            &str,
+            impl Fn(u32) -> Id,
+            impl Fn(Id) -> Result<Option<T>, E>,
+            impl Fn(&std::ffi::CStr) -> Result<Option<T>, E>,
+        ),
+    ) -> io::Result<T> {
+        match ident {
+            Identifier::ID(id) => by_id(ctor(*id)),
+            Identifier::Name(name) => by_name(name.as_cstr()),
+        }
+        .ok()
+        .flatten()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("{class} '{ident}' not found"),
+            )
+        })
+    }
+
+    let user = lookup(&peer.user, user_ctx)?.uid;
+    let group = if let Some(group) = &peer.group {
+        Some(lookup(group, group_ctx)?.gid)
+    } else {
+        None
+    };
+
+    let source = audit::secure_open_remote_sudoers(path, user, group)?;
     read_sudoers(source)
 }
 

--- a/src/sudoers/mod.rs
+++ b/src/sudoers/mod.rs
@@ -416,27 +416,12 @@ fn open_remote_sudoers(
 ) -> io::Result<Vec<basic_parser::Parsed<Sudo>>> {
     use system::{Group, User};
 
-    // these types deliberately don't have conversion traits defined to reduce
-    // the chance of mixing them up, but to keep things readable, let's define the common subset
-    let user_ctx = ("user", UserId::new, User::from_uid, User::from_name);
-    let group_ctx = ("group", GroupId::new, Group::from_gid, Group::from_name);
-
-    fn lookup<Id, T, E>(
+    fn check_validity<T, E>(
+        obj: Result<Option<T>, E>,
+        class: &str,
         ident: &Identifier,
-        (class, ctor, by_id, by_name): (
-            &str,
-            impl Fn(u32) -> Id,
-            impl Fn(Id) -> Result<Option<T>, E>,
-            impl Fn(&std::ffi::CStr) -> Result<Option<T>, E>,
-        ),
     ) -> io::Result<T> {
-        match ident {
-            Identifier::ID(id) => by_id(ctor(*id)),
-            Identifier::Name(name) => by_name(name.as_cstr()),
-        }
-        .ok()
-        .flatten()
-        .ok_or_else(|| {
+        obj.ok().flatten().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!("{class} '{ident}' not found"),
@@ -444,14 +429,23 @@ fn open_remote_sudoers(
         })
     }
 
-    let user = lookup(&peer.user, user_ctx)?.uid;
-    let group = if let Some(group) = &peer.group {
-        Some(lookup(group, group_ctx)?.gid)
-    } else {
-        None
+    let user = match &peer.user {
+        Identifier::Name(name) => User::from_name(name.as_cstr()),
+        Identifier::ID(id) => User::from_uid(UserId::new(*id)),
     };
 
-    let source = audit::secure_open_remote_sudoers(path, user, group)?;
+    let group = peer.group.as_ref().map(|group| match group {
+        Identifier::Name(name) => Group::from_name(name.as_cstr()),
+        Identifier::ID(id) => Group::from_gid(GroupId::new(*id)),
+    });
+
+    let user = check_validity(user, "user", &peer.user)?;
+
+    let group = group
+        .map(|g| check_validity(g, "group", peer.group.as_ref().unwrap()))
+        .transpose()?;
+
+    let source = audit::secure_open_remote_sudoers(path, user.uid, group.map(|x| x.gid))?;
     read_sudoers(source)
 }
 

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -17,8 +17,6 @@ use super::{
     Group, GroupId, User, UserId, cerr, inject_group, interface::UnixUser, set_supplementary_groups,
 };
 use crate::common::resolve::CurrentUser;
-#[cfg(feature = "unstable-remote-sudoers")]
-use crate::sudoers::{Identifier, PeerSpec};
 
 #[cfg(target_os = "linux")]
 pub(crate) fn no_new_privs_enabled() -> io::Result<bool> {
@@ -170,9 +168,10 @@ pub fn secure_open_sudoers(path: impl AsRef<Path>) -> io::Result<File> {
 #[cfg(feature = "unstable-remote-sudoers")]
 pub fn secure_open_remote_sudoers(
     path: impl AsRef<Path>,
-    peer_spec: &PeerSpec,
+    user: UserId,
+    group: Option<GroupId>,
 ) -> io::Result<BufReader<UnixStream>> {
-    secure_open_socket_impl(path.as_ref(), peer_spec)
+    secure_open_socket_impl(path.as_ref(), user, group)
 }
 
 /// Open a timestamp cookie file using various security checks
@@ -268,27 +267,10 @@ fn secure_open_impl(
 }
 
 #[cfg(feature = "unstable-remote-sudoers")]
-fn check_peer<Id>(
-    peer_identity: Id,
-    expected: Option<&Identifier>,
-    class: &str,
-    lookup: impl Fn(&CStr) -> Option<Id>,
-    from_u32: impl Fn(u32) -> Id,
-) -> io::Result<()>
+fn check_peer<Id>(peer_identity: Id, expected: Id, class: &str) -> io::Result<()>
 where
-    Id: std::fmt::Display + Copy + PartialEq,
+    Id: std::fmt::Display + PartialEq,
 {
-    let expected = match expected {
-        Some(Identifier::Name(name)) => lookup(name.as_cstr()).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("{class} '{name}' not found"),
-            )
-        })?,
-        Some(Identifier::ID(id)) => from_u32(*id),
-        None => return Ok(()),
-    };
-
     if peer_identity == expected {
         Ok(())
     } else {
@@ -299,32 +281,14 @@ where
     }
 }
 
-#[cfg(feature = "unstable-remote-sudoers")]
-fn check_group(peer_gid: GroupId, maybe_group: Option<&Identifier>) -> io::Result<()> {
-    check_peer(
-        peer_gid,
-        maybe_group,
-        "group",
-        |name| Group::from_name(name).ok().flatten().map(|x| x.gid),
-        GroupId::new,
-    )
-}
-
-#[cfg(feature = "unstable-remote-sudoers")]
-fn check_user(peer_uid: UserId, user: &Identifier) -> io::Result<()> {
-    check_peer(
-        peer_uid,
-        Some(user),
-        "user",
-        |name| User::from_name(name).ok().flatten().map(|x| x.uid),
-        UserId::new,
-    )
-}
-
 // Open the socket at path, provided that it is "secure".
 // "Secure" means that it passes the `checks` function above.
 #[cfg(feature = "unstable-remote-sudoers")]
-fn secure_open_socket_impl(path: &Path, peer_spec: &PeerSpec) -> io::Result<BufReader<UnixStream>> {
+fn secure_open_socket_impl(
+    path: &Path,
+    user: UserId,
+    group: Option<GroupId>,
+) -> io::Result<BufReader<UnixStream>> {
     // Check the metadata on the filesystem as extra security,
     // even knowing that it produces a TOCTOU.
     let meta = fs::metadata(path)?;
@@ -348,8 +312,10 @@ fn secure_open_socket_impl(path: &Path, peer_spec: &PeerSpec) -> io::Result<BufR
 
     // If there is an error in these checks, the function returns immediately
     // leaving `stream` out of scope and forcing the closing of the socket.
-    check_user(UserId::new(peer_creds.uid), &peer_spec.user)?;
-    check_group(GroupId::new(peer_creds.gid), peer_spec.group.as_ref())?;
+    check_peer(UserId::new(peer_creds.uid), user, "user")?;
+    if let Some(group) = group {
+        check_peer(GroupId::new(peer_creds.gid), group, "group")?;
+    }
 
     stream.shutdown(Shutdown::Write)?;
     let reader = BufReader::new(stream);

--- a/src/system/audit.rs
+++ b/src/system/audit.rs
@@ -268,75 +268,57 @@ fn secure_open_impl(
 }
 
 #[cfg(feature = "unstable-remote-sudoers")]
-fn check_user(peer_uid: libc::uid_t, user_id: &Identifier) -> io::Result<()> {
-    match user_id {
-        Identifier::Name(name) => {
-            let name_cstr = CString::new(name.as_ref()).map_err(|_| {
-                io::Error::new(io::ErrorKind::InvalidInput, "user name contains null byte")
-            })?;
-            let expected_user = User::from_name(&name_cstr)
-                .map_err(|e| io::Error::other(e.to_string()))?
-                .ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::NotFound, format!("user '{name}' not found"))
-                })?;
-            if peer_uid != expected_user.uid.inner() {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    format!(
-                        "peer process must run as user '{name}' (uid {}) but runs as {peer_uid}",
-                        expected_user.uid.inner()
-                    ),
-                ));
-            }
-        }
-        Identifier::ID(uid) => {
-            if peer_uid != *uid {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    format!("peer process must run as uid {uid} but runs as {peer_uid}"),
-                ));
-            }
-        }
+fn check_peer<Id>(
+    peer_identity: Id,
+    expected: Option<&Identifier>,
+    class: &str,
+    lookup: impl Fn(&CStr) -> Option<Id>,
+    from_u32: impl Fn(u32) -> Id,
+) -> io::Result<()>
+where
+    Id: std::fmt::Display + Copy + PartialEq,
+{
+    let expected = match expected {
+        Some(Identifier::Name(name)) => lookup(name.as_cstr()).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("{class} '{name}' not found"),
+            )
+        })?,
+        Some(Identifier::ID(id)) => from_u32(*id),
+        None => return Ok(()),
+    };
+
+    if peer_identity == expected {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("peer process must run as {class} {expected} but runs as {peer_identity}"),
+        ))
     }
-    Ok(())
 }
 
 #[cfg(feature = "unstable-remote-sudoers")]
-fn check_group(peer_gid: libc::gid_t, group_id: Option<&Identifier>) -> io::Result<()> {
-    let Some(group_id) = group_id else {
-        return Ok(());
-    };
+fn check_group(peer_gid: GroupId, maybe_group: Option<&Identifier>) -> io::Result<()> {
+    check_peer(
+        peer_gid,
+        maybe_group,
+        "group",
+        |name| Group::from_name(name).ok().flatten().map(|x| x.gid),
+        GroupId::new,
+    )
+}
 
-    match group_id {
-        Identifier::Name(name) => {
-            let name_cstr = CString::new(name.as_ref()).map_err(|_| {
-                io::Error::new(io::ErrorKind::InvalidInput, "group name contains null byte")
-            })?;
-            let expected_group = Group::from_name(&name_cstr)
-                .map_err(|e| io::Error::other(e.to_string()))?
-                .ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::NotFound, format!("group '{name}' not found"))
-                })?;
-            if peer_gid != expected_group.gid.inner() {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    format!(
-                        "peer process must run as group '{name}' (gid {}) but runs as gid {peer_gid}",
-                        expected_group.gid.inner()
-                    ),
-                ));
-            }
-        }
-        Identifier::ID(gid) => {
-            if peer_gid != *gid {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    format!("peer process must run as gid {gid} but runs as {peer_gid}"),
-                ));
-            }
-        }
-    }
-    Ok(())
+#[cfg(feature = "unstable-remote-sudoers")]
+fn check_user(peer_uid: UserId, user: &Identifier) -> io::Result<()> {
+    check_peer(
+        peer_uid,
+        Some(user),
+        "user",
+        |name| User::from_name(name).ok().flatten().map(|x| x.uid),
+        UserId::new,
+    )
 }
 
 // Open the socket at path, provided that it is "secure".
@@ -366,8 +348,8 @@ fn secure_open_socket_impl(path: &Path, peer_spec: &PeerSpec) -> io::Result<BufR
 
     // If there is an error in these checks, the function returns immediately
     // leaving `stream` out of scope and forcing the closing of the socket.
-    check_user(peer_creds.uid, &peer_spec.user)?;
-    check_group(peer_creds.gid, peer_spec.group.as_ref())?;
+    check_user(UserId::new(peer_creds.uid), &peer_spec.user)?;
+    check_group(GroupId::new(peer_creds.gid), peer_spec.group.as_ref())?;
 
     stream.shutdown(Shutdown::Write)?;
     let reader = BufReader::new(stream);


### PR DESCRIPTION
- no null byte check is necessary on the SudoString in an identifier
- use GroupId/UserId for extra code safety
- we shouldn't propagate errors upwards because it always ends up confusing for the user; if an I/O error occurs when looking up a group/user, that simply means the lookup failed.

Closes #1645 