### PR TITLE
Add regr test for SIGTTOU deadlock

### DIFF
--- a/test-framework/e2e-tests/src/regression.rs
+++ b/test-framework/e2e-tests/src/regression.rs
@@ -1,3 +1,6 @@
+use std::sync::mpsc;
+use std::time::Duration;
+
 use sudo_test::{Command, Env, TextFile, User};
 
 #[test]
@@ -86,5 +89,62 @@ fn correct_password_with_tab() {
             .as_user(username)
             .output(&env)
             .assert_success();
+    }
+}
+
+#[test]
+fn sigttou_in_foreground_does_not_deadlock_sudo() {
+    let inner_sh = "\
+for _ in 1 2 3 4; do
+    kill -TTOU $$
+done
+echo did-not-deadlock
+";
+
+    let launch_pl = r#"use strict;
+use warnings;
+use POSIX ();
+
+my $pid = fork();
+die "fork failed: $!" unless defined $pid;
+if ($pid == 0) {
+    POSIX::setpgid(0, 0) or die "setpgid (child) failed: $!";
+    exec("sh", "-c", "sudo sh /root/inner.sh | cat") or die "exec failed: $!";
+}
+POSIX::setpgid($pid, $pid);
+eval { POSIX::tcsetpgrp(0, $pid) };
+
+waitpid($pid, 0);
+exit($? == 0 ? 0 : 1);
+"#;
+
+    let env = Env(TextFile("ALL ALL=(ALL:ALL) NOPASSWD: ALL").chmod("644"))
+        .file("/root/inner.sh", TextFile(inner_sh).chmod("755"))
+        .file("/root/launch.pl", TextFile(launch_pl).chmod("755"))
+        .build();
+
+    let child = Command::new("perl")
+        .arg("/root/launch.pl")
+        // a tty is required for sudo to run the command in a pty
+        .tty(true)
+        .spawn(&env);
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(child.wait());
+    });
+
+    match rx.recv_timeout(Duration::from_secs(30)) {
+        Ok(output) => {
+            output.assert_success();
+            assert!(
+                output.stdout_unchecked().contains("did-not-deadlock"),
+                "unexpected output: {:?}",
+                output.stdout_unchecked()
+            );
+        }
+        Err(_) => panic!(
+            "sudo deadlocked after the command was stopped twice by SIGTTOU"
+        ),
     }
 }

--- a/test-framework/e2e-tests/src/regression.rs
+++ b/test-framework/e2e-tests/src/regression.rs
@@ -1,6 +1,3 @@
-use std::sync::mpsc;
-use std::time::Duration;
-
 use sudo_test::{Command, Env, TextFile, User};
 
 #[test]
@@ -89,41 +86,5 @@ fn correct_password_with_tab() {
             .as_user(username)
             .output(&env)
             .assert_success();
-    }
-}
-
-#[test]
-fn sigttou_in_foreground_does_not_deadlock_sudo() {
-    let inner_sh = "\
-for _ in 1 2 3 4; do
-    kill -TTOU $$
-done
-echo did-not-deadlock
-";
-
-    let env = Env(TextFile("ALL ALL=(ALL:ALL) NOPASSWD: ALL").chmod("644"))
-        .file("/root/inner.sh", TextFile(inner_sh).chmod("755"))
-        .build();
-
-    let child = Command::new("bash")
-        .args(["-c", "set -m; sudo sh /root/inner.sh | cat"])
-        .tty(true)
-        .spawn(&env);
-
-    let (tx, rx) = mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = tx.send(child.wait());
-    });
-
-    match rx.recv_timeout(Duration::from_secs(30)) {
-        Ok(output) => {
-            output.assert_success();
-            assert!(
-                output.stdout_unchecked().contains("did-not-deadlock"),
-                "unexpected output: {:?}",
-                output.stdout_unchecked()
-            );
-        }
-        Err(_) => panic!("sudo deadlocked after the command was stopped twice by SIGTTOU"),
     }
 }

--- a/test-framework/e2e-tests/src/regression.rs
+++ b/test-framework/e2e-tests/src/regression.rs
@@ -101,31 +101,12 @@ done
 echo did-not-deadlock
 ";
 
-    let launch_pl = r#"use strict;
-use warnings;
-use POSIX ();
-
-my $pid = fork();
-die "fork failed: $!" unless defined $pid;
-if ($pid == 0) {
-    POSIX::setpgid(0, 0) or die "setpgid (child) failed: $!";
-    exec("sh", "-c", "sudo sh /root/inner.sh | cat") or die "exec failed: $!";
-}
-POSIX::setpgid($pid, $pid);
-eval { POSIX::tcsetpgrp(0, $pid) };
-
-waitpid($pid, 0);
-exit($? == 0 ? 0 : 1);
-"#;
-
     let env = Env(TextFile("ALL ALL=(ALL:ALL) NOPASSWD: ALL").chmod("644"))
         .file("/root/inner.sh", TextFile(inner_sh).chmod("755"))
-        .file("/root/launch.pl", TextFile(launch_pl).chmod("755"))
         .build();
 
-    let child = Command::new("perl")
-        .arg("/root/launch.pl")
-        // a tty is required for sudo to run the command in a pty
+    let child = Command::new("bash")
+        .args(["-c", "set -m; sudo sh /root/inner.sh | cat"])
         .tty(true)
         .spawn(&env);
 
@@ -143,8 +124,6 @@ exit($? == 0 ? 0 : 1);
                 output.stdout_unchecked()
             );
         }
-        Err(_) => panic!(
-            "sudo deadlocked after the command was stopped twice by SIGTTOU"
-        ),
+        Err(_) => panic!("sudo deadlocked after the command was stopped twice by SIGTTOU"),
     }
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/mod.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/child_process/signal_handling/mod.rs
@@ -1,3 +1,6 @@
+use std::sync::mpsc;
+use std::time::Duration;
+
 use pretty_assertions::assert_eq;
 use sudo_test::{Command, Env};
 
@@ -144,6 +147,42 @@ fn sigtstp_works(tty: bool) {
     let did_suspend = suspended_iterations == 1;
 
     assert!(did_suspend);
+}
+
+#[test]
+fn sigttou_in_foreground_does_not_deadlock() {
+    let inner_sh = "\
+for _ in 1 2 3 4; do
+    kill -TTOU $$
+done
+echo did-not-deadlock
+";
+
+    let env = Env([SUDOERS_ALL_ALL_NOPASSWD, SUDOERS_USE_PTY])
+        .file("/root/inner.sh", inner_sh)
+        .build();
+
+    let child = Command::new("bash")
+        .args(["-c", "set -m; sudo sh /root/inner.sh | cat"])
+        .tty(true)
+        .spawn(&env);
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(child.wait());
+    });
+
+    match rx.recv_timeout(Duration::from_secs(30)) {
+        Ok(output) => {
+            output.assert_success();
+            assert!(
+                output.stdout_unchecked().contains("did-not-deadlock"),
+                "unexpected output: {:?}",
+                output.stdout_unchecked()
+            );
+        }
+        Err(_) => panic!("sudo deadlocked after the command was stopped twice by SIGTTOU"),
+    }
 }
 
 fn sigalrm_terminates_command(tty: bool) {


### PR DESCRIPTION
Closes #1604

From what I understand from the thread; when a pty-wrapped command was stopped by `SIGTTOU` twice (while sudo was already in the foreground with the terminal in raw mode ), `suspend_pty`'s `return Some(SIGCONT_FG)` was skipped and killpg'd `SIGTTOU` to its own process group

The test starts sudo under `use_pty` in a foreground, non-orphaned* process group with stdin on a tty and stdout piped, then runs a shell command that sends `SIGTTOU` to itself several times.

\* i first tried this in docker, but this orphans a process.