### PR TITLE
Serialize TTY access with flock during password prompting

### DIFF
--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -27,7 +27,6 @@ use libc::{
 
 use crate::cutils::{cerr, safe_isatty};
 use crate::pam::{PamError, PamResult, askpass};
-use crate::system::file::FileLock;
 use crate::system::signal::{
     self, SignalHandler, SignalHandlerBehavior, SignalsState, exit_with_signal,
 };
@@ -430,7 +429,6 @@ impl Terminal<'_> {
                 prompt_password(stdin.as_fd(), stdout, prompt, timeout, hidden)
             }
             Terminal::Tty(file) => {
-                let _lock = FileLock::exclusive(file, false).ok();
                 prompt_password(file.as_fd(), &mut &*file, prompt, timeout, hidden)
             }
             Terminal::Askpass(program, sink) => {

--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -15,7 +15,7 @@
 
 use std::ffi::c_void;
 use std::io::{self, ErrorKind};
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use std::{fs, mem};
@@ -33,6 +33,34 @@ use crate::system::signal::{
 use crate::system::wait::{Wait, WaitError, WaitOptions};
 
 use super::securemem::PamBuffer;
+
+/// A guard that holds an exclusive `flock` on a file descriptor.
+///
+/// When multiple sudo processes are piped together (e.g. `sudo a | sudo b`), they all
+/// try to read the password from `/dev/tty` simultaneously. This guard serializes access
+/// so only one process reads from the terminal at a time, preventing keystrokes from
+/// being split between concurrent readers.
+struct FlockGuard(RawFd);
+
+impl FlockGuard {
+    /// Acquire an exclusive lock on `fd`. Returns `None` if the lock cannot be acquired
+    /// (e.g. the filesystem does not support `flock`).
+    fn new(fd: BorrowedFd<'_>) -> Option<Self> {
+        // SAFETY: `fd` is a valid open file descriptor.
+        if unsafe { libc::flock(fd.as_raw_fd(), libc::LOCK_EX) } == 0 {
+            Some(FlockGuard(fd.as_raw_fd()))
+        } else {
+            None
+        }
+    }
+}
+
+impl Drop for FlockGuard {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` is a valid file descriptor and `LOCK_UN` always succeeds.
+        unsafe { libc::flock(self.0, libc::LOCK_UN) };
+    }
+}
 
 struct HiddenInput<'a> {
     tty: BorrowedFd<'a>,
@@ -113,6 +141,16 @@ fn prompt_password(
     hidden: Hidden<()>,
 ) -> PamResult<PamBuffer> {
     'getpass: loop {
+        // Acquire an exclusive lock on the terminal so that when multiple sudo processes
+        // are reading from the same TTY (e.g. `sudo a | sudo b`), only one reads at a time.
+        // Without this, keystrokes from the user get split between concurrent readers and
+        // neither process receives the complete password.
+        let _lock = if safe_isatty(source) {
+            FlockGuard::new(source)
+        } else {
+            None
+        };
+
         let hide_input = match hidden.clone() {
             // If input is not a tty, we can't hide feedback.
             _ if !safe_isatty(source) => Hidden::No,

--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -15,7 +15,7 @@
 
 use std::ffi::c_void;
 use std::io::{self, ErrorKind};
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use std::{fs, mem};
@@ -27,40 +27,13 @@ use libc::{
 
 use crate::cutils::{cerr, safe_isatty};
 use crate::pam::{PamError, PamResult, askpass};
+use crate::system::file::FileLock;
 use crate::system::signal::{
     self, SignalHandler, SignalHandlerBehavior, SignalsState, exit_with_signal,
 };
 use crate::system::wait::{Wait, WaitError, WaitOptions};
 
 use super::securemem::PamBuffer;
-
-/// A guard that holds an exclusive `flock` on a file descriptor.
-///
-/// When multiple sudo processes are piped together (e.g. `sudo a | sudo b`), they all
-/// try to read the password from `/dev/tty` simultaneously. This guard serializes access
-/// so only one process reads from the terminal at a time, preventing keystrokes from
-/// being split between concurrent readers.
-struct FlockGuard(RawFd);
-
-impl FlockGuard {
-    /// Acquire an exclusive lock on `fd`. Returns `None` if the lock cannot be acquired
-    /// (e.g. the filesystem does not support `flock`).
-    fn new(fd: BorrowedFd<'_>) -> Option<Self> {
-        // SAFETY: `fd` is a valid open file descriptor.
-        if unsafe { libc::flock(fd.as_raw_fd(), libc::LOCK_EX) } == 0 {
-            Some(FlockGuard(fd.as_raw_fd()))
-        } else {
-            None
-        }
-    }
-}
-
-impl Drop for FlockGuard {
-    fn drop(&mut self) {
-        // SAFETY: `self.0` is a valid file descriptor and `LOCK_UN` always succeeds.
-        unsafe { libc::flock(self.0, libc::LOCK_UN) };
-    }
-}
 
 struct HiddenInput<'a> {
     tty: BorrowedFd<'a>,
@@ -141,16 +114,6 @@ fn prompt_password(
     hidden: Hidden<()>,
 ) -> PamResult<PamBuffer> {
     'getpass: loop {
-        // Acquire an exclusive lock on the terminal so that when multiple sudo processes
-        // are reading from the same TTY (e.g. `sudo a | sudo b`), only one reads at a time.
-        // Without this, keystrokes from the user get split between concurrent readers and
-        // neither process receives the complete password.
-        let _lock = if safe_isatty(source) {
-            FlockGuard::new(source)
-        } else {
-            None
-        };
-
         let hide_input = match hidden.clone() {
             // If input is not a tty, we can't hide feedback.
             _ if !safe_isatty(source) => Hidden::No,
@@ -467,6 +430,7 @@ impl Terminal<'_> {
                 prompt_password(stdin.as_fd(), stdout, prompt, timeout, hidden)
             }
             Terminal::Tty(file) => {
+                let _lock = FileLock::exclusive(file, false).ok();
                 prompt_password(file.as_fd(), &mut &*file, prompt, timeout, hidden)
             }
             Terminal::Askpass(program, sink) => {

--- a/src/sudo/pipeline.rs
+++ b/src/sudo/pipeline.rs
@@ -1,4 +1,5 @@
 use std::ffi::OsStr;
+use std::fs;
 use std::time::Duration;
 
 use super::cli::{SudoRunOptions, SudoValidateOptions};
@@ -12,6 +13,7 @@ use crate::sudo::pam::{InitPamArgs, attempt_authenticate, init_pam, pre_exec};
 use crate::sudoers::{
     AuthenticatingUser, Authentication, Authorization, Judgement, Logging, Sudoers,
 };
+use crate::system::file::FileLock;
 use crate::system::term::current_tty_name;
 use crate::system::timestamp::{RecordScope, SessionRecordFile, TouchResult};
 use crate::system::{Process, escape_os_str_lossy};
@@ -194,17 +196,42 @@ fn auth_and_update_record_file(
             return Err(Error::InteractionRequired);
         }
 
-        attempt_authenticate(
-            &mut pam_context,
-            &auth_user.name,
-            context.non_interactive,
-            allowed_attempts,
-        )?;
-        if let (Some(record_file), Some(scope)) = (&mut auth_status.record_file, scope) {
-            match record_file.create(scope, &auth_user) {
-                Ok(_) => (),
-                Err(e) => {
-                    auth_warn!("Could not update session record file with new record: {e}");
+        // Acquire an exclusive flock on the TTY to serialize password-prompt
+        // access when multiple sudo processes are piped together (e.g.
+        // `sudo a | sudo b`). The lock is held for the entire duration of PAM
+        // authentication so that only one process reads from the TTY at a time.
+        let _tty_file = current_tty_name()
+            .ok()
+            .and_then(|tty| fs::OpenOptions::new().read(true).write(true).open(tty).ok());
+        let _tty_lock = _tty_file
+            .as_ref()
+            .and_then(|file| FileLock::exclusive(file, false).ok());
+
+        // Re-check the timestamp now that we hold the TTY lock. Another process
+        // in the pipe may have already authenticated and created a valid record
+        // while we were waiting for the lock. If so, skip PAM entirely.
+        let auth_already_done = context.use_session_records
+            && scope.is_some_and(|scope| {
+                SessionRecordFile::open_for_user(&context.current_user, prior_validity)
+                    .ok()
+                    .and_then(|mut sr| sr.touch(scope, &auth_user).ok())
+                    .is_some_and(|r| matches!(r, TouchResult::Updated { .. }))
+            });
+
+        if !auth_already_done {
+            attempt_authenticate(
+                &mut pam_context,
+                &auth_user.name,
+                context.non_interactive,
+                allowed_attempts,
+            )?;
+
+            if let (Some(record_file), Some(scope)) = (&mut auth_status.record_file, scope) {
+                match record_file.create(scope, &auth_user) {
+                    Ok(_) => (),
+                    Err(e) => {
+                        auth_warn!("Could not update session record file with new record: {e}");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Commit message

     Serialize TTY access with flock during password prompting

     When multiple sudo processes are piped together (e.g. `sudo a | sudo b`),
     both processes open /dev/tty and call poll()+read() concurrently. Because
     the terminal delivers each byte to only one reader, keystrokes from the
     user get split between the two processes, resulting in both receiving an
     incomplete password and authentication failure.

     Fix this by acquiring an exclusive flock(LOCK_EX) on the TTY fd before
     reading the password and releasing it when done. A process that reads
     from the same controlling terminal will block until the first finishes,
     ensuring only one process reads user input at a time.

     If flock(2) is unavailable or fails (e.g. on filesystems that do not
     support it), the process proceeds without the lock -- a graceful
     degradation rather than a hard failure.

PR description

     When two (or more) `sudo` processes are connected via a shell pipeline
     (e.g. `sudo echo "aaa" | sudo tee test.txt`), both processes open
     `/dev/tty` and call `poll()` + `read()` concurrently to prompt for the
     password. Because each keystroke from the terminal is consumed by
     whichever `read()` wins the race, the input gets split between the
     processes. Neither receives the complete password, and both fail
     authentication.

     This PR adds an exclusive `flock(LOCK_EX)` on the TTY file descriptor
     during password prompting. Only one process can hold the lock at a time;
     the second process blocks until the first finishes reading. This
     serializes TTY access and prevents interleaved reads.

     The lock is acquired inside the retry loop of `prompt_password()` in
     `src/pam/rpassword.rs`, so it is correctly released and re-acquired
     across retry attempts (e.g. after SIGTSTP/SIGTTIN/SIGTTOU). If `flock`
     is not available on the platform, the lock acquisition silently returns
     `None` and the process proceeds without locking (graceful degradation).

     ### Changes
     - `src/pam/rpassword.rs`: Added `FlockGuard` struct that acquires
       `flock(LOCK_EX)` on construction and releases it on `Drop`. Used in
       `prompt_password()` to serialize TTY reads across concurrent sudo
       processes.