### PR TITLE
Fix newline output for empty stdin prompts

### DIFF
--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -144,7 +144,8 @@ fn prompt_password(
             })
         };
 
-        let res = read_unbuffered(&mut reader, sink, &hide_input);
+        let write_newline = !prompt.is_empty() || matches!(hide_input, Hidden::WithFeedback(_));
+        let res = read_unbuffered(&mut reader, sink, &hide_input, write_newline);
 
         drop(hide_input);
         drop(handlers);
@@ -184,10 +185,12 @@ fn read_unbuffered(
     source: &mut TimeoutRead<'_>,
     sink: &mut dyn io::Write,
     hide_input: &Hidden<HiddenInput>,
+    write_newline: bool,
 ) -> PamResult<PamBuffer> {
     struct Bullets<'a> {
         visible_len: Option<usize>,
         sink: &'a mut dyn io::Write,
+        write_newline: bool,
     }
 
     const BULLET: &[u8] = b"*";
@@ -222,13 +225,16 @@ fn read_unbuffered(
     impl Drop for Bullets<'_> {
         fn drop(&mut self) {
             self.clear();
-            let _ = self.sink.write(b"\n");
+            if self.write_newline {
+                let _ = self.sink.write(b"\n");
+            }
         }
     }
 
     let mut feedback = Bullets {
         visible_len: matches!(hide_input, Hidden::WithFeedback(_)).then_some(0),
         sink,
+        write_newline,
     };
 
     let mut password = PamBuffer::default();
@@ -435,7 +441,7 @@ impl Terminal<'_> {
                 let (command_pid, askpass_stdout) = askpass::spawn_askpass(program, prompt)?;
 
                 let mut reader = TimeoutRead::new(askpass_stdout.as_fd(), None);
-                let password = read_unbuffered(&mut reader, sink, &Hidden::No)?;
+                let password = read_unbuffered(&mut reader, sink, &Hidden::No, false)?;
 
                 loop {
                     match command_pid.wait(WaitOptions::new()) {
@@ -501,6 +507,7 @@ mod test {
             &mut TimeoutRead::new(rx.as_fd(), None),
             &mut stdout,
             &Hidden::No,
+            false,
         )
         .unwrap();
         // check that the \n is not part of input
@@ -518,6 +525,30 @@ mod test {
     }
 
     #[test]
+    fn empty_prompt_does_not_write_to_sink() {
+        let mut sink = Vec::new();
+        let (rx, mut tx) = make_pipe();
+        tx.write_all(b"password123\n").unwrap();
+        drop(tx);
+
+        prompt_password(rx.as_fd(), &mut sink, "", None, Hidden::No).unwrap();
+
+        assert!(sink.is_empty());
+    }
+
+    #[test]
+    fn displayed_prompt_ends_with_newline() {
+        let mut sink = Vec::new();
+        let (rx, mut tx) = make_pipe();
+        tx.write_all(b"password123\n").unwrap();
+        drop(tx);
+
+        prompt_password(rx.as_fd(), &mut sink, "Password: ", None, Hidden::No).unwrap();
+
+        assert_eq!(sink, b"Password: \n");
+    }
+
+    #[test]
     fn miri_test_longpwd() {
         let mut stdout = Vec::new();
         let (rx, mut tx) = make_pipe();
@@ -527,7 +558,8 @@ mod test {
             read_unbuffered(
                 &mut TimeoutRead::new(rx.as_fd(), None),
                 &mut stdout,
-                &Hidden::No
+                &Hidden::No,
+                false,
             )
             .is_ok()
         );
@@ -539,7 +571,8 @@ mod test {
             read_unbuffered(
                 &mut TimeoutRead::new(rx.as_fd(), None),
                 &mut stdout,
-                &Hidden::No
+                &Hidden::No,
+                false,
             )
             .is_err()
         );


### PR DESCRIPTION
**Describe the changes done on this pull request**

Password input cleanup now writes a trailing newline only when a prompt or feedback was displayed. This keeps `sudo -S -p ''` stderr empty while preserving visible prompt cleanup.

The regressions assert raw sink bytes because the compliance harness removes one trailing newline, and include a non-empty prompt control.

Fixes #1648.

**Validation**

- `cargo test prompt_ --release`
- `cargo clippy --no-deps --all-targets -- --deny warnings`
- `cargo fmt --all -- --check`

**Pull Request Checklist**

- [x] I have read and accepted the [code of conduct](https://github.com/trifectatechfoundation/sudo-rs/blob/master/CODE_OF_CONDUCT.md) for this project.
- [x] I have tested, formatted and ran clippy over my changes.
- [x] I have commented and documented my changes.
- [x] This pull request fixes issue #1648, where the expected behavior and likely code path were documented.