### PR TITLE
Fix newline for empty prompts

### DIFF
--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -161,6 +161,11 @@ fn prompt_password(
             }
         }
 
+        // If there was a prompt, write a new line to move the cursor to the start
+        if !prompt.is_empty() {
+            let _ = write_unbuffered(sink, b"\n");
+        }
+
         return res;
     }
 }
@@ -222,7 +227,6 @@ fn read_unbuffered(
     impl Drop for Bullets<'_> {
         fn drop(&mut self) {
             self.clear();
-            let _ = self.sink.write(b"\n");
         }
     }
 

--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -522,6 +522,30 @@ mod test {
     }
 
     #[test]
+    fn empty_prompt_does_not_write_to_sink() {
+        let mut sink = Vec::new();
+        let (rx, mut tx) = make_pipe();
+        tx.write_all(b"password123\n").unwrap();
+        drop(tx);
+
+        prompt_password(rx.as_fd(), &mut sink, "", None, Hidden::No).unwrap();
+
+        assert!(sink.is_empty());
+    }
+
+    #[test]
+    fn displayed_prompt_ends_with_newline() {
+        let mut sink = Vec::new();
+        let (rx, mut tx) = make_pipe();
+        tx.write_all(b"password123\n").unwrap();
+        drop(tx);
+
+        prompt_password(rx.as_fd(), &mut sink, "Password: ", None, Hidden::No).unwrap();
+
+        assert_eq!(sink, b"Password: \n");
+    }
+
+    #[test]
     fn miri_test_longpwd() {
         let mut stdout = Vec::new();
         let (rx, mut tx) = make_pipe();


### PR DESCRIPTION
Closes #1648 

Note: this does mean that in irregular exits (e.g. due to `?`, or a panic) of `prompt_password`, the new line would not be printed.  But the only irregular that is there is the `SIGTSTP`/`SIGTTIN`/`SIGTTOU`, and actually with this patch the behaviour  of those seems closer to ogsudo as well (e.g. `^Z` will cause a newline to be printed anyway)

In particular, any I/O errors in `read_unbuffered` are handled by `prompt_password` and not propagated.