### PR TITLE
Allow deleted passwords as an authentication method

### DIFF
--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -54,7 +54,7 @@ pub(super) fn init_pam(
         Some(auth_user),
     )?;
     pam.mark_silent(matches!(launch, LaunchType::Direct));
-    pam.mark_allow_null_auth_token(false);
+    pam.mark_allow_null_auth_token(true);
     pam.set_requesting_user(requesting_user)?;
 
     match auth_prompt.as_deref() {

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -446,3 +446,28 @@ cat {PAM_ENV_VALUE} >&3"#
     let (expected, pam_env) = parse_expected_tty_and_pam_env(&stdout);
     assert_pam_tty_matches_expected(&expected, &pam_env);
 }
+
+#[test]
+fn empty_password_nullok() {
+    let env = Env(format!("{USERNAME} ALL=(ALL:ALL) ALL"))
+        .user(User(USERNAME).password(PASSWORD))
+        .file(
+            "/etc/pam.d/sudo",
+            "auth sufficient pam_unix.so nullok
+auth requisite pam_deny.so
+",
+        )
+        .build();
+
+    Command::new("passwd")
+        .args(["-d", USERNAME])
+        .output(&env)
+        .assert_success();
+
+    Command::new("sudo")
+        .args(["-S", "true"])
+        .as_user(USERNAME)
+        .stdin("")
+        .output(&env)
+        .assert_success();
+}


### PR DESCRIPTION
Resolves: #1656.

Related issue in `su-rs`: #1521 (which was fixed by #1516)
