### PR TITLE
Fix FileLock descriptor lifetime

### DIFF
--- a/src/system/file/lock.rs
+++ b/src/system/file/lock.rs
@@ -1,4 +1,9 @@
-use std::{ffi::c_int, fs::File, io::Result, os::fd::AsRawFd};
+use std::{
+    ffi::c_int,
+    fs::File,
+    io::Result,
+    os::fd::{AsRawFd, RawFd},
+};
 
 use crate::cutils::cerr;
 

--- a/src/system/file/lock.rs
+++ b/src/system/file/lock.rs
@@ -1,34 +1,29 @@
-use std::{
-    ffi::c_int,
-    fs::File,
-    io::Result,
-    os::fd::{AsRawFd, RawFd},
-};
+use std::{ffi::c_int, fs::File, io::Result, os::fd::AsRawFd};
 
 use crate::cutils::cerr;
 
 pub(crate) struct FileLock {
-    fd: RawFd,
+    file: File,
 }
 
 impl FileLock {
     /// Get an exclusive lock on the file, waits if there is currently a lock
     /// on the file if `nonblocking` is true.
     pub(crate) fn exclusive(file: &File, nonblocking: bool) -> Result<Self> {
-        let fd = file.as_raw_fd();
-        flock(fd, LockOp::LockExclusive, nonblocking)?;
-        Ok(Self { fd })
+        let file = file.try_clone()?;
+        flock(file.as_raw_fd(), LockOp::LockExclusive, nonblocking)?;
+        Ok(Self { file })
     }
 
     /// Release the lock on the file.
     pub(crate) fn unlock(self) -> Result<()> {
-        flock(self.fd, LockOp::Unlock, false)
+        flock(self.file.as_raw_fd(), LockOp::Unlock, false)
     }
 }
 
 impl Drop for FileLock {
     fn drop(&mut self) {
-        flock(self.fd, LockOp::Unlock, false).ok();
+        flock(self.file.as_raw_fd(), LockOp::Unlock, false).ok();
     }
 }
 
@@ -70,5 +65,15 @@ mod tests {
         let f = tempfile().unwrap();
 
         FileLock::exclusive(&f, false).unwrap().unlock().unwrap();
+    }
+
+    #[test]
+    fn lock_keeps_file_descriptor_open() {
+        let f = tempfile().unwrap();
+        let lock = FileLock::exclusive(&f, false).unwrap();
+
+        drop(f);
+
+        lock.unlock().unwrap();
     }
 }


### PR DESCRIPTION
Fixes #1653.

## Summary

- Keep a duplicated `File` in `FileLock` instead of a raw descriptor.
- Add a regression test for releasing a lock after the caller closes its file handle.

## Why

`FileLock` could outlive the `File` from which it captured a raw descriptor. A later unlock could then operate on a closed or reused descriptor. The duplicated handle keeps the lock's descriptor valid for its full lifetime.

## Checks

- `cargo fmt --check`
- `cargo metadata --no-deps --format-version 1`
