### PR TITLE
Add FreeBSD CI to replace Cirrus

### DIFF
--- a/.github/workflows/freebsd.yaml
+++ b/.github/workflows/freebsd.yaml
@@ -1,0 +1,47 @@
+name: FreeBSD
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+    branches:
+      - main
+
+jobs:
+  freebsd:
+    name: FreeBSD unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Unit tests in a FreeBSD VM
+        uses: vmactions/freebsd-vm@77ed28d336d03fe19a3f4f7266c1d2c4714dd79d # v1.5.2
+        with:
+          usesh: true
+          cache-after-prepare: true
+          # system::time::tests::get_process_start_time compares the process
+          # start time against the wall clock, so the guest clock must be sane.
+          sync-time: true
+          prepare: |
+            pkg install -y rust git-tiny
+          run: |
+            set -e
+            rustc --version
+            cargo --version
+
+            # The unit tests must not run as root: src/su/context.rs says
+            # "this test is allowed to fail if run as root -- do not run unit
+            # tests as root", and the VM logs in as root by default.
+            pw useradd sudorstest -m
+            chown -R sudorstest .
+
+            # We skip a couple of tests which fail when running as root.
+            su -m sudorstest -c "cd $PWD && env HOME=/home/sudorstest cargo test --workspace --all-targets --release -- --skip group_as_non_root --skip test_secure_open_cookie_file --skip test_traverse_secure_open_positive"

--- a/src/system/time.rs
+++ b/src/system/time.rs
@@ -118,6 +118,40 @@ impl ProcessCreateTime {
         }
     }
 
+    /// The current time on the same clock `Process::starting_time` reports.
+    ///
+    /// This deliberately does NOT reuse `SystemTime::now`, which always reads
+    /// `CLOCK_BOOTTIME`. On FreeBSD the process start time comes from
+    /// `kinfo_proc.ki_start`, which the kernel exports as absolute wall clock,
+    /// while `CLOCK_BOOTTIME` is an alias for the uptime clock there -- so the
+    /// two are not comparable. `SystemTime::now` must stay on the monotonic
+    /// clock (it guards the credential cache timeout), hence the split.
+    #[cfg(test)]
+    pub(super) fn now() -> std::io::Result<ProcessCreateTime> {
+        let mut spec = MaybeUninit::<libc::timespec>::uninit();
+        // SAFETY: valid pointer is passed to clock_gettime
+        crate::cutils::cerr(unsafe {
+            libc::clock_gettime(
+                if cfg!(target_os = "freebsd") {
+                    libc::CLOCK_REALTIME
+                } else {
+                    libc::CLOCK_BOOTTIME
+                },
+                spec.as_mut_ptr(),
+            )
+        })?;
+        // SAFETY: The `libc::clock_gettime` will correctly initialize `spec`,
+        // otherwise it will return early with the `?` operator.
+        let spec = unsafe { spec.assume_init() };
+
+        // the below conversion is not as useless as clippy thinks, on 32bit systems
+        #[allow(clippy::useless_conversion)]
+        Ok(ProcessCreateTime::new(
+            spec.tv_sec.into(),
+            spec.tv_nsec.into(),
+        ))
+    }
+
     pub(super) fn encode(&self, target: &mut impl Write) -> std::io::Result<()> {
         let secs = self.secs.to_ne_bytes();
         let nsecs = self.nsecs.to_ne_bytes();
@@ -178,10 +212,7 @@ mod tests {
         use crate::system::{Process, WithProcess};
         let time = Process::starting_time(WithProcess::Current).unwrap();
 
-        let now = {
-            let super::SystemTime { secs, nsecs } = super::SystemTime::now().unwrap();
-            super::ProcessCreateTime { secs, nsecs }
-        };
+        let now = super::ProcessCreateTime::now().unwrap();
 
         assert!(time.secs > now.secs - 24 * 60 * 60);
         assert!(time < now);


### PR DESCRIPTION
Closes #1543

Cirrus CI shut down on 2026-06-01, which removed the FreeBSD unit test
coverage. This runs the same test command in a FreeBSD VM booted under
QEMU/KVM on a regular `ubuntu-latest` runner, keeping the skips
`.cirrus.yml` carried. The suite runs as an unprivileged user, since
`src/su/context.rs` notes `invalid_shell` is allowed to fail under root
while the VM logs in as root.

## Second commit: a test-only fix the job is blocked on

Enabling the job surfaced one failing test,
`system::time::tests::get_process_start_time`. It is a test-only regression,
not a defect in `Process::starting_time`:

- On FreeBSD `kinfo_proc.ki_start` is absolute wall clock -- the kernel adds
  `boottime` in `fill_kinfo_proc_only()` before exporting it.
- `SystemTime::now()` reads `CLOCK_BOOTTIME`, which on FreeBSD is an alias
  for the uptime clock (clock_gettime(2): "unrelated to the `kern.boottime`
  sysctl").

So the test compared an epoch-scale value against the VM's uptime and failed
deterministically on every FreeBSD run; the first assertion passed only
because its right-hand side was negative.

064de34 had handled exactly this with a `#[cfg(test)]`
`ProcessCreateTime::now()` that selects `CLOCK_REALTIME` on FreeBSD. The DRY
cleanup in 62d1d30 removed it and rebuilt the comparand by destructuring
`SystemTime`'s fields into `ProcessCreateTime`, bypassing the newtype
separation 064de34 introduced -- a no-op on Linux, a guaranteed failure on
FreeBSD.

This restores that helper and documents why it cannot be folded into
`SystemTime::now()`, which must keep reading the monotonic clock per #1022.
Production code is untouched.

## Verification

Before the test fix:
https://github.com/neilpang/sudo-rs/actions/runs/30707863594

```
test result: FAILED. 175 passed; 1 failed
failures: system::time::tests::get_process_start_time
```

After:
https://github.com/neilpang/sudo-rs/actions/runs/30730157525

```
test result: ok. 176 passed; 0 failed
rustc 1.97.1 (pkg), FreeBSD 15.1, job time 2m37s
```
