### PR TITLE
README: add postmarketOS as a subsection of Alpine

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ To install the `sudo-rs` version of `su`, which is packaged separately, run:
 apk add sudo-rs-su
 ```
 
+#### postmarketOS
+
+On postmarketOS, sudo-rs is installed and enabled by default on all new installs.
+
+
 ### Installing our pre-compiled x86-64 binaries
 
 You can also switch to sudo-rs manually by using our pre-compiled tarballs.


### PR DESCRIPTION
postmarketOS is a disto based on Alpine Linux, as of the June 2026 release, new installs are using sudo-rs instead of doas.

From [the June 2026 release notes](https://postmarketos.org/blog/2026/06/21/v26.06-release/ ):
"New postmarketOS installations use [sudo-rs instead of doas](https://postmarketos.org/edge/2026/03/18/sudo-rs-instead-of-doas/) by default. Thanks Aster!"


