### PR TITLE
sudoers: accept tab as command/argument separator

### DIFF
--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -214,6 +214,7 @@ fn permission_test() {
     pass!(["user ALL=/bin/hello arg"], "user" => root(), "server"; "/bin/hello arg");
     pass!(["user ALL=/bin/hello  arg"], "user" => root(), "server"; "/bin/hello arg");
     pass!(["user ALL=/bin/hello arg"], "user" => root(), "server"; "/bin/hello  arg");
+    pass!(["user ALL=/bin/hello\targ"], "user" => root(), "server"; "/bin/hello arg");
     FAIL!(["user ALL=/bin/hello arg"], "user" => root(), "server"; "/bin/hello boo");
     // several test cases with globbing in the arguments are explicitly not supported by sudo-rs
     //pass!(["user ALL=/bin/hello a*g"], "user" => root(), "server"; "/bin/hello  aaaarg");

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -245,7 +245,7 @@ impl Token for Command {
     }
 
     fn accept(c: char) -> bool {
-        SimpleCommand::accept(c) || c == ' '
+        SimpleCommand::accept(c) || matches!(c, ' ' | '\t')
     }
 
     const ALLOW_ESCAPE: bool = SimpleCommand::ALLOW_ESCAPE;


### PR DESCRIPTION
Fixes #1669

Fixes an issue where tabs were not treated as valid separators between command tokens when parsing sudoers command specifications.

This changes the parser to treat \t the same way as a space when accepting command tokens.