### PR TITLE
sudoers: accept TAB as Command argument separator

### DIFF
--- a/src/sudoers/test/mod.rs
+++ b/src/sudoers/test/mod.rs
@@ -485,6 +485,23 @@ fn sudoedit_recognized() {
 }
 
 #[test]
+fn command_accepts_tab_as_argument_separator() {
+    // TAB is ordinary sudoers whitespace between a command and its arguments.
+    // Rejecting it left the remainder of the line as "garbage at end of line".
+    let line = "ALL ALL=/usr/bin/ls\thuk";
+    assert!(parse_line(line).is_spec());
+
+    let CommandSpec(_, Qualified::Allow(Meta::Only((cmd, args)))) =
+        parse_eval::<ast::CommandSpec>("/usr/bin/ls\thuk")
+    else {
+        panic!();
+    };
+    assert_eq!(cmd.as_str(), "/usr/bin/ls");
+    let Args::Exact(args) = args else { panic!() };
+    assert_eq!(args.as_ref(), &["huk"][..]);
+}
+
+#[test]
 #[should_panic = "list does not take arguments"]
 fn list_does_not_take_args() {
     parse_eval::<ast::CommandSpec>("list /etc/tmux.conf");

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -247,7 +247,7 @@ impl Token for Command {
     fn accept(c: char) -> bool {
         // Space and TAB separate command path from arguments (and arguments
         // from each other), matching traditional sudoers whitespace.
-        SimpleCommand::accept(c) || c == ' ' || c == '\t'
+        SimpleCommand::accept(c) || matches!(c, ' ' | '\t')
     }
 
     const ALLOW_ESCAPE: bool = SimpleCommand::ALLOW_ESCAPE;

--- a/src/sudoers/tokens.rs
+++ b/src/sudoers/tokens.rs
@@ -245,12 +245,15 @@ impl Token for Command {
     }
 
     fn accept(c: char) -> bool {
-        SimpleCommand::accept(c) || c == ' '
+        // Space and TAB separate command path from arguments (and arguments
+        // from each other), matching traditional sudoers whitespace.
+        SimpleCommand::accept(c) || c == ' ' || c == '\t'
     }
 
     const ALLOW_ESCAPE: bool = SimpleCommand::ALLOW_ESCAPE;
     fn escaped(c: char) -> bool {
-        SimpleCommand::escaped(c)
+        // Allow escaping TAB the same way as space when it appears in a path.
+        SimpleCommand::escaped(c) || c == '\t'
     }
 }
 


### PR DESCRIPTION
## Summary

`Command::accept` only treated ASCII space as whitespace between a command path and its arguments. A TAB stopped the token early, so the rest of the line became a garbage-at-end-of-line parse error, e.g.:

```
ALL ALL=/usr/bin/ls<TAB>huk
```

Accept TAB the same way as space when tokenizing commands, and allow escaping TAB like space when it appears in a path. `construct` already splits on all whitespace via `split_whitespace`.

## Test plan

- [x] Unit test `command_accepts_tab_as_argument_separator` parses `ALL ALL=/usr/bin/ls\thuk` and `/usr/bin/ls\thuk` with args `[huk]`
- [ ] CI `cargo test` on Linux (local host is Windows; sudo-rs is Linux/FreeBSD-only)

Fixes #1669