### PR TITLE
Fetch active groups for the current user using `getgroups`.

### DIFF
--- a/src/common/resolve.rs
+++ b/src/common/resolve.rs
@@ -63,9 +63,10 @@ impl CurrentUser {
     }
 
     pub fn resolve() -> Result<Self, Error> {
-        Ok(Self {
-            inner: User::real()?.ok_or(Error::UserNotFound("current user".to_string()))?,
-        })
+        let mut cur_user = User::real()?.ok_or(Error::UserNotFound("current user".to_string()))?;
+        // the current user can also have groups that are defined at runtime, so fetch the dynamic groups
+        cur_user.groups = User::real_groups()?;
+        Ok(Self { inner: cur_user })
     }
 }
 

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -520,6 +520,31 @@ impl User {
             unsafe { Self::from_libc(&pwd).map(Some) }
         }
     }
+
+    pub fn real_groups() -> Result<Vec<GroupId>, Error> {
+        // From man getgroups:
+        //   The maximum number of supplementary group IDs can be found at run time using sysconf(3):
+        //   ngroups_max = sysconf(_SC_NGROUPS_MAX);
+        //   The  maximum  return  value of getgroups() cannot be larger than one more than this value.
+        // So, unlike the "_MAX" definitions above which suggest an initial size, this really is the "max" value.
+        let len = sysconf(libc::_SC_NGROUPS_MAX).unwrap_or(65536) as usize;
+        let mut groups = vec![GroupId::new(u32::MAX); len];
+
+        let len = len
+            .try_into()
+            .expect("_SC_NGROUPS_MAX should fit in a c_int");
+
+        // SAFETY: getgroups is passed a valid pointer to a chunk of memory of the correct size
+        // We can cast to gid_t because `GroupId` is marked as transparent
+        let num_groups =
+            cerr(unsafe { libc::getgroups(len, groups.as_mut_ptr().cast::<libc::gid_t>()) })?;
+
+        groups.resize_with(num_groups as usize, || {
+            panic!("invalid groups count returned from getgroups, this should not happen")
+        });
+
+        Ok(groups)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/test-framework/sudo-compliance-tests/src/su/flag_shell.rs
+++ b/test-framework/sudo-compliance-tests/src/su/flag_shell.rs
@@ -253,7 +253,7 @@ fn when_no_etc_shells_file_uses_a_default_list() {
             .output(&env);
 
         output.assert_success();
-        assert_not_contains!(output.stderr(), format!("su: using restricted shell"));
+        assert_not_contains!(output.stderr(), "su: using restricted shell".to_string());
     }
 }
 

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -509,7 +509,7 @@ auth requisite pam_deny.so
 #[test]
 #[ignore = "gh1665"]
 fn loads_pam_groups() {
-    let env = Env(format!("ALL ALL=(ALL:ALL) ALL"))
+    let env = Env("ALL ALL=(ALL:ALL) ALL".to_string())
         .group(GROUPNAME)
         .user(User(USERNAME).password(PASSWORD))
         .file(

--- a/test-framework/sudo-compliance-tests/src/sudo/pam.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/pam.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use sudo_test::{Command, Env, User};
 
-use crate::{PASSWORD, USERNAME};
+use crate::{GROUPNAME, PASSWORD, USERNAME};
 
 #[cfg(target_os = "linux")]
 mod env;
@@ -470,4 +470,70 @@ auth requisite pam_deny.so
         .stdin("")
         .output(&env)
         .assert_success();
+}
+
+#[test]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "FreeBSD doesn't support /etc/security"
+)]
+fn pam_groups_recognized() {
+    // because sudo-rs doesn't load the groups (see gh #1665), we need to use other tools
+    // to load the pam_group.so ones.
+    let env = Env(format!("%{GROUPNAME} ALL=(ALL:ALL) ALL"))
+        .group(GROUPNAME)
+        .user(User(USERNAME).password(PASSWORD))
+        .file(
+            "/etc/pam.d/runuser",
+            "auth optional pam_group.so
+auth sufficient pam_unix.so nullok
+auth requisite pam_deny.so
+        ",
+        )
+        .file(
+            "/etc/security/group.conf",
+            format!(
+                "*;*;*;Al0000-2400;{GROUPNAME}
+"
+            ),
+        )
+        .build();
+
+    Command::new("runuser")
+        .args(["-u", USERNAME, "--", "sudo", "-S", "true"])
+        .stdin(PASSWORD)
+        .output(&env)
+        .assert_success();
+}
+
+#[test]
+#[ignore = "gh1665"]
+fn loads_pam_groups() {
+    let env = Env(format!("ALL ALL=(ALL:ALL) ALL"))
+        .group(GROUPNAME)
+        .user(User(USERNAME).password(PASSWORD))
+        .file(
+            "/etc/pam.d/sudo",
+            "auth optional pam_group.so
+auth sufficient pam_unix.so nullok
+auth requisite pam_deny.so
+        ",
+        )
+        .file(
+            "/etc/security/group.conf",
+            format!(
+                "*;*;*;Al0000-2400;{GROUPNAME}
+"
+            ),
+        )
+        .build();
+
+    let output = Command::new("sudo")
+        .args(["-u", USERNAME, "--", "groups"])
+        .stdin(PASSWORD)
+        .output(&env);
+
+    output.assert_success();
+
+    assert_contains!(output.stdout(), GROUPNAME);
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/sudoers/runas_alias.rs
@@ -230,7 +230,7 @@ fn when_only_groupname_is_given_user_arg_fails() {
     } else {
         assert_contains!(
             stderr,
-            format!("I'm sorry ferris. I'm afraid I can't do that")
+            "I'm sorry ferris. I'm afraid I can't do that".to_string()
         );
     }
 }
@@ -267,7 +267,7 @@ fn when_only_username_is_given_group_arg_fails() {
     } else {
         assert_contains!(
             stderr,
-            format!("I'm sorry ferris. I'm afraid I can't do that")
+            "I'm sorry ferris. I'm afraid I can't do that".to_string()
         );
     }
 }

--- a/test-framework/sudo-compliance-tests/src/sudo/syslog.rs
+++ b/test-framework/sudo-compliance-tests/src/sudo/syslog.rs
@@ -35,7 +35,7 @@ fn sudo_respects_log_allowed() {
         .assert_success();
 
     let auth_log = rsyslog.auth_log();
-    assert_not_contains!(auth_log, format!("COMMAND="));
+    assert_not_contains!(auth_log, "COMMAND=".to_string());
 }
 
 #[test]

--- a/test-framework/sudo-compliance-tests/src/sudoedit.rs
+++ b/test-framework/sudo-compliance-tests/src/sudoedit.rs
@@ -268,7 +268,10 @@ rm $1",
     if sudo_test::is_original_sudo() {
         assert_contains!(stderr, format!("sudoedit: {ETC_SUDOERS} left unmodified"));
     } else {
-        assert_contains!(stderr, format!("sudo: failed to read from temporary file"));
+        assert_contains!(
+            stderr,
+            "sudo: failed to read from temporary file".to_string()
+        );
     }
 }
 


### PR DESCRIPTION
Closes #1660

Also adds the failing compliance tests for #1665 